### PR TITLE
Implement List Scopes admin endpoint

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminScopeController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminScopeController.kt
@@ -1,0 +1,96 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.mapper.admin.AdminScopeResourceMapper
+import com.sympauthy.api.resource.admin.AdminScopeListResource
+import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.ScopeManager
+import com.sympauthy.business.model.oauth2.*
+import com.sympauthy.security.SecurityRule.ADMIN_CONFIG_READ
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+
+@Controller("/api/v1/admin/scopes")
+@Secured(ADMIN_CONFIG_READ)
+class AdminScopeController(
+    @Inject private val scopeManager: ScopeManager,
+    @Inject private val scopeMapper: AdminScopeResourceMapper
+) {
+
+    @Operation(
+        description = "Retrieve all configured scopes (consentable, grantable, client). Since scopes are defined in configuration, this endpoint exposes them as read-only resources.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "page",
+                description = "Zero-indexed page number.",
+                schema = Schema(type = "integer", defaultValue = "0")
+            ),
+            Parameter(
+                name = "size",
+                description = "Number of results per page.",
+                schema = Schema(type = "integer", defaultValue = "20")
+            ),
+            Parameter(
+                name = "type",
+                description = "Filter by scope type.",
+                schema = Schema(type = "string", allowableValues = ["consentable", "grantable", "client"])
+            ),
+            Parameter(
+                name = "enabled",
+                description = "Filter by enabled status.",
+                schema = Schema(type = "boolean")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Paginated list of scopes."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:config:read."
+            )
+        ]
+    )
+    @Get
+    suspend fun listScopes(
+        @QueryValue page: Int?,
+        @QueryValue size: Int?,
+        @QueryValue type: String?,
+        @QueryValue enabled: Boolean?
+    ): AdminScopeListResource {
+        val (page, size) = resolvePageParams(page, size)
+        val scopes = scopeManager.listScopes()
+            .let { list -> filterByType(list, type) }
+            .let { list -> if (enabled != null) list.filter { enabled } else list }
+            .sortedBy { it.scope }
+        val paged = scopes
+            .drop(page * size)
+            .take(size)
+            .map { scope ->
+                val claims = scopeManager.listClaimsProtectedByScope(scope)
+                scopeMapper.toResource(scope, claims)
+            }
+        return AdminScopeListResource(
+            scopes = paged,
+            page = page,
+            size = size,
+            total = scopes.size
+        )
+    }
+
+    private fun filterByType(scopes: List<Scope>, type: String?): List<Scope> {
+        return when (type?.lowercase()) {
+            "consentable" -> scopes.filterIsInstance<ConsentableUserScope>()
+            "grantable" -> scopes.filterIsInstance<GrantableUserScope>()
+            "client" -> scopes.filterIsInstance<ClientScope>()
+            null -> scopes
+            else -> emptyList()
+        }
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminScopeResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminScopeResourceMapper.kt
@@ -1,0 +1,26 @@
+package com.sympauthy.api.mapper.admin
+
+import com.sympauthy.api.resource.admin.AdminScopeResource
+import com.sympauthy.business.model.oauth2.*
+import com.sympauthy.business.model.user.claim.Claim
+import jakarta.inject.Singleton
+
+@Singleton
+class AdminScopeResourceMapper {
+
+    fun toResource(scope: Scope, claims: List<Claim>): AdminScopeResource {
+        return AdminScopeResource(
+            id = scope.scope,
+            type = toTypeString(scope),
+            origin = scope.origin.value,
+            enabled = true,
+            claims = if (scope is ConsentableUserScope) claims.map { it.id } else null
+        )
+    }
+
+    private fun toTypeString(scope: Scope): String = when (scope) {
+        is ConsentableUserScope -> "consentable"
+        is GrantableUserScope -> "grantable"
+        is ClientScope -> "client"
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminScopeListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminScopeListResource.kt
@@ -1,0 +1,19 @@
+package com.sympauthy.api.resource.admin
+
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Paginated list of scopes."
+)
+@Serdeable
+data class AdminScopeListResource(
+    @get:Schema(description = "Array of scope records.")
+    val scopes: List<AdminScopeResource>,
+    @get:Schema(description = "Current page number.")
+    val page: Int,
+    @get:Schema(description = "Number of results per page.")
+    val size: Int,
+    @get:Schema(description = "Total number of scopes.")
+    val total: Int
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminScopeResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminScopeResource.kt
@@ -1,0 +1,32 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Information about a configured scope."
+)
+@Serdeable
+data class AdminScopeResource(
+    @get:Schema(description = "Unique scope identifier.")
+    val id: String,
+    @get:Schema(
+        description = "Scope type.",
+        allowableValues = ["consentable", "grantable", "client"]
+    )
+    val type: String,
+    @get:Schema(
+        description = "Where the scope is defined.",
+        allowableValues = ["openid", "system", "custom"]
+    )
+    val origin: String,
+    @get:Schema(description = "Whether the scope is enabled.")
+    val enabled: Boolean,
+    @get:Schema(
+        description = "Array of claim identifiers protected by this scope. Only present for consentable scopes.",
+        nullable = true
+    )
+    @get:JsonInclude(JsonInclude.Include.ALWAYS)
+    val claims: List<String>?
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/ScopeManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/ScopeManager.kt
@@ -4,6 +4,7 @@ import com.sympauthy.business.exception.businessExceptionOf
 import com.sympauthy.business.model.client.Client
 import com.sympauthy.business.model.oauth2.*
 import com.sympauthy.business.model.user.OpenIdConnectScope
+import com.sympauthy.business.model.user.claim.Claim
 import com.sympauthy.config.model.CustomScopeConfig
 import com.sympauthy.config.model.ScopesConfig
 import com.sympauthy.config.model.OpenIdConnectScopeConfig
@@ -17,7 +18,8 @@ import kotlinx.coroutines.flow.toList
 
 @Singleton
 class ScopeManager(
-    @Inject private val uncheckedScopesConfig: ScopesConfig
+    @Inject private val uncheckedScopesConfig: ScopesConfig,
+    @Inject private val claimManager: ClaimManager
 ) {
     /**
      * Consentable scopes defined in the OpenID Connect specification (profile, email, address, phone).
@@ -141,6 +143,18 @@ class ScopeManager(
         }
 
         return foundScope
+    }
+
+    /**
+     * Return the list of [Claim] that are protected by the given [scope].
+     * A claim is protected by a scope if the scope must be requested to read the claim.
+     *
+     * Only consentable scopes protect claims. Returns an empty list for grantable and client scopes.
+     */
+    fun listClaimsProtectedByScope(scope: Scope): List<Claim> {
+        if (scope !is ConsentableUserScope) return emptyList()
+        return claimManager.listAllClaims()
+            .filter { it.readScopes.contains(scope.scope) }
     }
 
     /**

--- a/server/src/main/kotlin/com/sympauthy/business/model/oauth2/Scope.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/oauth2/Scope.kt
@@ -1,5 +1,7 @@
 package com.sympauthy.business.model.oauth2
 
+import com.sympauthy.business.model.user.isOpenIdConnectScope
+
 /**
  * Represents a scope that can be requested during an OAuth2/OpenID Connect flow.
  *
@@ -61,3 +63,25 @@ val Scope.isUserScope: Boolean get() = this is ConsentableUserScope || this is G
  * True if this scope is a client scope for `client_credentials` flows.
  */
 val Scope.isClientScope: Boolean get() = this is ClientScope
+
+/**
+ * Origin of a scope, indicating which specification or system defines it.
+ */
+enum class ScopeOrigin(val value: String) {
+    /** Scope defined by the OpenID Connect specification. */
+    OPENID("openid"),
+    /** Scope defined by SympAuthy for administration or client APIs. */
+    SYSTEM("system"),
+    /** Scope defined by the operator in configuration. */
+    CUSTOM("custom")
+}
+
+/**
+ * The origin of this scope, indicating where it is defined.
+ */
+val Scope.origin: ScopeOrigin
+    get() = when {
+        scope.isOpenIdConnectScope() || scope.isBuiltInGrantableScope() -> ScopeOrigin.OPENID
+        scope.isAdminScope() || scope.isBuiltInClientScope() -> ScopeOrigin.SYSTEM
+        else -> ScopeOrigin.CUSTOM
+    }

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminScopeControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminScopeControllerTest.kt
@@ -1,0 +1,204 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.mapper.admin.AdminScopeResourceMapper
+import com.sympauthy.api.resource.admin.AdminScopeResource
+import com.sympauthy.api.util.DEFAULT_PAGE
+import com.sympauthy.api.util.DEFAULT_PAGE_SIZE
+import com.sympauthy.business.manager.ScopeManager
+import com.sympauthy.business.model.oauth2.ClientScope
+import com.sympauthy.business.model.oauth2.ConsentableUserScope
+import com.sympauthy.business.model.oauth2.GrantableUserScope
+import com.sympauthy.business.model.oauth2.Scope
+import com.sympauthy.business.model.user.claim.Claim
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class AdminScopeControllerTest {
+
+    @MockK
+    lateinit var scopeManager: ScopeManager
+
+    @MockK
+    lateinit var scopeMapper: AdminScopeResourceMapper
+
+    @InjectMockKs
+    lateinit var controller: AdminScopeController
+
+    private fun mockClaim(id: String): Claim = mockk {
+        every { this@mockk.id } returns id
+    }
+
+    private fun mockResource(id: String, type: String, claims: List<String>? = null): AdminScopeResource =
+        AdminScopeResource(
+            id = id,
+            type = type,
+            origin = "openid",
+            enabled = true,
+            claims = claims
+        )
+
+    @Test
+    fun `listScopes - Return paginated list with defaults`() = runTest {
+        val profile = ConsentableUserScope("profile")
+        val openid = GrantableUserScope("openid", discoverable = true)
+        val scopes = listOf(profile, openid)
+
+        val profileClaims = listOf(mockClaim("name"), mockClaim("family_name"))
+        val profileResource = mockResource("profile", "consentable", listOf("name", "family_name"))
+        val openidResource = mockResource("openid", "grantable")
+
+        coEvery { scopeManager.listScopes() } returns scopes
+        every { scopeManager.listClaimsProtectedByScope(openid) } returns emptyList()
+        every { scopeManager.listClaimsProtectedByScope(profile) } returns profileClaims
+        every { scopeMapper.toResource(openid, emptyList()) } returns openidResource
+        every { scopeMapper.toResource(profile, profileClaims) } returns profileResource
+
+        val result = controller.listScopes(null, null, null, null)
+
+        assertEquals(DEFAULT_PAGE, result.page)
+        assertEquals(DEFAULT_PAGE_SIZE, result.size)
+        assertEquals(2, result.total)
+        assertEquals(2, result.scopes.size)
+        // Sorted by scope id: openid < profile
+        assertSame(openidResource, result.scopes[0])
+        assertSame(profileResource, result.scopes[1])
+    }
+
+    @Test
+    fun `listScopes - Filter by type consentable`() = runTest {
+        val profile = ConsentableUserScope("profile")
+        val openid = GrantableUserScope("openid", discoverable = true)
+
+        val profileClaims = listOf(mockClaim("name"))
+        val profileResource = mockResource("profile", "consentable", listOf("name"))
+
+        coEvery { scopeManager.listScopes() } returns listOf(profile, openid)
+        every { scopeManager.listClaimsProtectedByScope(profile) } returns profileClaims
+        every { scopeMapper.toResource(profile, profileClaims) } returns profileResource
+
+        val result = controller.listScopes(null, null, "consentable", null)
+
+        assertEquals(1, result.total)
+        assertEquals(1, result.scopes.size)
+        assertSame(profileResource, result.scopes[0])
+    }
+
+    @Test
+    fun `listScopes - Filter by type grantable`() = runTest {
+        val profile = ConsentableUserScope("profile")
+        val openid = GrantableUserScope("openid", discoverable = true)
+
+        val openidResource = mockResource("openid", "grantable")
+
+        coEvery { scopeManager.listScopes() } returns listOf(profile, openid)
+        every { scopeManager.listClaimsProtectedByScope(openid) } returns emptyList()
+        every { scopeMapper.toResource(openid, emptyList()) } returns openidResource
+
+        val result = controller.listScopes(null, null, "grantable", null)
+
+        assertEquals(1, result.total)
+        assertEquals(1, result.scopes.size)
+        assertSame(openidResource, result.scopes[0])
+    }
+
+    @Test
+    fun `listScopes - Filter by type client`() = runTest {
+        val profile = ConsentableUserScope("profile")
+        val usersRead = ClientScope("users:read")
+
+        val usersReadResource = mockResource("users:read", "client")
+
+        coEvery { scopeManager.listScopes() } returns listOf(profile, usersRead)
+        every { scopeManager.listClaimsProtectedByScope(usersRead) } returns emptyList()
+        every { scopeMapper.toResource(usersRead, emptyList()) } returns usersReadResource
+
+        val result = controller.listScopes(null, null, "client", null)
+
+        assertEquals(1, result.total)
+        assertEquals(1, result.scopes.size)
+        assertSame(usersReadResource, result.scopes[0])
+    }
+
+    @Test
+    fun `listScopes - Unknown type returns empty list`() = runTest {
+        val profile = ConsentableUserScope("profile")
+
+        coEvery { scopeManager.listScopes() } returns listOf(profile)
+
+        val result = controller.listScopes(null, null, "unknown", null)
+
+        assertEquals(0, result.total)
+        assertTrue(result.scopes.isEmpty())
+    }
+
+    @Test
+    fun `listScopes - Apply page and size`() = runTest {
+        val scopes = listOf(
+            ConsentableUserScope("address"),
+            ConsentableUserScope("email"),
+            GrantableUserScope("openid", discoverable = true),
+            ConsentableUserScope("phone"),
+            ConsentableUserScope("profile")
+        )
+        val resources = scopes.map { mockResource(it.scope, "consentable") }
+
+        coEvery { scopeManager.listScopes() } returns scopes
+        scopes.forEachIndexed { i, scope ->
+            every { scopeManager.listClaimsProtectedByScope(scope) } returns emptyList()
+            every { scopeMapper.toResource(scope, emptyList()) } returns resources[i]
+        }
+
+        val result = controller.listScopes(1, 2, null, null)
+
+        assertEquals(1, result.page)
+        assertEquals(2, result.size)
+        assertEquals(5, result.total)
+        assertEquals(2, result.scopes.size)
+    }
+
+    @Test
+    fun `listScopes - Return empty page when page exceeds total`() = runTest {
+        val scope = ConsentableUserScope("profile")
+        coEvery { scopeManager.listScopes() } returns listOf(scope)
+
+        val result = controller.listScopes(5, 20, null, null)
+
+        assertEquals(5, result.page)
+        assertEquals(1, result.total)
+        assertTrue(result.scopes.isEmpty())
+    }
+
+    @Test
+    fun `listScopes - Claims populated for consentable, null for others`() = runTest {
+        val profile = ConsentableUserScope("profile")
+        val openid = GrantableUserScope("openid", discoverable = true)
+
+        val profileClaims = listOf(mockClaim("name"))
+
+        coEvery { scopeManager.listScopes() } returns listOf(profile, openid)
+        every { scopeManager.listClaimsProtectedByScope(profile) } returns profileClaims
+        every { scopeManager.listClaimsProtectedByScope(openid) } returns emptyList()
+        every { scopeMapper.toResource(profile, profileClaims) } returns AdminScopeResource(
+            id = "profile", type = "consentable", origin = "openid", enabled = true,
+            claims = listOf("name")
+        )
+        every { scopeMapper.toResource(openid, emptyList()) } returns AdminScopeResource(
+            id = "openid", type = "grantable", origin = "openid", enabled = true,
+            claims = null
+        )
+
+        val result = controller.listScopes(null, null, null, null)
+
+        assertNotNull(result.scopes.first { it.id == "profile" }.claims)
+        assertNull(result.scopes.first { it.id == "openid" }.claims)
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/ScopeManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/ScopeManagerTest.kt
@@ -25,6 +25,9 @@ class ScopeManagerTest {
     @MockK
     lateinit var scopesConfig: EnabledScopesConfig
 
+    @MockK
+    lateinit var claimManager: ClaimManager
+
     @SpyK
     @InjectMockKs
     lateinit var scopeManager: ScopeManager


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/admin/scopes` endpoint with pagination and filtering by `type` (consentable/grantable/client) and `enabled` status
- Add `ScopeOrigin` enum (`openid`, `system`, `custom`) and `Scope.origin` extension property to identify where each scope is defined
- Add `ScopeManager.listClaimsProtectedByScope()` to expose claim IDs on consentable scopes
- Consentable scopes include a `claims` array; grantable and client scopes omit it (`null`)

Closes #160

## Test plan

- [x] 8 unit tests covering default pagination, type filtering, unknown type, page boundaries, and claims presence
- [x] All 322 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)