### PR TITLE
Update Get User endpoint to return identifier claims

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserController.kt
@@ -1,6 +1,8 @@
 package com.sympauthy.api.controller.admin
 
+import com.sympauthy.api.mapper.admin.AdminUserDetailResourceMapper
 import com.sympauthy.api.mapper.admin.AdminUserResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserDetailResource
 import com.sympauthy.api.resource.admin.AdminUserListResource
 import com.sympauthy.api.resource.admin.AdminUserResource
 import com.sympauthy.api.util.orNotFound
@@ -30,7 +32,8 @@ class AdminUserController(
     @Inject private val userSearchManager: UserSearchManager,
     @Inject private val collectedClaimManager: CollectedClaimManager,
     @Inject private val claimManager: ClaimManager,
-    @Inject private val userMapper: AdminUserResourceMapper
+    @Inject private val userMapper: AdminUserResourceMapper,
+    @Inject private val userDetailMapper: AdminUserDetailResourceMapper
 ) {
 
     companion object {
@@ -161,12 +164,10 @@ class AdminUserController(
     @Get("/{id}")
     suspend fun getUser(
         @PathVariable id: UUID
-    ): AdminUserResource {
+    ): AdminUserDetailResource {
         val user = userManager.findByIdOrNull(id).orNotFound()
-        val collectedClaims = collectedClaimManager.findByUserId(user.id)
-        val enabledClaims = claimManager.listEnabledClaims()
-        val claimsMap = userMapper.buildClaimsMap(collectedClaims, enabledClaims)
-        return userMapper.toResource(user, claimsMap)
+        val identifierClaims = collectedClaimManager.findIdentifierByUserId(user.id)
+        return userDetailMapper.toResource(user, identifierClaims)
     }
 
     /**

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/TimeZoneController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/TimeZoneController.kt
@@ -40,7 +40,7 @@ This is why it has been decided than this operation will not support pagination.
     suspend fun listTimeZones(
         @PathVariable claimId: String
     ): List<TimeZoneResource> {
-        val claim = claimManager.findById(claimId).orNotFound()
+        val claim = claimManager.findByIdOrNull(claimId).orNotFound()
         val timeZones = timeZoneProvider.listAvailableTimezones(claim)
         return timeZoneResourceMapper.toResources(timeZones)
     }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/CollectedClaimUpdateMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/CollectedClaimUpdateMapper.kt
@@ -22,7 +22,7 @@ class CollectedClaimUpdateMapper(
         val exceptionByClaimMap = mutableMapOf<Claim, LocalizedException>()
 
         for ((claimId, value) in values) {
-            val claim = claimManager.findById(claimId) ?: continue
+            val claim = claimManager.findByIdOrNull(claimId) ?: continue
             try {
                 val validatedAndCleanedValue = claimValueValidator.validateAndCleanValueForClaim(claim, value)
                 claimUpdates.add(

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
@@ -12,4 +12,7 @@ class AdminApiMapperFactory {
 
     @Singleton
     fun consentResourceMapper(): AdminConsentResourceMapper = Mappers.getMapper(AdminConsentResourceMapper::class.java)
+
+    @Singleton
+    fun userDetailResourceMapper(): AdminUserDetailResourceMapper = Mappers.getMapper(AdminUserDetailResourceMapper::class.java)
 }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminUserDetailResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminUserDetailResourceMapper.kt
@@ -1,0 +1,29 @@
+package com.sympauthy.api.mapper.admin
+
+import com.sympauthy.api.mapper.config.OutputResourceMapperConfig
+import com.sympauthy.api.resource.admin.AdminUserDetailResource
+import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.business.model.user.User
+import com.sympauthy.business.model.user.UserStatus
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import org.mapstruct.Named
+
+@Mapper(
+    config = OutputResourceMapperConfig::class
+)
+abstract class AdminUserDetailResourceMapper {
+
+    @Mapping(source = "user.id", target = "userId")
+    @Mapping(source = "user.status", target = "status", qualifiedByName = ["toStatusString"])
+    @Mapping(source = "user.creationDate", target = "createdAt")
+    @Mapping(source = "identifierClaims", target = "identifierClaims", qualifiedByName = ["toClaimsMap"])
+    abstract fun toResource(user: User, identifierClaims: List<CollectedClaim>): AdminUserDetailResource
+
+    @Named("toStatusString")
+    fun toStatusString(status: UserStatus): String = status.name.lowercase()
+
+    @Named("toClaimsMap")
+    fun toClaimsMap(claims: List<CollectedClaim>): Map<String, Any?> =
+        claims.associate { it.claim.id to it.value }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserDetailResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserDetailResource.kt
@@ -1,0 +1,33 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.*
+
+@Schema(
+    description = "Detailed information about a user."
+)
+@Serdeable
+data class AdminUserDetailResource(
+    @get:Schema(
+        description = "Unique identifier of the user."
+    )
+    @get:JsonProperty("user_id")
+    val userId: UUID,
+    @get:Schema(
+        description = "Status of the user."
+    )
+    val status: String,
+    @get:Schema(
+        description = "The date and time (in UTC timezone) at which the user has been created."
+    )
+    @get:JsonProperty("created_at")
+    val createdAt: LocalDateTime,
+    @get:Schema(
+        description = "Identifier claims associated to the user. Keys are claim identifiers, values are claim values."
+    )
+    @get:JsonProperty("identifier_claims")
+    val identifierClaims: Map<String, Any?>
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/ClaimManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/ClaimManager.kt
@@ -2,6 +2,7 @@ package com.sympauthy.business.manager
 
 import com.sympauthy.business.model.user.claim.Claim
 import com.sympauthy.business.model.user.claim.StandardClaim
+import com.sympauthy.config.model.AuthConfig
 import com.sympauthy.config.model.ClaimsConfig
 import com.sympauthy.config.model.orThrow
 import jakarta.inject.Inject
@@ -9,7 +10,8 @@ import jakarta.inject.Singleton
 
 @Singleton
 class ClaimManager(
-    @Inject private val uncheckedClaimsConfig: ClaimsConfig
+    @Inject private val uncheckedClaimsConfig: ClaimsConfig,
+    @Inject private val uncheckedAuthConfig: AuthConfig
 ) {
 
     private val cachedClaimsMap by lazy {
@@ -23,7 +25,7 @@ class ClaimManager(
      * Note: This operation is optimized to be called inside loops as it is meant to be consumed by the entity to
      * business mapper.
      */
-    fun findById(id: String): Claim? {
+    fun findByIdOrNull(id: String): Claim? {
         return cachedClaimsMap[id]
     }
 
@@ -60,5 +62,14 @@ class ClaimManager(
      */
     fun listStandardClaims(): List<StandardClaim> {
         return cachedClaimsMap.values.filterIsInstance<StandardClaim>()
+    }
+
+    /**
+     * Return all [Claim] configured as identifier claims.
+     */
+    fun listIdentifierClaims(): List<Claim> {
+        return uncheckedAuthConfig.orThrow()
+            .identifierClaims
+            .mapNotNull { findByIdOrNull(it.id) }
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowClaimValidationManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowClaimValidationManager.kt
@@ -44,7 +44,7 @@ open class WebAuthorizationFlowClaimValidationManager(
             PHONE_NUMBER_CLAIM -> PHONE_NUMBER_CLAIM.media.claim
             else -> null
         }
-        return claimId?.let(claimManager::findById)
+        return claimId?.let(claimManager::findByIdOrNull)
     }
 
     /**

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowOauth2ProviderManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowOauth2ProviderManager.kt
@@ -183,7 +183,7 @@ open class WebAuthorizationFlowOauth2ProviderManager(
 
         // Resolve the Claim business objects for each identifier claim.
         val claimObjects = identifierClaims.associateWith { claim ->
-            claimManager.findById(claim.id)
+            claimManager.findByIdOrNull(claim.id)
                 ?: throw businessExceptionOf(
                     "user.create_with_provider.missing_identifier_claim_config",
                     "claim" to claim.id

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowPasswordManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowPasswordManager.kt
@@ -130,7 +130,7 @@ open class WebAuthorizationFlowPasswordManager(
     fun getIdentifierClaims(): List<Claim> {
         return uncheckedAuthConfig.orThrow()
             .identifierClaims
-            .mapNotNull { claimManager.findById(it.id) }
+            .mapNotNull { claimManager.findByIdOrNull(it.id) }
     }
 
     /**

--- a/server/src/main/kotlin/com/sympauthy/business/manager/user/CollectedClaimManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/user/CollectedClaimManager.kt
@@ -34,13 +34,26 @@ open class CollectedClaimManager(
      *
      * Note: This method is insecure and may leak information to the client that the end-user has not granted access to,
      * use [findByUserIdAndReadableByScopes] instead. This method is intended when the authorization server requires
-     *  having full access to the user's claims (ex. when creating a new user).
+     *  having full access to the user's claims (ex. when creating a new user, admin endpoints, etc.).
      */
     suspend fun findByUserId(userId: UUID): List<CollectedClaim> {
         return collectedClaimRepository.findByUserId(userId)
             .asSequence()
             .mapNotNull(collectedClaimMapper::toCollectedClaim)
             .toList()
+    }
+
+    /**
+     * Return the list of [CollectedClaim] for the identifier claims collected from the user identified by [userId].
+     *
+     * Note: This method is insecure and may leak information to the client that the end-user has not granted access to.
+     * This method is intended when the authorization server requires having full access to the user's claims
+     * (ex. when creating a new user, admin endpoints, etc.).
+     */
+    suspend fun findIdentifierByUserId(userId: UUID): List<CollectedClaim> {
+        val identifierClaimIds = claimManager.listIdentifierClaims().map { it.id }
+        return collectedClaimRepository.findByUserIdAndClaimInList(userId, identifierClaimIds)
+            .mapNotNull(collectedClaimMapper::toCollectedClaim)
     }
 
     /**

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/CollectedClaimMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/CollectedClaimMapper.kt
@@ -22,7 +22,7 @@ abstract class CollectedClaimMapper {
      * has changed and the data cannot be deserialized anymore.
      */
     fun toCollectedClaim(entity: CollectedClaimEntity): CollectedClaim? {
-        val claim = claimManager.findById(entity.claim) ?: return null
+        val claim = claimManager.findByIdOrNull(entity.claim) ?: return null
         val value = if (entity.value != null) {
             claimValueMapper.toBusiness(entity.value, claim.dataType) ?: return null
         } else null

--- a/server/src/main/kotlin/com/sympauthy/data/repository/CollectedClaimRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/repository/CollectedClaimRepository.kt
@@ -17,6 +17,8 @@ interface CollectedClaimRepository : CoroutineCrudRepository<CollectedClaimEntit
 
     suspend fun findByUserId(userId: UUID): List<CollectedClaimEntity>
 
+    suspend fun findByUserIdAndClaimInList(userId: UUID, claim: List<String>): List<CollectedClaimEntity>
+
     suspend fun findByUserIdInList(userId: List<UUID>): List<CollectedClaimEntity>
 
     /**

--- a/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
@@ -53,6 +53,15 @@
     ]
   },
   {
+    "name": "com.sympauthy.api.mapper.admin.AdminUserDetailResourceMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sympauthy.api.mapper.flow.ClaimsValidationFlowResultResourceMapperImpl",
     "methods": [
       {

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserControllerTest.kt
@@ -1,0 +1,96 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.exception.LocalizedHttpException
+import com.sympauthy.api.mapper.admin.AdminUserDetailResourceMapper
+import com.sympauthy.api.mapper.admin.AdminUserResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserDetailResource
+import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.user.CollectedClaimManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.manager.user.UserSearchManager
+import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.business.model.user.User
+import com.sympauthy.business.model.user.UserStatus
+import com.sympauthy.business.model.user.claim.Claim
+import io.micronaut.http.HttpStatus
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class AdminUserControllerTest {
+
+    @MockK
+    lateinit var userManager: UserManager
+
+    @MockK
+    lateinit var userSearchManager: UserSearchManager
+
+    @MockK
+    lateinit var collectedClaimManager: CollectedClaimManager
+
+    @MockK
+    lateinit var claimManager: ClaimManager
+
+    @MockK
+    lateinit var userMapper: AdminUserResourceMapper
+
+    @MockK
+    lateinit var userDetailMapper: AdminUserDetailResourceMapper
+
+    @InjectMockKs
+    lateinit var controller: AdminUserController
+
+    private val userId: UUID = UUID.randomUUID()
+    private val creationDate: LocalDateTime = LocalDateTime.of(2025, 1, 1, 0, 0)
+
+    @Test
+    fun `getUser - Returns user with identifier claims`() = runTest {
+        val user = User(id = userId, status = UserStatus.ENABLED, creationDate = creationDate)
+        val emailClaim = mockk<Claim> { every { id } returns "email" }
+        val collectedClaim = mockk<CollectedClaim> {
+            every { claim } returns emailClaim
+            every { value } returns "user@example.com"
+        }
+        val identifierClaims = listOf(collectedClaim)
+        val identifierClaimsMap = mapOf("email" to "user@example.com")
+
+        val expectedResource = AdminUserDetailResource(
+            userId = userId,
+            status = "enabled",
+            createdAt = creationDate,
+            identifierClaims = identifierClaimsMap
+        )
+
+        coEvery { userManager.findByIdOrNull(userId) } returns user
+        coEvery { collectedClaimManager.findIdentifierByUserId(userId) } returns identifierClaims
+        every { userDetailMapper.toResource(user, identifierClaims) } returns expectedResource
+
+        val result = controller.getUser(userId)
+
+        assertEquals(userId, result.userId)
+        assertEquals("enabled", result.status)
+        assertEquals(identifierClaimsMap, result.identifierClaims)
+    }
+
+    @Test
+    fun `getUser - Returns 404 when user not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.getUser(userId)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowOauth2ProviderManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowOauth2ProviderManagerTest.kt
@@ -115,7 +115,7 @@ class WebAuthorizationFlowOauth2ProviderManagerTest {
 
         every { uncheckedAuthConfig.userMergingEnabled } returns true
         every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdClaim.EMAIL)
-        every { claimManager.findById(OpenIdClaim.Id.EMAIL) } returns emailClaim
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.EMAIL) } returns emailClaim
         coEvery { userManager.findByIdentifierClaims(mapOf("email" to "user@example.com")) } returns existingUser
         coJustRun { providerClaimsManager.saveUserInfo(provider, existingUser.id, providerUserInfo) }
 
@@ -138,7 +138,7 @@ class WebAuthorizationFlowOauth2ProviderManagerTest {
 
         every { uncheckedAuthConfig.userMergingEnabled } returns true
         every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdClaim.EMAIL)
-        every { claimManager.findById(OpenIdClaim.Id.EMAIL) } returns emailClaim
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.EMAIL) } returns emailClaim
         coEvery { userManager.findByIdentifierClaims(mapOf("email" to "new@example.com")) } returns null
         coEvery { userManager.createUser() } returns newUser
         coJustRun { collectedClaimManager.update(newUser, any()) }
@@ -171,8 +171,8 @@ class WebAuthorizationFlowOauth2ProviderManagerTest {
 
         every { uncheckedAuthConfig.userMergingEnabled } returns true
         every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdClaim.EMAIL, OpenIdClaim.PHONE_NUMBER)
-        every { claimManager.findById(OpenIdClaim.Id.EMAIL) } returns emailClaim
-        every { claimManager.findById(OpenIdClaim.Id.PHONE_NUMBER) } returns phoneClaim
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.EMAIL) } returns emailClaim
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.PHONE_NUMBER) } returns phoneClaim
         coEvery {
             userManager.findByIdentifierClaims(mapOf("email" to "user@example.com", "phone_number" to "+33612345678"))
         } returns existingUser
@@ -198,8 +198,8 @@ class WebAuthorizationFlowOauth2ProviderManagerTest {
 
         every { uncheckedAuthConfig.userMergingEnabled } returns true
         every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdClaim.EMAIL, OpenIdClaim.PHONE_NUMBER)
-        every { claimManager.findById(OpenIdClaim.Id.EMAIL) } returns emailClaim
-        every { claimManager.findById(OpenIdClaim.Id.PHONE_NUMBER) } returns phoneClaim
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.EMAIL) } returns emailClaim
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.PHONE_NUMBER) } returns phoneClaim
         coEvery {
             userManager.findByIdentifierClaims(mapOf("email" to "new@example.com", "phone_number" to "+33612345678"))
         } returns null
@@ -248,7 +248,7 @@ class WebAuthorizationFlowOauth2ProviderManagerTest {
 
         every { uncheckedAuthConfig.userMergingEnabled } returns true
         every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdClaim.EMAIL)
-        every { claimManager.findById(OpenIdClaim.Id.EMAIL) } returns null
+        every { claimManager.findByIdOrNull(OpenIdClaim.Id.EMAIL) } returns null
 
         val exception = assertThrows<BusinessException> {
             manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)


### PR DESCRIPTION
## Summary
- Replace `claims` (all enabled claims) with `identifier_claims` on `GET /api/v1/admin/users/{id}`, returning only identifier claim values for a lightweight admin user summary.
- Add DB-side filtering via `CollectedClaimRepository.findByUserIdAndClaimInList` and `CollectedClaimManager.findIdentifierByUserId`.
- Create `AdminUserDetailResource` and MapStruct-based `AdminUserDetailResourceMapper` with native-image reflect-config registration.
- Rename `ClaimManager.findById` → `findByIdOrNull` to follow nullable convention, and add `listIdentifierClaims()`.
- The list endpoint (`GET /api/v1/admin/users`) is unchanged and continues returning `claims`.

Closes #155

## Test plan
- [x] All 302 existing tests pass
- [x] New `AdminUserControllerTest` covers successful get and 404 case
- [x] Manual: `GET /api/v1/admin/users/{id}` returns `identifier_claims` (not `claims`)
- [x] Manual: `GET /api/v1/admin/users` still returns `claims` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)