### PR TITLE
Add client type to Admin API client endpoints

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminClientResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminClientResourceMapper.kt
@@ -16,7 +16,11 @@ import java.net.URI
 abstract class AdminClientResourceMapper {
 
     @Mapping(source = "id", target = "clientId")
+    @Mapping(source = "public", target = "type", qualifiedByName = ["toClientType"])
     abstract fun toResource(client: Client): AdminClientResource
+
+    @org.mapstruct.Named("toClientType")
+    fun toClientType(public: Boolean): String = if (public) "public" else "confidential"
 
     fun toScope(scope: Scope): String = scope.scope
 

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientResource.kt
@@ -11,6 +11,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class AdminClientResource(
     @get:JsonProperty("client_id")
     val clientId: String,
+    @Schema(
+        description = "Whether the client is public or confidential. " +
+            "See [OAuth 2.1 - Client Types](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-2.1).",
+        allowableValues = ["public", "confidential"]
+    )
+    val type: String,
     @get:JsonProperty("allowed_scopes")
     val allowedScopes: List<String>,
     @get:JsonProperty("default_scopes")

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminClientControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminClientControllerTest.kt
@@ -38,6 +38,7 @@ class AdminClientControllerTest {
 
     private fun mockResource(clientId: String): AdminClientResource = AdminClientResource(
         clientId = clientId,
+        type = "confidential",
         allowedScopes = emptyList(),
         defaultScopes = emptyList(),
         allowedRedirectUris = emptyList()


### PR DESCRIPTION
## Summary
- Add a `type` field (`"public"` | `"confidential"`) to the admin client response (`GET /api/v1/admin/clients` and `GET /api/v1/admin/clients/{client_id}`)
- Map the existing `Client.public` boolean to the string representation via MapStruct
- Include OpenAPI schema annotation with link to OAuth 2.1 Client Types spec

Closes #144

## Test plan
- [x] Existing `AdminClientControllerTest` updated and passing (6/6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)