### PR TITLE
Add three-tier CORS handling and admin config

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/AdminUiUrlPrinter.kt
+++ b/server/src/main/kotlin/com/sympauthy/AdminUiUrlPrinter.kt
@@ -1,0 +1,28 @@
+package com.sympauthy
+
+import com.sympauthy.config.model.AdminConfig
+import com.sympauthy.config.model.EnabledAdminConfig
+import com.sympauthy.config.model.EnabledUrlsConfig
+import com.sympauthy.config.model.UrlsConfig
+import com.sympauthy.util.loggerForClass
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.discovery.event.ServiceReadyEvent
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Singleton
+class AdminUiUrlPrinter(
+    @Inject private val adminConfig: AdminConfig,
+    @Inject private val urlsConfig: UrlsConfig
+) : ApplicationEventListener<ServiceReadyEvent> {
+
+    private val logger = loggerForClass()
+
+    override fun onApplicationEvent(event: ServiceReadyEvent) {
+        val config = adminConfig as? EnabledAdminConfig ?: return
+        if (!config.enabled || !config.integratedUi) return
+
+        val urls = urlsConfig as? EnabledUrlsConfig ?: return
+        logger.info("Admin UI available at ${urls.root}/admin")
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/filter/AdminCorsFilter.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/filter/AdminCorsFilter.kt
@@ -1,0 +1,148 @@
+package com.sympauthy.api.filter
+
+import com.sympauthy.config.model.AdminConfig
+import com.sympauthy.config.model.EnabledAdminConfig
+import com.sympauthy.config.model.EnabledUrlsConfig
+import com.sympauthy.config.model.UrlsConfig
+import io.micronaut.core.order.Ordered
+import io.micronaut.http.*
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.filter.ServerFilterPhase
+import io.reactivex.rxjava3.core.Flowable
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * CORS filter for the admin API (`/api/v1/admin/`).
+ *
+ * ## Allowed origins
+ * - **`admin.enabled = false`** — no CORS headers (fail-secure, filter is inactive).
+ * - **`admin.enabled = true`, `admin.integrated-ui = true`** — the allowed origin is derived from
+ *   `urls.root` (same root URL as the server). Only that specific origin receives CORS headers.
+ * - **`admin.enabled = true`, `admin.integrated-ui = false`** — the admin UI is hosted externally
+ *   and its origin is unknown, so all origins are allowed (`Access-Control-Allow-Origin: *`).
+ *
+ * ## Request handling
+ * Same pattern as [FlowCorsFilter]:
+ * - **No `Origin` header** — passed through unchanged.
+ * - **OPTIONS preflight, allowed origin** — short-circuited with `200` and full CORS headers.
+ * - **OPTIONS preflight, unknown origin** — short-circuited with bare `200`, no CORS headers.
+ * - **Regular request, allowed origin** — proceeds through chain; CORS headers appended.
+ * - **Regular request, unknown origin** — passed through unchanged.
+ *
+ * In wildcard mode (non-integrated UI), all origins are considered allowed.
+ */
+@Filter("/api/v1/admin/**")
+class AdminCorsFilter(
+    @Inject private val adminConfig: AdminConfig,
+    @Inject private val urlsConfig: UrlsConfig
+) : HttpServerFilter, Ordered {
+
+    override fun getOrder(): Int = ServerFilterPhase.FIRST.before()
+
+    private sealed class CorsMode {
+        /** Admin disabled or config invalid — no CORS headers. */
+        data object Inactive : CorsMode()
+        /** Integrated UI — only the origin derived from `urls.root` is allowed. */
+        data class Restricted(val allowedOrigin: String) : CorsMode()
+        /** External UI — all origins allowed (`*`). */
+        data object Wildcard : CorsMode()
+    }
+
+    private val corsMode: CorsMode by lazy { buildCorsMode() }
+
+    private fun buildCorsMode(): CorsMode {
+        val config = adminConfig as? EnabledAdminConfig ?: return CorsMode.Inactive
+        if (!config.enabled) return CorsMode.Inactive
+
+        if (!config.integratedUi) return CorsMode.Wildcard
+
+        val urls = urlsConfig as? EnabledUrlsConfig ?: return CorsMode.Inactive
+        val root = urls.root
+        val origin = buildString {
+            append(root.scheme).append("://").append(root.host)
+            if (root.port != -1) append(":").append(root.port)
+        }
+        return CorsMode.Restricted(origin)
+    }
+
+    override fun doFilter(
+        request: HttpRequest<*>,
+        chain: ServerFilterChain
+    ): Publisher<MutableHttpResponse<*>> {
+        val mode = corsMode
+        if (mode is CorsMode.Inactive) return chain.proceed(request)
+
+        val origin = request.headers.origin.getOrNull()
+            ?: return chain.proceed(request)
+
+        return when (mode) {
+            is CorsMode.Wildcard -> handleWildcard(request, chain)
+            is CorsMode.Restricted -> handleRestricted(request, chain, origin, mode.allowedOrigin)
+            is CorsMode.Inactive -> chain.proceed(request) // unreachable
+        }
+    }
+
+    private fun handleWildcard(
+        request: HttpRequest<*>,
+        chain: ServerFilterChain
+    ): Publisher<MutableHttpResponse<*>> {
+        if (request.method == HttpMethod.OPTIONS) {
+            val response = HttpResponse.ok<Any>()
+            addWildcardCorsHeaders(response, preflight = true)
+            return Flowable.just(response)
+        }
+        return Flowable.fromPublisher(chain.proceed(request)).map { response ->
+            addWildcardCorsHeaders(response, preflight = false)
+            response
+        }
+    }
+
+    private fun handleRestricted(
+        request: HttpRequest<*>,
+        chain: ServerFilterChain,
+        origin: String,
+        allowedOrigin: String
+    ): Publisher<MutableHttpResponse<*>> {
+        val isAllowed = origin == allowedOrigin
+
+        if (request.method == HttpMethod.OPTIONS) {
+            val response = HttpResponse.ok<Any>()
+            if (isAllowed) addRestrictedCorsHeaders(response, origin, preflight = true)
+            return Flowable.just(response)
+        }
+
+        if (!isAllowed) return chain.proceed(request)
+
+        return Flowable.fromPublisher(chain.proceed(request)).map { response ->
+            addRestrictedCorsHeaders(response, origin, preflight = false)
+            response
+        }
+    }
+
+    private fun addWildcardCorsHeaders(response: MutableHttpResponse<*>, preflight: Boolean) {
+        response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        if (preflight) {
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, DELETE, OPTIONS")
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, Authorization")
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "86400")
+        }
+    }
+
+    private fun addRestrictedCorsHeaders(
+        response: MutableHttpResponse<*>,
+        origin: String,
+        preflight: Boolean
+    ) {
+        response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin)
+        response.headers.add(HttpHeaders.VARY, HttpHeaders.ORIGIN)
+        if (preflight) {
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, DELETE, OPTIONS")
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, Authorization")
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "86400")
+        }
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/filter/DiscoveryCorsFilter.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/filter/DiscoveryCorsFilter.kt
@@ -1,0 +1,56 @@
+package com.sympauthy.api.filter
+
+import io.micronaut.core.order.Ordered
+import io.micronaut.http.*
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.filter.ServerFilterPhase
+import io.reactivex.rxjava3.core.Flowable
+import org.reactivestreams.Publisher
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * CORS filter for OpenID discovery endpoints (`/.well-known/`).
+ *
+ * These endpoints serve public metadata (OpenID configuration, JWKS) and, per standard OIDC practice,
+ * allow all origins (`Access-Control-Allow-Origin: *`).
+ *
+ * ## Request handling
+ * - **No `Origin` header** — not a browser CORS request; passed through unchanged.
+ * - **OPTIONS preflight** — short-circuited with `200` and wildcard CORS headers.
+ * - **Regular request with `Origin`** — proceeds through the chain; wildcard CORS header appended.
+ */
+@Filter("/.well-known/**")
+class DiscoveryCorsFilter : HttpServerFilter, Ordered {
+
+    override fun getOrder(): Int = ServerFilterPhase.FIRST.before()
+
+    override fun doFilter(
+        request: HttpRequest<*>,
+        chain: ServerFilterChain
+    ): Publisher<MutableHttpResponse<*>> {
+        val origin = request.headers.origin.getOrNull()
+            ?: return chain.proceed(request)
+
+        if (request.method == HttpMethod.OPTIONS) {
+            val response = HttpResponse.ok<Any>()
+            addCorsHeaders(response, preflight = true)
+            return Flowable.just(response)
+        }
+
+        return Flowable.fromPublisher(chain.proceed(request)).map { response ->
+            addCorsHeaders(response, preflight = false)
+            response
+        }
+    }
+
+    private fun addCorsHeaders(response: MutableHttpResponse<*>, preflight: Boolean) {
+        response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        if (preflight) {
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS")
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, Authorization")
+            response.headers.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "86400")
+        }
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/config/factory/AdminConfigFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/factory/AdminConfigFactory.kt
@@ -1,0 +1,54 @@
+package com.sympauthy.config.factory
+
+import com.sympauthy.config.ConfigParser
+import com.sympauthy.config.exception.ConfigurationException
+import com.sympauthy.config.model.AdminConfig
+import com.sympauthy.config.model.DisabledAdminConfig
+import com.sympauthy.config.model.EnabledAdminConfig
+import com.sympauthy.config.properties.AdminConfigurationProperties
+import com.sympauthy.config.properties.AdminConfigurationProperties.Companion.ADMIN_KEY
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Factory
+class AdminConfigFactory(
+    @Inject private val parser: ConfigParser
+) {
+
+    @Singleton
+    fun provideAdminConfig(
+        properties: AdminConfigurationProperties
+    ): AdminConfig {
+        val errors = mutableListOf<ConfigurationException>()
+
+        val enabled = try {
+            parser.getBooleanOrThrow(
+                properties, "$ADMIN_KEY.enabled",
+                AdminConfigurationProperties::enabled
+            )
+        } catch (e: ConfigurationException) {
+            errors.add(e)
+            null
+        }
+
+        val integratedUi = try {
+            parser.getBooleanOrThrow(
+                properties, "$ADMIN_KEY.integrated-ui",
+                AdminConfigurationProperties::integratedUi
+            )
+        } catch (e: ConfigurationException) {
+            errors.add(e)
+            null
+        }
+
+        return if (errors.isEmpty()) {
+            EnabledAdminConfig(
+                enabled = enabled!!,
+                integratedUi = integratedUi!!
+            )
+        } else {
+            DisabledAdminConfig(errors)
+        }
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/config/model/AdminConfig.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/model/AdminConfig.kt
@@ -1,0 +1,23 @@
+package com.sympauthy.config.model
+
+import com.sympauthy.config.exception.ConfigurationException
+
+sealed class AdminConfig(
+    configurationErrors: List<ConfigurationException>? = null
+) : Config(configurationErrors)
+
+data class EnabledAdminConfig(
+    val enabled: Boolean,
+    val integratedUi: Boolean
+) : AdminConfig()
+
+class DisabledAdminConfig(
+    configurationErrors: List<ConfigurationException>
+) : AdminConfig(configurationErrors)
+
+fun AdminConfig.orThrow(): EnabledAdminConfig {
+    return when (this) {
+        is EnabledAdminConfig -> this
+        is DisabledAdminConfig -> throw this.invalidConfig
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/config/properties/AdminConfigurationProperties.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/properties/AdminConfigurationProperties.kt
@@ -1,0 +1,14 @@
+package com.sympauthy.config.properties
+
+import com.sympauthy.config.properties.AdminConfigurationProperties.Companion.ADMIN_KEY
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties(ADMIN_KEY)
+interface AdminConfigurationProperties {
+    val enabled: String?
+    val integratedUi: String?
+
+    companion object {
+        const val ADMIN_KEY = "admin"
+    }
+}

--- a/server/src/main/resources/application-admin.yml
+++ b/server/src/main/resources/application-admin.yml
@@ -3,6 +3,10 @@
 #
 # Activate this environment by adding "admin" to MICRONAUT_ENVIRONMENTS (e.g. "default,admin").
 
+admin:
+  enabled: true
+  integrated-ui: true
+
 clients:
   admin:
     public: true

--- a/server/src/test/kotlin/com/sympauthy/api/filter/AdminCorsFilterTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/filter/AdminCorsFilterTest.kt
@@ -1,0 +1,77 @@
+package com.sympauthy.api.filter
+
+import com.sympauthy.api.AbstractFlowIntegrationTest
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class AdminCorsFilterTest : AbstractFlowIntegrationTest() {
+
+    // Must match urls.root from application-test.yml
+    private val allowedOrigin = "http://localhost:18080"
+    private val unknownOrigin = "http://evil.example.com"
+    private val adminPath = "/api/v1/admin/clients"
+
+    @Test
+    fun `OPTIONS preflight with allowed origin returns 200 with CORS headers`() {
+        val request = HttpRequest.OPTIONS<Any>(adminPath)
+            .header(HttpHeaders.ORIGIN, allowedOrigin)
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name)
+
+        val response = httpClient.toBlocking().exchange(request, String::class.java)
+
+        assertEquals(200, response.status.code)
+        assertEquals(allowedOrigin, response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+        assertNotNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS])
+        assertNotNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS])
+        assertNotNull(response.headers[HttpHeaders.ACCESS_CONTROL_MAX_AGE])
+    }
+
+    @Test
+    fun `OPTIONS preflight with unknown origin returns 200 without CORS headers`() {
+        val request = HttpRequest.OPTIONS<Any>(adminPath)
+            .header(HttpHeaders.ORIGIN, unknownOrigin)
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name)
+
+        val response = httpClient.toBlocking().exchange(request, String::class.java)
+
+        assertEquals(200, response.status.code)
+        assertNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+    }
+
+    @Test
+    fun `GET with allowed origin appends CORS headers`() {
+        val response = exchange(
+            HttpRequest.GET<Any>(adminPath).header(HttpHeaders.ORIGIN, allowedOrigin)
+        )
+
+        assertEquals(allowedOrigin, response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+        assertTrue(response.headers.getAll(HttpHeaders.VARY).any { HttpHeaders.ORIGIN in it })
+    }
+
+    @Test
+    fun `GET with unknown origin does not append CORS headers`() {
+        val response = exchange(
+            HttpRequest.GET<Any>(adminPath).header(HttpHeaders.ORIGIN, unknownOrigin)
+        )
+
+        assertNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+    }
+
+    @Test
+    fun `GET without Origin header does not append CORS headers`() {
+        val response = exchange(HttpRequest.GET<Any>(adminPath))
+
+        assertNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+    }
+
+    private fun exchange(request: HttpRequest<*>): HttpResponse<*> = try {
+        httpClient.toBlocking().exchange(request, String::class.java)
+    } catch (e: HttpClientResponseException) {
+        e.response
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/api/filter/DiscoveryCorsFilterTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/filter/DiscoveryCorsFilterTest.kt
@@ -1,0 +1,65 @@
+package com.sympauthy.api.filter
+
+import com.sympauthy.api.AbstractFlowIntegrationTest
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class DiscoveryCorsFilterTest : AbstractFlowIntegrationTest() {
+
+    private val anyOrigin = "http://some-app.example.com"
+    private val discoveryPath = "/.well-known/openid-configuration"
+    private val jwksPath = "/.well-known/public.jwk"
+
+    @Test
+    fun `OPTIONS preflight returns 200 with wildcard CORS headers`() {
+        val request = HttpRequest.OPTIONS<Any>(discoveryPath)
+            .header(HttpHeaders.ORIGIN, anyOrigin)
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name)
+
+        val response = httpClient.toBlocking().exchange(request, String::class.java)
+
+        assertEquals(200, response.status.code)
+        assertEquals("*", response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+        assertNotNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS])
+        assertNotNull(response.headers[HttpHeaders.ACCESS_CONTROL_MAX_AGE])
+    }
+
+    @Test
+    fun `GET with Origin header returns wildcard CORS header`() {
+        val response = exchange(
+            HttpRequest.GET<Any>(discoveryPath).header(HttpHeaders.ORIGIN, anyOrigin)
+        )
+
+        assertEquals("*", response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+    }
+
+    @Test
+    fun `GET without Origin header does not add CORS headers`() {
+        val response = exchange(HttpRequest.GET<Any>(discoveryPath))
+
+        assertNull(response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+    }
+
+    @Test
+    fun `JWKS endpoint OPTIONS preflight returns wildcard CORS headers`() {
+        val request = HttpRequest.OPTIONS<Any>(jwksPath)
+            .header(HttpHeaders.ORIGIN, anyOrigin)
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name)
+
+        val response = httpClient.toBlocking().exchange(request, String::class.java)
+
+        assertEquals(200, response.status.code)
+        assertEquals("*", response.headers[HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN])
+    }
+
+    private fun exchange(request: HttpRequest<*>): HttpResponse<*> = try {
+        httpClient.toBlocking().exchange(request, String::class.java)
+    } catch (e: HttpClientResponseException) {
+        e.response
+    }
+}

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -14,3 +14,7 @@ auth:
 
 urls:
   root: http://localhost:18080
+
+admin:
+  enabled: true
+  integrated-ui: true


### PR DESCRIPTION
Closes #129

## Summary
- Scope `FlowCorsFilter` to `/api/v1/flow/**` only (was `MATCH_ALL_PATTERN`)
- Add `DiscoveryCorsFilter` with `Access-Control-Allow-Origin: *` for `/.well-known/**`
- Add `AdminCorsFilter` for `/api/v1/admin/**` with two modes:
  - **Integrated UI** (`admin.integrated-ui: true`): restricted to `urls.root` origin
  - **External UI** (`admin.integrated-ui: false`): wildcard `*`
- Introduce `AdminConfig` sealed class with `admin.enabled` and `admin.integrated-ui` properties
- Add `AdminUiUrlPrinter` to log admin UI URL at startup when integrated
- Enable admin config in `application-admin.yml` environment

## Test plan
- [x] `DiscoveryCorsFilterTest` — wildcard CORS on `/.well-known/**` (4 tests)
- [x] `AdminCorsFilterTest` — restricted CORS on `/api/v1/admin/**` (5 tests)
- [x] Existing `FlowCorsFilterTest` still passes (5 tests)
- [x] Manual: verify `/.well-known/openid-configuration` returns `Access-Control-Allow-Origin: *`
- [x] Manual: verify admin endpoints return CORS headers with correct origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)