### PR TITLE
Add Admin API endpoints to list and revoke user MFA methods

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaController.kt
@@ -1,0 +1,126 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.exception.httpExceptionOf
+import com.sympauthy.api.mapper.admin.AdminUserMfaMethodResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserMfaMethodListResource
+import com.sympauthy.api.resource.admin.AdminUserMfaRevokeResource
+import com.sympauthy.api.util.orNotFound
+import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.mfa.TotpManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.security.SecurityRule.ADMIN_USERS_READ
+import com.sympauthy.security.SecurityRule.ADMIN_USERS_WRITE
+import io.micronaut.http.HttpStatus.NOT_FOUND
+import io.micronaut.http.annotation.*
+import io.micronaut.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+import java.util.*
+
+@Controller("/api/v1/admin/users/{userId}/mfa")
+class AdminUserMfaController(
+    @Inject private val userManager: UserManager,
+    @Inject private val totpManager: TotpManager,
+    @Inject private val mfaMapper: AdminUserMfaMethodResourceMapper
+) {
+
+    @Operation(
+        description = "Retrieve a paginated list of registered MFA methods for a given user.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "userId",
+                description = "Unique identifier of the user.",
+                schema = Schema(type = "string", format = "uuid")
+            ),
+            Parameter(
+                name = "page",
+                description = "Zero-indexed page number.",
+                schema = Schema(type = "integer", defaultValue = "0")
+            ),
+            Parameter(
+                name = "size",
+                description = "Number of results per page.",
+                schema = Schema(type = "integer", defaultValue = "20")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Paginated list of MFA methods."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:read."
+            ),
+            ApiResponse(responseCode = "404", description = "No user found with the given identifier.")
+        ]
+    )
+    @Get
+    @Secured(ADMIN_USERS_READ)
+    suspend fun listMfaMethods(
+        @PathVariable userId: UUID,
+        @QueryValue page: Int?,
+        @QueryValue size: Int?
+    ): AdminUserMfaMethodListResource {
+        userManager.findByIdOrNull(userId).orNotFound()
+        val (page, size) = resolvePageParams(page, size)
+        val allEnrollments = totpManager.findConfirmedEnrollments(userId)
+        val paged = allEnrollments
+            .drop(page * size)
+            .take(size)
+            .map(mfaMapper::toResource)
+        return AdminUserMfaMethodListResource(
+            mfaMethods = paged,
+            page = page,
+            size = size,
+            total = allEnrollments.size
+        )
+    }
+
+    @Operation(
+        description = "Revoke a specific MFA method registered by a user. " +
+            "The user will need to re-enroll on their next sign-in if MFA is required.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "userId",
+                description = "Unique identifier of the user.",
+                schema = Schema(type = "string", format = "uuid")
+            ),
+            Parameter(
+                name = "mfaId",
+                description = "Unique identifier of the MFA registration to revoke.",
+                schema = Schema(type = "string", format = "uuid")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "MFA method revoked successfully."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:write."
+            ),
+            ApiResponse(responseCode = "404", description = "No MFA registration found with the given identifier.")
+        ]
+    )
+    @Delete("/{mfaId}")
+    @Secured(ADMIN_USERS_WRITE)
+    suspend fun revokeMfaMethod(
+        @PathVariable userId: UUID,
+        @PathVariable mfaId: UUID
+    ): AdminUserMfaRevokeResource {
+        userManager.findByIdOrNull(userId).orNotFound()
+        val enrollment = totpManager.findConfirmedEnrollmentOrNull(mfaId).orNotFound()
+        if (enrollment.userId != userId) {
+            throw httpExceptionOf(NOT_FOUND, "not_found", "description.not_found")
+        }
+        totpManager.deleteEnrollment(enrollment)
+        return AdminUserMfaRevokeResource(
+            userId = userId,
+            mfaId = mfaId,
+            revoked = true
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
@@ -18,4 +18,7 @@ class AdminApiMapperFactory {
 
     @Singleton
     fun userClaimResourceMapper(): AdminUserClaimResourceMapper = Mappers.getMapper(AdminUserClaimResourceMapper::class.java)
+
+    @Singleton
+    fun mfaMethodResourceMapper(): AdminUserMfaMethodResourceMapper = Mappers.getMapper(AdminUserMfaMethodResourceMapper::class.java)
 }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminUserMfaMethodResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminUserMfaMethodResourceMapper.kt
@@ -1,0 +1,18 @@
+package com.sympauthy.api.mapper.admin
+
+import com.sympauthy.api.mapper.config.OutputResourceMapperConfig
+import com.sympauthy.api.resource.admin.AdminUserMfaMethodResource
+import com.sympauthy.business.model.mfa.TotpEnrollment
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+
+@Mapper(
+    config = OutputResourceMapperConfig::class
+)
+abstract class AdminUserMfaMethodResourceMapper {
+
+    @Mapping(source = "id", target = "mfaId")
+    @Mapping(source = "confirmedDate", target = "registeredAt")
+    @Mapping(target = "type", constant = "totp")
+    abstract fun toResource(enrollment: TotpEnrollment): AdminUserMfaMethodResource
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaMethodListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaMethodListResource.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Paginated list of MFA methods."
+)
+@Serdeable
+data class AdminUserMfaMethodListResource(
+    @get:Schema(description = "Array of registered MFA method records.")
+    @get:JsonProperty("mfa_methods")
+    val mfaMethods: List<AdminUserMfaMethodResource>,
+    @get:Schema(description = "Current page number.")
+    val page: Int,
+    @get:Schema(description = "Number of results per page.")
+    val size: Int,
+    @get:Schema(description = "Total number of registered MFA methods for this user.")
+    val total: Int
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaMethodResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaMethodResource.kt
@@ -1,0 +1,22 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.*
+
+@Schema(
+    description = "Information about a registered MFA method."
+)
+@Serdeable
+data class AdminUserMfaMethodResource(
+    @get:Schema(description = "Unique identifier of the MFA registration.")
+    @get:JsonProperty("mfa_id")
+    val mfaId: UUID,
+    @get:Schema(description = "Type of MFA method.", allowableValues = ["totp"])
+    val type: String,
+    @get:Schema(description = "Date and time at which the MFA method was registered.")
+    @get:JsonProperty("registered_at")
+    val registeredAt: LocalDateTime
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaRevokeResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaRevokeResource.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    description = "Result of an MFA method revocation."
+)
+@Serdeable
+data class AdminUserMfaRevokeResource(
+    @get:Schema(description = "Unique identifier of the user.")
+    @get:JsonProperty("user_id")
+    val userId: UUID,
+    @get:Schema(description = "Unique identifier of the revoked MFA registration.")
+    @get:JsonProperty("mfa_id")
+    val mfaId: UUID,
+    @get:Schema(description = "Whether the MFA method was successfully revoked.")
+    val revoked: Boolean
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/mfa/TotpManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/mfa/TotpManager.kt
@@ -104,6 +104,22 @@ class TotpManager(
     }
 
     /**
+     * Returns the confirmed TOTP enrollment with the given [enrollmentId], or null if not found or not confirmed.
+     */
+    suspend fun findConfirmedEnrollmentOrNull(enrollmentId: UUID): TotpEnrollment? {
+        return totpEnrollmentRepository.findById(enrollmentId)
+            ?.takeIf { it.confirmedDate != null }
+            ?.let(totpEnrollmentMapper::toTotpEnrollment)
+    }
+
+    /**
+     * Deletes the given TOTP [enrollment].
+     */
+    suspend fun deleteEnrollment(enrollment: TotpEnrollment) {
+        totpEnrollmentRepository.deleteById(enrollment.id)
+    }
+
+    /**
      * Builds a standard otpauth:// URI ready for QR code generation.
      *
      * The [issuer] is the name of the service (e.g. the configured application name or domain).

--- a/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
@@ -44,6 +44,15 @@
     ]
   },
   {
+    "name": "com.sympauthy.api.mapper.admin.AdminUserMfaMethodResourceMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sympauthy.api.mapper.admin.AdminConsentResourceMapperImpl",
     "methods": [
       {

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaControllerTest.kt
@@ -1,0 +1,169 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.exception.LocalizedHttpException
+import com.sympauthy.api.mapper.admin.AdminUserMfaMethodResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserMfaMethodResource
+import com.sympauthy.business.manager.mfa.TotpManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.mfa.TotpEnrollment
+import com.sympauthy.business.model.user.User
+import io.micronaut.http.HttpStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class AdminUserMfaControllerTest {
+
+    @MockK
+    lateinit var userManager: UserManager
+
+    @MockK
+    lateinit var totpManager: TotpManager
+
+    @MockK
+    lateinit var mfaMapper: AdminUserMfaMethodResourceMapper
+
+    @InjectMockKs
+    lateinit var controller: AdminUserMfaController
+
+    private val userId: UUID = UUID.randomUUID()
+    private val mfaId: UUID = UUID.randomUUID()
+    private val confirmedDate: LocalDateTime = LocalDateTime.of(2026, 2, 10, 8, 45, 0)
+
+    private fun mockEnrollment(
+        id: UUID = mfaId,
+        enrollmentUserId: UUID = userId
+    ): TotpEnrollment = TotpEnrollment(
+        id = id,
+        userId = enrollmentUserId,
+        secret = ByteArray(20),
+        creationDate = confirmedDate,
+        confirmedDate = confirmedDate
+    )
+
+    private fun mockResource(id: UUID = mfaId): AdminUserMfaMethodResource = AdminUserMfaMethodResource(
+        mfaId = id,
+        type = "totp",
+        registeredAt = confirmedDate
+    )
+
+    @Test
+    fun `listMfaMethods - Returns paginated list of confirmed enrollments`() = runTest {
+        val enrollment = mockEnrollment()
+        val resource = mockResource()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { totpManager.findConfirmedEnrollments(userId) } returns listOf(enrollment)
+        every { mfaMapper.toResource(enrollment) } returns resource
+
+        val result = controller.listMfaMethods(userId, null, null)
+
+        assertEquals(1, result.mfaMethods.size)
+        assertEquals(mfaId, result.mfaMethods[0].mfaId)
+        assertEquals("totp", result.mfaMethods[0].type)
+        assertEquals(0, result.page)
+        assertEquals(20, result.size)
+        assertEquals(1, result.total)
+    }
+
+    @Test
+    fun `listMfaMethods - Returns 404 when user not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.listMfaMethods(userId, null, null)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `listMfaMethods - Returns empty list when user has no MFA`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { totpManager.findConfirmedEnrollments(userId) } returns emptyList()
+
+        val result = controller.listMfaMethods(userId, null, null)
+
+        assertTrue(result.mfaMethods.isEmpty())
+        assertEquals(0, result.total)
+    }
+
+    @Test
+    fun `listMfaMethods - Respects pagination parameters`() = runTest {
+        val enrollments = (0 until 3).map { mockEnrollment(id = UUID.randomUUID()) }
+        val resources = enrollments.map { mockResource(id = it.id) }
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { totpManager.findConfirmedEnrollments(userId) } returns enrollments
+        enrollments.forEachIndexed { i, e -> every { mfaMapper.toResource(e) } returns resources[i] }
+
+        val result = controller.listMfaMethods(userId, 1, 2)
+
+        assertEquals(1, result.mfaMethods.size)
+        assertEquals(1, result.page)
+        assertEquals(2, result.size)
+        assertEquals(3, result.total)
+    }
+
+    @Test
+    fun `revokeMfaMethod - Deletes enrollment and returns revoked response`() = runTest {
+        val enrollment = mockEnrollment()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { totpManager.findConfirmedEnrollmentOrNull(mfaId) } returns enrollment
+        coEvery { totpManager.deleteEnrollment(enrollment) } returns Unit
+
+        val result = controller.revokeMfaMethod(userId, mfaId)
+
+        assertEquals(userId, result.userId)
+        assertEquals(mfaId, result.mfaId)
+        assertTrue(result.revoked)
+        coVerify { totpManager.deleteEnrollment(enrollment) }
+    }
+
+    @Test
+    fun `revokeMfaMethod - Returns 404 when user not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.revokeMfaMethod(userId, mfaId)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `revokeMfaMethod - Returns 404 when MFA method not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { totpManager.findConfirmedEnrollmentOrNull(mfaId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.revokeMfaMethod(userId, mfaId)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `revokeMfaMethod - Returns 404 when enrollment belongs to different user`() = runTest {
+        val otherUserId = UUID.randomUUID()
+        val enrollment = mockEnrollment(enrollmentUserId = otherUserId)
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { totpManager.findConfirmedEnrollmentOrNull(mfaId) } returns enrollment
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.revokeMfaMethod(userId, mfaId)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/mfa/TotpManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/mfa/TotpManagerTest.kt
@@ -237,6 +237,59 @@ class TotpManagerTest {
         assertFalse(manager.isCodeValidForUser(userId, invalidCode))
     }
 
+    // --- findConfirmedEnrollmentOrNull ---
+
+    @Test
+    fun `findConfirmedEnrollmentOrNull - Returns enrollment when found and confirmed`() = runTest {
+        val enrollmentId = UUID.randomUUID()
+        val entity = mockk<TotpEnrollmentEntity> {
+            every { confirmedDate } returns java.time.LocalDateTime.now()
+        }
+        val enrollment = mockk<TotpEnrollment>()
+
+        coEvery { totpEnrollmentRepository.findById(enrollmentId) } returns entity
+        every { totpEnrollmentMapper.toTotpEnrollment(entity) } returns enrollment
+
+        val result = manager.findConfirmedEnrollmentOrNull(enrollmentId)
+
+        assertSame(enrollment, result)
+    }
+
+    @Test
+    fun `findConfirmedEnrollmentOrNull - Returns null when not found`() = runTest {
+        val enrollmentId = UUID.randomUUID()
+
+        coEvery { totpEnrollmentRepository.findById(enrollmentId) } returns null
+
+        assertNull(manager.findConfirmedEnrollmentOrNull(enrollmentId))
+    }
+
+    @Test
+    fun `findConfirmedEnrollmentOrNull - Returns null when found but not confirmed`() = runTest {
+        val enrollmentId = UUID.randomUUID()
+        val entity = mockk<TotpEnrollmentEntity> {
+            every { confirmedDate } returns null
+        }
+
+        coEvery { totpEnrollmentRepository.findById(enrollmentId) } returns entity
+
+        assertNull(manager.findConfirmedEnrollmentOrNull(enrollmentId))
+    }
+
+    // --- deleteEnrollment ---
+
+    @Test
+    fun `deleteEnrollment - Deletes enrollment by id`() = runTest {
+        val enrollmentId = UUID.randomUUID()
+        val enrollment = mockk<TotpEnrollment> { every { id } returns enrollmentId }
+
+        coEvery { totpEnrollmentRepository.deleteById(enrollmentId) } returns 1
+
+        manager.deleteEnrollment(enrollment)
+
+        coVerify { totpEnrollmentRepository.deleteById(enrollmentId) }
+    }
+
     // --- findConfirmedEnrollments ---
 
     @Test


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/admin/users/{userId}/mfa` endpoint to list registered MFA methods for a user (paginated, scoped to `admin:users:read`)
- Add `DELETE /api/v1/admin/users/{userId}/mfa/{mfaId}` endpoint to revoke a specific MFA method (scoped to `admin:users:write`, with ownership check)
- Add `findConfirmedEnrollmentOrNull` and `deleteEnrollment` methods to `TotpManager`
- Register `AdminUserMfaMethodResourceMapper` in `AdminApiMapperFactory` and `reflect-config.json` for native image support

Closes #154

## Test plan

- [x] Unit tests for `TotpManager.findConfirmedEnrollmentOrNull` (found & confirmed, not found, unconfirmed)
- [x] Unit test for `TotpManager.deleteEnrollment`
- [x] Unit tests for `AdminUserMfaController.listMfaMethods` (paginated list, 404 on unknown user, empty list, pagination params)
- [x] Unit tests for `AdminUserMfaController.revokeMfaMethod` (success, 404 on unknown user, 404 on unknown MFA, 404 on user mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)