### PR TITLE
Add read-only admin claims endpoint

### DIFF
--- a/bruno/Admin API/List claims.bru
+++ b/bruno/Admin API/List claims.bru
@@ -1,0 +1,18 @@
+meta {
+  name: List claims
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{serverUrl}}/api/v1/admin/claims
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~page: 0
+  ~size: 20
+  ~enabled: true
+  ~required: true
+}

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClaimController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClaimController.kt
@@ -1,0 +1,83 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.mapper.admin.AdminClaimResourceMapper
+import com.sympauthy.api.resource.admin.AdminClaimListResource
+import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.model.user.claim.Claim
+import com.sympauthy.security.SecurityRule.ADMIN_CONFIG_READ
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+
+@Controller("/api/v1/admin/claims")
+@Secured(ADMIN_CONFIG_READ)
+class AdminClaimController(
+    @Inject private val claimManager: ClaimManager,
+    @Inject private val claimMapper: AdminClaimResourceMapper
+) {
+
+    @Operation(
+        description = "Retrieve all configured claims (standard and custom). Since claims are defined in configuration files, this endpoint exposes them as read-only resources.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "page",
+                description = "Zero-indexed page number.",
+                schema = Schema(type = "integer", defaultValue = "0")
+            ),
+            Parameter(
+                name = "size",
+                description = "Number of results per page.",
+                schema = Schema(type = "integer", defaultValue = "20")
+            ),
+            Parameter(
+                name = "enabled",
+                description = "Filter by enabled status.",
+                schema = Schema(type = "boolean")
+            ),
+            Parameter(
+                name = "required",
+                description = "Filter by required status.",
+                schema = Schema(type = "boolean")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Paginated list of claims."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:config:read."
+            )
+        ]
+    )
+    @Get
+    fun listClaims(
+        @QueryValue page: Int?,
+        @QueryValue size: Int?,
+        @QueryValue enabled: Boolean?,
+        @QueryValue required: Boolean?
+    ): AdminClaimListResource {
+        val (page, size) = resolvePageParams(page, size)
+        val claims = claimManager.listAllClaims()
+            .let { list -> if (enabled != null) list.filter { it.enabled == enabled } else list }
+            .let { list -> if (required != null) list.filter { it.required == required } else list }
+            .sortedWith(compareByDescending<Claim> { it.enabled }.thenBy { it.id })
+        val paged = claims
+            .drop(page * size)
+            .take(size)
+            .map(claimMapper::toResource)
+        return AdminClaimListResource(
+            claims = paged,
+            page = page,
+            size = size,
+            total = claims.size
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminClaimResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminClaimResourceMapper.kt
@@ -1,0 +1,25 @@
+package com.sympauthy.api.mapper.admin
+
+import com.sympauthy.api.resource.admin.AdminClaimResource
+import com.sympauthy.business.model.user.claim.Claim
+import com.sympauthy.business.model.user.claim.ClaimGroup
+import com.sympauthy.business.model.user.claim.StandardClaim
+import jakarta.inject.Singleton
+
+@Singleton
+class AdminClaimResourceMapper {
+
+    fun toResource(claim: Claim): AdminClaimResource {
+        return AdminClaimResource(
+            id = claim.id,
+            type = claim.dataType.name.lowercase(),
+            standard = claim is StandardClaim,
+            enabled = claim.enabled,
+            required = claim.required,
+            allowedValues = claim.allowedValues,
+            group = claim.group?.toGroupString()
+        )
+    }
+
+    private fun ClaimGroup.toGroupString(): String = name.lowercase()
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClaimListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClaimListResource.kt
@@ -1,0 +1,15 @@
+package com.sympauthy.api.resource.admin
+
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Paginated list of claims."
+)
+@Serdeable
+data class AdminClaimListResource(
+    val claims: List<AdminClaimResource>,
+    val page: Int,
+    val size: Int,
+    val total: Int
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClaimResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClaimResource.kt
@@ -1,0 +1,20 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Information about a configured claim."
+)
+@Serdeable
+data class AdminClaimResource(
+    val id: String,
+    val type: String,
+    val standard: Boolean,
+    val enabled: Boolean,
+    val required: Boolean,
+    @get:JsonProperty("allowed_values")
+    val allowedValues: List<Any>?,
+    val group: String?
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/ClaimManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/ClaimManager.kt
@@ -30,7 +30,14 @@ class ClaimManager(
     /**
      * Return all [Claim] enabled on this authorization server.
      */
-    fun listClaims(): List<Claim> {
+    fun listEnabledClaims(): List<Claim> {
+        return cachedClaimsMap.values.filter { it.enabled }
+    }
+
+    /**
+     * Return all [Claim] configured on this authorization server, including disabled ones.
+     */
+    fun listAllClaims(): List<Claim> {
         return cachedClaimsMap.values.toList()
     }
 
@@ -38,14 +45,14 @@ class ClaimManager(
      * List all [Claim] that we want to present to the end-user during the authentication flow.
      */
     fun listCollectableClaims(): List<Claim> {
-        return listClaims().filter(Claim::userInputted)
+        return listEnabledClaims().filter(Claim::userInputted)
     }
 
     /**
      * Return all [Claim] required to be provided by the end-user during its authorization flow.
      */
     fun listRequiredClaims(): List<Claim> {
-        return listClaims().filter(Claim::required)
+        return listEnabledClaims().filter(Claim::required)
     }
 
     /**

--- a/server/src/main/kotlin/com/sympauthy/business/model/user/claim/Claim.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/user/claim/Claim.kt
@@ -6,6 +6,10 @@ sealed class Claim(
      */
     val id: String,
     /**
+     * Whether the claim is enabled on this authorization server.
+     */
+    val enabled: Boolean,
+    /**
      * Identifier of the claim indicating the value of this claims has been verified by the authorization server.
      * Ex. email_verified for the standard email claim.
      */

--- a/server/src/main/kotlin/com/sympauthy/business/model/user/claim/CustomClaim.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/user/claim/CustomClaim.kt
@@ -7,6 +7,7 @@ class CustomClaim(
     allowedValues: List<Any>?
 ): Claim(
     id = id,
+    enabled = true,
     verifiedId = null, // Add support for verification on custom claim.
     dataType = dataType,
     group = null,

--- a/server/src/main/kotlin/com/sympauthy/business/model/user/claim/StandardClaim.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/user/claim/StandardClaim.kt
@@ -5,6 +5,7 @@ package com.sympauthy.business.model.user.claim
  */
 class StandardClaim(
     openIdClaim: OpenIdClaim,
+    enabled: Boolean,
     required: Boolean,
     allowedValues: List<Any>?
 ) : Claim(
@@ -12,6 +13,7 @@ class StandardClaim(
     verifiedId = openIdClaim.verifiedId,
     dataType = openIdClaim.type,
     group = openIdClaim.group,
+    enabled = enabled,
     required = required,
     userInputted = !openIdClaim.generated,
     allowedValues = allowedValues

--- a/server/src/main/kotlin/com/sympauthy/config/factory/ClaimsConfigFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/factory/ClaimsConfigFactory.kt
@@ -25,7 +25,7 @@ class ClaimsConfigFactory(
     ): ClaimsConfig {
         val errors = mutableListOf<ConfigurationException>()
 
-        val standardClaims = OpenIdClaim.entries.mapNotNull { openIdClaim ->
+        val standardClaims = OpenIdClaim.entries.map { openIdClaim ->
             provideStandardClaim(
                 properties = propertiesList.firstOrNull { it.id == openIdClaim.id },
                 openIdClaim = openIdClaim,
@@ -47,7 +47,7 @@ class ClaimsConfigFactory(
         // We ignore the check is the config is invalid since to avoid crashing the server.
         if (uncheckedAdvancedConfig is EnabledAdvancedConfig) {
             val emailClaim = standardClaims.firstOrNull { it.id == EMAIL }
-            if (uncheckedAdvancedConfig.userMergingStrategy == BY_MAIL && emailClaim == null) {
+            if (uncheckedAdvancedConfig.userMergingStrategy == BY_MAIL && emailClaim?.enabled != true) {
                 errors.add(
                     configExceptionOf(
                         "$CLAIMS_KEY.${EMAIL}",
@@ -68,9 +68,14 @@ class ClaimsConfigFactory(
         properties: ClaimConfigurationProperties?,
         openIdClaim: OpenIdClaim,
         errors: MutableList<ConfigurationException>
-    ): Claim? {
+    ): Claim {
         if (properties == null) {
-            return null
+            return StandardClaim(
+                openIdClaim = openIdClaim,
+                enabled = false,
+                required = false,
+                allowedValues = null
+            )
         }
         val enabled = try {
             parser.getBooleanOrThrow(
@@ -79,7 +84,6 @@ class ClaimsConfigFactory(
             )
         } catch (e: ConfigurationException) {
             errors.add(e)
-            return null
         }
         val required = try {
             parser.getBoolean(
@@ -88,7 +92,6 @@ class ClaimsConfigFactory(
             ) ?: false
         } catch (e: ConfigurationException) {
             errors.add(e)
-            return null
         }
         val allowedValues = getAllowedValues(
             properties = properties,
@@ -96,13 +99,12 @@ class ClaimsConfigFactory(
             type = openIdClaim.type,
             errors = errors
         )
-        return if (enabled) {
-            StandardClaim(
-                openIdClaim = openIdClaim,
-                required = required,
-                allowedValues = allowedValues
-            )
-        } else null
+        return StandardClaim(
+            openIdClaim = openIdClaim,
+            enabled = enabled,
+            required = required,
+            allowedValues = allowedValues
+        )
     }
 
     private fun getAllowedValues(

--- a/server/src/test/kotlin/com/sympauthy/security/UserAuthenticationTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/security/UserAuthenticationTest.kt
@@ -34,14 +34,14 @@ class UserAuthenticationTest {
         val auth = createAuthentication(
             listOf(
                 Scope(scope = "openid", admin = false, discoverable = true),
-                Scope(scope = AdminScopeId.CLIENTS_READ, admin = true, discoverable = false),
+                Scope(scope = AdminScopeId.CONFIG_READ, admin = true, discoverable = false),
                 Scope(scope = AdminScopeId.USERS_READ, admin = true, discoverable = false)
             )
         )
         val roles = auth.roles.toList()
         assertTrue(roles.contains(IS_USER))
         assertTrue(roles.contains(IS_ADMIN))
-        assertTrue(roles.contains("SCOPE_${AdminScopeId.CLIENTS_READ}"))
+        assertTrue(roles.contains("SCOPE_${AdminScopeId.CONFIG_READ}"))
         assertTrue(roles.contains("SCOPE_${AdminScopeId.USERS_READ}"))
         assertEquals(4, roles.size)
     }


### PR DESCRIPTION
## Summary
- Add `enabled` property to `Claim` model so all 16 OpenIdClaim entries are tracked (disabled ones included)
- Implement `GET /api/v1/admin/claims` secured with `admin:config:read` scope
- Support `enabled` and `required` query parameter filters, pagination, and sorting (enabled first, then by id)
- Add Bruno request for the new endpoint

Closes #136

## Test plan
- [x] All existing tests pass (`./gradlew test`)
- [x] Start server, request `GET /api/v1/admin/claims` with admin token — verify all standard claims appear
- [x] Test filters: `?enabled=true`, `?required=true`, `?enabled=false`
- [x] Test pagination: `?page=0&size=5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)