### PR TITLE
Add Admin API: List User Claims with Metadata and Filtering (#156)

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserClaimController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserClaimController.kt
@@ -1,0 +1,174 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.mapper.admin.AdminUserClaimResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserClaimListResource
+import com.sympauthy.api.util.orNotFound
+import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.user.CollectedClaimManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.user.claim.StandardClaim
+import com.sympauthy.config.model.AuthConfig
+import com.sympauthy.config.model.orThrow
+import com.sympauthy.security.SecurityRule.ADMIN_USERS_READ
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+import java.util.*
+
+@Controller("/api/v1/admin/users/{userId}/claims")
+class AdminUserClaimController(
+    @Inject private val userManager: UserManager,
+    @Inject private val claimManager: ClaimManager,
+    @Inject private val collectedClaimManager: CollectedClaimManager,
+    @Inject private val uncheckedAuthConfig: AuthConfig,
+    @Inject private val userClaimMapper: AdminUserClaimResourceMapper
+) {
+
+    @Operation(
+        description = "Retrieve a paginated list of claims for a given user, with metadata and filtering.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "userId",
+                description = "Unique identifier of the user.",
+                schema = Schema(type = "string", format = "uuid")
+            ),
+            Parameter(
+                name = "page",
+                description = "Zero-indexed page number.",
+                schema = Schema(type = "integer", defaultValue = "0")
+            ),
+            Parameter(
+                name = "size",
+                description = "Number of results per page.",
+                schema = Schema(type = "integer", defaultValue = "20")
+            ),
+            Parameter(
+                name = "claim_id",
+                description = "Filter by specific claim identifier.",
+                schema = Schema(type = "string")
+            ),
+            Parameter(
+                name = "identifier",
+                description = "Filter by whether the claim is an identifier claim.",
+                schema = Schema(type = "boolean")
+            ),
+            Parameter(
+                name = "required",
+                description = "Filter by whether the claim is required.",
+                schema = Schema(type = "boolean")
+            ),
+            Parameter(
+                name = "collected",
+                description = "Filter by whether the claim has been collected.",
+                schema = Schema(type = "boolean")
+            ),
+            Parameter(
+                name = "verified",
+                description = "Filter by whether the claim has been verified.",
+                schema = Schema(type = "boolean")
+            ),
+            Parameter(
+                name = "standard",
+                description = "Filter by whether the claim is a standard OpenID Connect claim.",
+                schema = Schema(type = "boolean")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Paginated list of user claims."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:read."
+            ),
+            ApiResponse(responseCode = "404", description = "No user found with the given identifier.")
+        ]
+    )
+    @Get
+    @Secured(ADMIN_USERS_READ)
+    suspend fun listUserClaims(
+        @PathVariable userId: UUID,
+        @QueryValue page: Int?,
+        @QueryValue size: Int?,
+        @QueryValue("claim_id") claimId: String?,
+        @QueryValue identifier: Boolean?,
+        @QueryValue required: Boolean?,
+        @QueryValue collected: Boolean?,
+        @QueryValue verified: Boolean?,
+        @QueryValue standard: Boolean?
+    ): AdminUserClaimListResource {
+        userManager.findByIdOrNull(userId).orNotFound()
+        val (resolvedPage, resolvedSize) = resolvePageParams(page, size)
+
+        val identifierClaimIds = uncheckedAuthConfig.orThrow()
+            .identifierClaims
+            .map { it.id }
+            .toSet()
+
+        // Get all enabled claims and filter out *_verified claims
+        val allVerifiedIds = claimManager.listEnabledClaims()
+            .mapNotNull { it.verifiedId }
+            .toSet()
+        var filteredClaims = claimManager.listEnabledClaims()
+            .filter { it.id !in allVerifiedIds }
+
+        // Apply claim-metadata-only filters
+        if (claimId != null) {
+            filteredClaims = filteredClaims.filter { it.id == claimId }
+        }
+        if (identifier != null) {
+            filteredClaims = filteredClaims.filter { (it.id in identifierClaimIds) == identifier }
+        }
+        if (required != null) {
+            filteredClaims = filteredClaims.filter { it.required == required }
+        }
+        if (standard != null) {
+            filteredClaims = filteredClaims.filter { (it is StandardClaim) == standard }
+        }
+
+        // Fetch collected claims only for the filtered set
+        val collectedClaimMap = collectedClaimManager.findByUserIdAndClaims(userId, filteredClaims)
+            .associateBy { it.claim.id }
+
+        // Apply collected-data-dependent filters
+        if (collected != null) {
+            filteredClaims = filteredClaims.filter { claim ->
+                val hasValue = collectedClaimMap[claim.id]?.value != null
+                hasValue == collected
+            }
+        }
+        if (verified != null) {
+            filteredClaims = filteredClaims.filter { claim ->
+                val isVerified = collectedClaimMap[claim.id]?.verificationDate != null
+                isVerified == verified
+            }
+        }
+
+        val total = filteredClaims.size
+        val paged = filteredClaims
+            .drop(resolvedPage * resolvedSize)
+            .take(resolvedSize)
+            .map { claim ->
+                userClaimMapper.toResource(
+                    claim = claim,
+                    collectedClaim = collectedClaimMap[claim.id],
+                    identifier = claim.id in identifierClaimIds
+                )
+            }
+
+        return AdminUserClaimListResource(
+            claims = paged,
+            page = resolvedPage,
+            size = resolvedSize,
+            total = total
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
@@ -15,4 +15,7 @@ class AdminApiMapperFactory {
 
     @Singleton
     fun userDetailResourceMapper(): AdminUserDetailResourceMapper = Mappers.getMapper(AdminUserDetailResourceMapper::class.java)
+
+    @Singleton
+    fun userClaimResourceMapper(): AdminUserClaimResourceMapper = Mappers.getMapper(AdminUserClaimResourceMapper::class.java)
 }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminUserClaimResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminUserClaimResourceMapper.kt
@@ -1,0 +1,38 @@
+package com.sympauthy.api.mapper.admin
+
+import com.sympauthy.api.mapper.config.OutputResourceMapperConfig
+import com.sympauthy.api.resource.admin.AdminUserClaimResource
+import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.business.model.user.claim.Claim
+import com.sympauthy.business.model.user.claim.ClaimDataType
+import com.sympauthy.business.model.user.claim.ClaimGroup
+import com.sympauthy.business.model.user.claim.StandardClaim
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import org.mapstruct.Named
+
+@Mapper(
+    config = OutputResourceMapperConfig::class
+)
+abstract class AdminUserClaimResourceMapper {
+
+    @Mapping(source = "claim.id", target = "claimId")
+    @Mapping(source = "claim.dataType", target = "type", qualifiedByName = ["toTypeString"])
+    @Mapping(source = "claim", target = "standard", qualifiedByName = ["toStandard"])
+    @Mapping(source = "claim.required", target = "required")
+    @Mapping(source = "identifier", target = "identifier")
+    @Mapping(source = "claim.group", target = "group", qualifiedByName = ["toGroupString"])
+    @Mapping(source = "collectedClaim.value", target = "value")
+    @Mapping(source = "collectedClaim.collectionDate", target = "collectedAt")
+    @Mapping(source = "collectedClaim.verificationDate", target = "verifiedAt")
+    abstract fun toResource(claim: Claim, collectedClaim: CollectedClaim?, identifier: Boolean): AdminUserClaimResource
+
+    @Named("toTypeString")
+    fun toTypeString(dataType: ClaimDataType): String = dataType.name.lowercase()
+
+    @Named("toStandard")
+    fun toStandard(claim: Claim): Boolean = claim is StandardClaim
+
+    @Named("toGroupString")
+    fun toGroupString(group: ClaimGroup?): String? = group?.name?.lowercase()
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserClaimListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserClaimListResource.kt
@@ -1,0 +1,15 @@
+package com.sympauthy.api.resource.admin
+
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Paginated list of user claims."
+)
+@Serdeable
+data class AdminUserClaimListResource(
+    val claims: List<AdminUserClaimResource>,
+    val page: Int,
+    val size: Int,
+    val total: Int
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserClaimResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserClaimResource.kt
@@ -1,0 +1,34 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(
+    description = "Information about a claim collected from a user."
+)
+@Serdeable
+data class AdminUserClaimResource(
+    @get:Schema(description = "Identifier of the claim.")
+    @get:JsonProperty("claim_id")
+    val claimId: String,
+    @get:Schema(description = "The collected value of the claim, or null if not collected.")
+    val value: Any?,
+    @get:Schema(description = "Data type of the claim (e.g. string, boolean).")
+    val type: String,
+    @get:Schema(description = "Whether this is a standard OpenID Connect claim.")
+    val standard: Boolean,
+    @get:Schema(description = "Whether this claim is required.")
+    val required: Boolean,
+    @get:Schema(description = "Whether this claim is used as an identifier.")
+    val identifier: Boolean,
+    @get:Schema(description = "Group this claim belongs to, if any.")
+    val group: String?,
+    @get:Schema(description = "Date and time at which the claim value was collected.")
+    @get:JsonProperty("collected_at")
+    val collectedAt: LocalDateTime?,
+    @get:Schema(description = "Date and time at which the claim value was verified.")
+    @get:JsonProperty("verified_at")
+    val verifiedAt: LocalDateTime?
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/user/CollectedClaimManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/user/CollectedClaimManager.kt
@@ -44,6 +44,19 @@ open class CollectedClaimManager(
     }
 
     /**
+     * Return the list of [CollectedClaim] for the given [claims] collected from the user identified by [userId].
+     *
+     * Note: This method is insecure and may leak information to the client that the end-user has not granted access to.
+     *      * This method is intended when the authorization server requires having full access to the user's claims
+     *      * (ex. when creating a new user, admin endpoints, etc.).
+     */
+    suspend fun findByUserIdAndClaims(userId: UUID, claims: List<Claim>): List<CollectedClaim> {
+        val claimIds = claims.map { it.id }
+        return collectedClaimRepository.findByUserIdAndClaimInList(userId, claimIds)
+            .mapNotNull(collectedClaimMapper::toCollectedClaim)
+    }
+
+    /**
      * Return the list of [CollectedClaim] for the identifier claims collected from the user identified by [userId].
      *
      * Note: This method is insecure and may leak information to the client that the end-user has not granted access to.
@@ -51,9 +64,7 @@ open class CollectedClaimManager(
      * (ex. when creating a new user, admin endpoints, etc.).
      */
     suspend fun findIdentifierByUserId(userId: UUID): List<CollectedClaim> {
-        val identifierClaimIds = claimManager.listIdentifierClaims().map { it.id }
-        return collectedClaimRepository.findByUserIdAndClaimInList(userId, identifierClaimIds)
-            .mapNotNull(collectedClaimMapper::toCollectedClaim)
+        return findByUserIdAndClaims(userId, claimManager.listIdentifierClaims())
     }
 
     /**

--- a/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
@@ -53,6 +53,15 @@
     ]
   },
   {
+    "name": "com.sympauthy.api.mapper.admin.AdminUserClaimResourceMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sympauthy.api.mapper.admin.AdminUserDetailResourceMapperImpl",
     "methods": [
       {

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserClaimControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserClaimControllerTest.kt
@@ -1,0 +1,403 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.exception.LocalizedHttpException
+import com.sympauthy.api.mapper.admin.AdminUserClaimResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserClaimResource
+import com.sympauthy.api.util.DEFAULT_PAGE
+import com.sympauthy.api.util.DEFAULT_PAGE_SIZE
+import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.user.CollectedClaimManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.business.model.user.User
+import com.sympauthy.business.model.user.claim.ClaimDataType
+import com.sympauthy.business.model.user.claim.CustomClaim
+import com.sympauthy.business.model.user.claim.OpenIdClaim
+import com.sympauthy.business.model.user.claim.StandardClaim
+import com.sympauthy.config.model.AuthConfig
+import com.sympauthy.config.model.EnabledAuthConfig
+import io.micronaut.http.HttpStatus
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class AdminUserClaimControllerTest {
+
+    @MockK
+    lateinit var userManager: UserManager
+
+    @MockK
+    lateinit var claimManager: ClaimManager
+
+    @MockK
+    lateinit var collectedClaimManager: CollectedClaimManager
+
+    @MockK
+    lateinit var uncheckedAuthConfig: AuthConfig
+
+    @MockK
+    lateinit var userClaimMapper: AdminUserClaimResourceMapper
+
+    @InjectMockKs
+    lateinit var controller: AdminUserClaimController
+
+    private val userId = UUID.randomUUID()
+
+    private val emailClaim = StandardClaim(
+        openIdClaim = OpenIdClaim.EMAIL,
+        enabled = true,
+        required = true,
+        allowedValues = null
+    )
+
+    private val nameClaim = StandardClaim(
+        openIdClaim = OpenIdClaim.NAME,
+        enabled = true,
+        required = false,
+        allowedValues = null
+    )
+
+    // email_verified — should be filtered out
+    private val emailVerifiedClaim = CustomClaim(
+        id = "email_verified",
+        dataType = ClaimDataType.STRING,
+        required = false,
+        allowedValues = null
+    )
+
+    private val customClaim = CustomClaim(
+        id = "custom_field",
+        dataType = ClaimDataType.STRING,
+        required = false,
+        allowedValues = null
+    )
+
+    private fun mockUser(): User = mockk {
+        every { id } returns userId
+    }
+
+    private fun mockEnabledAuthConfig(identifierClaimIds: List<OpenIdClaim>) {
+        val enabledConfig = mockk<EnabledAuthConfig> {
+            every { identifierClaims } returns identifierClaimIds
+        }
+        every { uncheckedAuthConfig.let { any<(AuthConfig) -> EnabledAuthConfig>().invoke(it) } } returns enabledConfig
+        // Use the orThrow extension properly by mocking the sealed class cast
+    }
+
+    private fun setupAuthConfig(identifierOpenIdClaims: List<OpenIdClaim> = listOf(OpenIdClaim.EMAIL)) {
+        val enabledConfig = EnabledAuthConfig(
+            issuer = "test",
+            audience = "test",
+            token = mockk(),
+            identifierClaims = identifierOpenIdClaims,
+            userMergingEnabled = false,
+            byPassword = mockk()
+        )
+        // uncheckedAuthConfig must be the EnabledAuthConfig itself for orThrow() to work
+        // But since it's injected as AuthConfig, we need to mock it properly
+        // Actually, @MockK creates a mock of AuthConfig. orThrow() checks `is EnabledAuthConfig`.
+        // We can't make a MockK of AuthConfig pass `is EnabledAuthConfig` check.
+        // So we replace the field directly.
+    }
+
+    private fun mockResource(claimId: String, value: Any? = null): AdminUserClaimResource = AdminUserClaimResource(
+        claimId = claimId,
+        value = value,
+        type = "string",
+        standard = true,
+        required = false,
+        identifier = false,
+        group = null,
+        collectedAt = null,
+        verifiedAt = null
+    )
+
+    private fun mockCollectedClaim(
+        claim: com.sympauthy.business.model.user.claim.Claim,
+        value: Any? = "test-value",
+        verificationDate: LocalDateTime? = null
+    ): CollectedClaim = CollectedClaim(
+        userId = userId,
+        claim = claim,
+        value = value,
+        verified = verificationDate != null,
+        collectionDate = LocalDateTime.now(),
+        verificationDate = verificationDate
+    )
+
+    private fun setupDefault(
+        claims: List<com.sympauthy.business.model.user.claim.Claim> = listOf(emailClaim, nameClaim),
+        identifierOpenIdClaims: List<OpenIdClaim> = listOf(OpenIdClaim.EMAIL)
+    ) {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns claims
+
+        val enabledConfig = EnabledAuthConfig(
+            issuer = "test",
+            audience = "test",
+            token = mockk(),
+            identifierClaims = identifierOpenIdClaims,
+            userMergingEnabled = false,
+            byPassword = mockk()
+        )
+        // We need uncheckedAuthConfig to be an EnabledAuthConfig for orThrow() to work.
+        // Since @MockK creates a mock of AuthConfig (sealed class), and orThrow() uses a `when` on `is EnabledAuthConfig`,
+        // we must use a relaxed mock approach or directly set the field.
+        // The simplest workaround: replace the controller's field via reflection or use @RelaxedMockK.
+        // Actually, let's just create the controller manually for these tests.
+    }
+
+    // Helper to create controller with real EnabledAuthConfig
+    private fun createController(
+        identifierOpenIdClaims: List<OpenIdClaim> = listOf(OpenIdClaim.EMAIL)
+    ): AdminUserClaimController {
+        val enabledConfig = EnabledAuthConfig(
+            issuer = "test",
+            audience = "test",
+            token = mockk(),
+            identifierClaims = identifierOpenIdClaims,
+            userMergingEnabled = false,
+            byPassword = mockk()
+        )
+        return AdminUserClaimController(
+            userManager = userManager,
+            claimManager = claimManager,
+            collectedClaimManager = collectedClaimManager,
+            uncheckedAuthConfig = enabledConfig,
+            userClaimMapper = userClaimMapper
+        )
+    }
+
+    @Test
+    fun `listUserClaims - Return paginated list with defaults`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, nameClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val emailResource = mockResource("email")
+        val nameResource = mockResource("name")
+        every { userClaimMapper.toResource(emailClaim, null, true) } returns emailResource
+        every { userClaimMapper.toResource(nameClaim, null, false) } returns nameResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, null, null, null, null)
+
+        assertEquals(DEFAULT_PAGE, result.page)
+        assertEquals(DEFAULT_PAGE_SIZE, result.size)
+        assertEquals(2, result.total)
+        assertEquals(2, result.claims.size)
+        assertSame(emailResource, result.claims[0])
+        assertSame(nameResource, result.claims[1])
+    }
+
+    @Test
+    fun `listUserClaims - Verified claims are excluded`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        // emailClaim has verifiedId = "email_verified", so emailVerifiedClaim should be excluded
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, emailVerifiedClaim, nameClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val emailResource = mockResource("email")
+        val nameResource = mockResource("name")
+        every { userClaimMapper.toResource(emailClaim, null, true) } returns emailResource
+        every { userClaimMapper.toResource(nameClaim, null, false) } returns nameResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, null, null, null, null)
+
+        assertEquals(2, result.total)
+        assertEquals(listOf("email", "name"), result.claims.map { it.claimId })
+    }
+
+    @Test
+    fun `listUserClaims - Filter by claimId`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, nameClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val emailResource = mockResource("email")
+        every { userClaimMapper.toResource(emailClaim, null, true) } returns emailResource
+
+        val result = ctrl.listUserClaims(userId, null, null, "email", null, null, null, null, null)
+
+        assertEquals(1, result.total)
+        assertEquals("email", result.claims[0].claimId)
+    }
+
+    @Test
+    fun `listUserClaims - Filter by identifier`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, nameClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val emailResource = mockResource("email")
+        every { userClaimMapper.toResource(emailClaim, null, true) } returns emailResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, true, null, null, null, null)
+
+        assertEquals(1, result.total)
+        assertEquals("email", result.claims[0].claimId)
+    }
+
+    @Test
+    fun `listUserClaims - Filter by required`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, nameClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val emailResource = mockResource("email")
+        every { userClaimMapper.toResource(emailClaim, null, true) } returns emailResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, true, null, null, null)
+
+        assertEquals(1, result.total)
+        assertEquals("email", result.claims[0].claimId)
+    }
+
+    @Test
+    fun `listUserClaims - Filter by standard`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, customClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val customResource = mockResource("custom_field")
+        every { userClaimMapper.toResource(customClaim, null, false) } returns customResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, null, null, null, false)
+
+        assertEquals(1, result.total)
+        assertEquals("custom_field", result.claims[0].claimId)
+    }
+
+    @Test
+    fun `listUserClaims - Filter by collected`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, nameClaim)
+
+        val collectedEmail = mockCollectedClaim(emailClaim, "user@test.com")
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns listOf(collectedEmail)
+
+        val emailResource = mockResource("email", "user@test.com")
+        every { userClaimMapper.toResource(emailClaim, collectedEmail, true) } returns emailResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, null, true, null, null)
+
+        assertEquals(1, result.total)
+        assertEquals("email", result.claims[0].claimId)
+    }
+
+    @Test
+    fun `listUserClaims - Filter by verified`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim, nameClaim)
+
+        val verifiedDate = LocalDateTime.of(2025, 1, 1, 0, 0)
+        val collectedEmail = mockCollectedClaim(emailClaim, "user@test.com", verifiedDate)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns listOf(collectedEmail)
+
+        val emailResource = mockResource("email", "user@test.com")
+        every { userClaimMapper.toResource(emailClaim, collectedEmail, true) } returns emailResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, null, null, true, null)
+
+        assertEquals(1, result.total)
+        assertEquals("email", result.claims[0].claimId)
+    }
+
+    @Test
+    fun `listUserClaims - Claims without collected values show null metadata`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(nameClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val nameResource = AdminUserClaimResource(
+            claimId = "name",
+            value = null,
+            type = "string",
+            standard = true,
+            required = false,
+            identifier = false,
+            group = "identity",
+            collectedAt = null,
+            verifiedAt = null
+        )
+        every { userClaimMapper.toResource(nameClaim, null, false) } returns nameResource
+
+        val result = ctrl.listUserClaims(userId, null, null, null, null, null, null, null, null)
+
+        assertEquals(1, result.total)
+        assertNull(result.claims[0].value)
+        assertNull(result.claims[0].collectedAt)
+        assertNull(result.claims[0].verifiedAt)
+    }
+
+    @Test
+    fun `listUserClaims - Throw 404 when user not found`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            ctrl.listUserClaims(userId, null, null, null, null, null, null, null, null)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `listUserClaims - Pagination works correctly`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+
+        val claims = (1..5).map {
+            CustomClaim(id = "claim_$it", dataType = ClaimDataType.STRING, required = false, allowedValues = null)
+        }
+        every { claimManager.listEnabledClaims() } returns claims
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val resources = claims.map { mockResource(it.id) }
+        claims.forEachIndexed { i, claim ->
+            every { userClaimMapper.toResource(claim, null, false) } returns resources[i]
+        }
+
+        val result = ctrl.listUserClaims(userId, 1, 2, null, null, null, null, null, null)
+
+        assertEquals(1, result.page)
+        assertEquals(2, result.size)
+        assertEquals(5, result.total)
+        assertEquals(2, result.claims.size)
+        assertSame(resources[2], result.claims[0])
+        assertSame(resources[3], result.claims[1])
+    }
+
+    @Test
+    fun `listUserClaims - Empty page when page exceeds total`() = runTest {
+        val ctrl = createController()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockUser()
+        every { claimManager.listEnabledClaims() } returns listOf(emailClaim)
+        coEvery { collectedClaimManager.findByUserIdAndClaims(userId, any()) } returns emptyList()
+
+        val result = ctrl.listUserClaims(userId, 5, 20, null, null, null, null, null, null)
+
+        assertEquals(5, result.page)
+        assertEquals(1, result.total)
+        assertTrue(result.claims.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/admin/users/{userId}/claims` endpoint returning paginated claim values with metadata (`collected_at`, `verified_at`)
- Support filtering by `claim_id`, `identifier`, `required`, `collected`, `verified`, and `standard`
- Add `findByUserIdAndClaims` to `CollectedClaimManager` and refactor `findIdentifierByUserId` to use it
- Exclude `*_verified` claims (e.g. `email_verified`) from results

## Test plan
- [x] Unit tests for all filters (`claimId`, `identifier`, `required`, `collected`, `verified`, `standard`)
- [x] Unit tests for pagination (default, custom page/size, empty page beyond total)
- [x] Unit test for 404 when user not found
- [x] Unit test for verified-claim exclusion
- [x] Unit test for null metadata when claim not collected
- [x] Full test suite passes

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)