### PR TITLE
Move auto-consent to newAuthorizeAttempt

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizeAttemptManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizeAttemptManager.kt
@@ -10,6 +10,7 @@ import com.sympauthy.business.model.client.Client
 import com.sympauthy.business.model.flow.AuthorizationFlow
 import com.sympauthy.business.model.oauth2.*
 import com.sympauthy.business.model.oauth2.CodeChallengeMethod
+import com.sympauthy.business.model.oauth2.ConsentedBy
 import com.sympauthy.business.model.oauth2.OAuth2ErrorCode.INVALID_REQUEST
 import com.sympauthy.business.model.user.User
 import com.sympauthy.data.model.AuthorizeAttemptEntity
@@ -58,6 +59,11 @@ class AuthorizeAttemptManager(
     ): AuthorizeAttempt {
         val now = LocalDateTime.now()
 
+        // When no error, auto-consent consentable scopes at creation time
+        val consentableScopes = if (error == null) {
+            (scopes ?: emptyList()).filterIsInstance<ConsentableUserScope>()
+        } else null
+
         val entity = AuthorizeAttemptEntity(
             clientId = client?.id,
             authorizationFlowId = authorizationFlow?.id,
@@ -70,6 +76,10 @@ class AuthorizeAttemptManager(
             errorDetailsId = error?.detailsId,
             errorDescriptionId = error?.descriptionId,
             errorValues = error?.values,
+
+            consentedScopes = consentableScopes?.map(Scope::scope)?.toTypedArray(),
+            consentedAt = consentableScopes?.let { now },
+            consentedBy = consentableScopes?.let { ConsentedBy.AUTO.name },
 
             codeChallenge = codeChallenge,
             codeChallengeMethod = codeChallengeMethod?.value,

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManager.kt
@@ -11,9 +11,6 @@ import com.sympauthy.business.model.flow.WebAuthorizationFlow
 import com.sympauthy.business.model.oauth2.AuthorizeAttempt
 import com.sympauthy.business.model.oauth2.CompletedAuthorizeAttempt
 import com.sympauthy.business.model.oauth2.OnGoingAuthorizeAttempt
-import com.sympauthy.business.manager.ScopeManager
-import com.sympauthy.business.model.oauth2.ConsentableUserScope
-import com.sympauthy.business.model.oauth2.ConsentedBy
 import com.sympauthy.business.model.oauth2.GrantedBy
 import com.sympauthy.business.model.user.CollectedClaim
 import com.sympauthy.config.model.AuthorizationFlowsConfig
@@ -33,7 +30,6 @@ import jakarta.inject.Singleton
 class AuthorizationFlowManager(
     @Inject private val authorizeAttemptManager: AuthorizeAttemptManager,
     @Inject private val scopeGrantingManager: ScopeGrantingManager,
-    @Inject private val scopeManager: ScopeManager,
     @Inject private val consentManager: ConsentManager,
     @Inject private val authorizationFlowsConfig: AuthorizationFlowsConfig,
     @Inject private val uncheckedUrlsConfig: UrlsConfig,
@@ -107,12 +103,6 @@ class AuthorizationFlowManager(
         var modifiedAuthorizedAttempt = authorizeAttempt
         // FIXME: Verify that the attempt is completable (has a user ?, more ?)
 
-        // Resolve requested scope strings to typed Scope objects
-        val requestedScopes = authorizeAttempt.requestedScopes.mapNotNull { scopeManager.find(it) }
-
-        // Separate consentable scopes (auto-consented for now) from grantable scopes
-        val consentedScopes = requestedScopes.filterIsInstance<ConsentableUserScope>()
-
         // Grant only grantable scopes through the granting pipeline
         val grantScopesResult = scopeGrantingManager.grantScopes(
             authorizeAttempt = authorizeAttempt,
@@ -122,12 +112,6 @@ class AuthorizationFlowManager(
             authorizeAttempt = modifiedAuthorizedAttempt,
             grantedScopes = grantScopesResult.grantedScopes,
             grantedBy = if (grantScopesResult.allAutoGranted) GrantedBy.AUTO else GrantedBy.RULE
-        )
-        // Auto-consent all requested consentable scopes (no consent screen yet)
-        modifiedAuthorizedAttempt = authorizeAttemptManager.setConsentedScopes(
-            authorizeAttempt = modifiedAuthorizedAttempt,
-            consentedScopes = consentedScopes,
-            consentedBy = ConsentedBy.AUTO
         )
 
         val hasAnyScope = !modifiedAuthorizedAttempt.grantedScopes.isNullOrEmpty() ||

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManagerTest.kt
@@ -1,7 +1,6 @@
 package com.sympauthy.business.manager.flow
 
 import com.sympauthy.business.exception.BusinessException
-import com.sympauthy.business.manager.ScopeManager
 import com.sympauthy.business.manager.auth.AuthorizeAttemptManager
 import com.sympauthy.business.manager.auth.GrantScopesResult
 import com.sympauthy.business.manager.auth.ScopeGrantingManager
@@ -40,9 +39,6 @@ class AuthorizationFlowManagerTest {
 
     @MockK
     lateinit var scopeGrantingManager: ScopeGrantingManager
-
-    @MockK
-    lateinit var scopeManager: ScopeManager
 
     @MockK
     lateinit var consentManager: ConsentManager
@@ -86,9 +82,8 @@ class AuthorizationFlowManagerTest {
         val grantedScopes = listOf("read")
         val consentedScopes = emptyList<String>()
         val grantedScopeObjects = grantedScopes.map { mockkScope(it) }
-        val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId)
-        val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = grantedScopes)
-        val afterConsented = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = grantedScopes, consentedScopes = consentedScopes)
+        val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId, consentedScopes = consentedScopes)
+        val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = grantedScopes, consentedScopes = consentedScopes)
         val completedAttempt = mockk<CompletedAuthorizeAttempt> {
             every { this@mockk.userId } returns userId
             every { this@mockk.clientId } returns clientId
@@ -97,7 +92,6 @@ class AuthorizationFlowManagerTest {
         val collectedClaims = emptyList<CollectedClaim>()
 
         every { uncheckedFeaturesConfig.allowAccessToClientWithoutScope } returns false
-        coEvery { scopeManager.find(any()) } returns null
 
         val grantScopesResult = GrantScopesResult(
             requestedScopes = grantedScopeObjects,
@@ -112,10 +106,7 @@ class AuthorizationFlowManagerTest {
         coEvery {
             authorizeAttemptManager.setGrantedScopes(onGoingAttempt, grantedScopeObjects, any())
         } returns afterGranted
-        coEvery {
-            authorizeAttemptManager.setConsentedScopes(afterGranted, emptyList(), any())
-        } returns afterConsented
-        coEvery { authorizeAttemptManager.markAsComplete(afterConsented) } returns completedAttempt
+        coEvery { authorizeAttemptManager.markAsComplete(afterGranted) } returns completedAttempt
         coEvery { consentManager.saveGrantedConsent(userId, clientId, consentedScopes) } returns mockk()
 
         val result = manager.completeAuthorization(onGoingAttempt, collectedClaims)
@@ -129,9 +120,8 @@ class AuthorizationFlowManagerTest {
         runTest {
             val userId = UUID.randomUUID()
             val clientId = "client-id"
-            val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId)
-            val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = emptyList())
-            val afterConsented = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = emptyList(), consentedScopes = emptyList())
+            val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId, consentedScopes = emptyList())
+            val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = emptyList(), consentedScopes = emptyList())
             val completedAttempt = mockk<CompletedAuthorizeAttempt> {
                 every { this@mockk.userId } returns userId
                 every { this@mockk.clientId } returns clientId
@@ -140,7 +130,6 @@ class AuthorizationFlowManagerTest {
             val collectedClaims = emptyList<CollectedClaim>()
 
             every { uncheckedFeaturesConfig.allowAccessToClientWithoutScope } returns true
-            coEvery { scopeManager.find(any()) } returns null
 
             val grantScopesResult = GrantScopesResult(
                 requestedScopes = emptyList(),
@@ -155,10 +144,7 @@ class AuthorizationFlowManagerTest {
             coEvery {
                 authorizeAttemptManager.setGrantedScopes(onGoingAttempt, emptyList(), any())
             } returns afterGranted
-            coEvery {
-                authorizeAttemptManager.setConsentedScopes(afterGranted, emptyList(), any())
-            } returns afterConsented
-            coEvery { authorizeAttemptManager.markAsComplete(afterConsented) } returns completedAttempt
+            coEvery { authorizeAttemptManager.markAsComplete(afterGranted) } returns completedAttempt
             coEvery { consentManager.saveGrantedConsent(userId, clientId, emptyList()) } returns mockk()
 
             val result = manager.completeAuthorization(onGoingAttempt, collectedClaims)
@@ -171,14 +157,12 @@ class AuthorizationFlowManagerTest {
     fun `completeAuthorization - Marks as failed when no scopes granted and allowAccessToClientWithoutScope is false`() =
         runTest {
             val userId = UUID.randomUUID()
-            val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId)
-            val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = emptyList())
-            val afterConsented = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = emptyList(), consentedScopes = emptyList())
+            val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId, consentedScopes = emptyList())
+            val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = emptyList(), consentedScopes = emptyList())
             val failedAttempt = mockk<FailedAuthorizeAttempt>()
             val collectedClaims = emptyList<CollectedClaim>()
 
             every { uncheckedFeaturesConfig.allowAccessToClientWithoutScope } returns false
-            coEvery { scopeManager.find(any()) } returns null
 
             val grantScopesResult = GrantScopesResult(
                 requestedScopes = emptyList(),
@@ -193,9 +177,6 @@ class AuthorizationFlowManagerTest {
             coEvery {
                 authorizeAttemptManager.setGrantedScopes(onGoingAttempt, emptyList(), any())
             } returns afterGranted
-            coEvery {
-                authorizeAttemptManager.setConsentedScopes(afterGranted, emptyList(), any())
-            } returns afterConsented
             coEvery {
                 authorizeAttemptManager.markAsFailedIfNotRecoverable(onGoingAttempt, any())
             } returns failedAttempt
@@ -217,17 +198,14 @@ class AuthorizationFlowManagerTest {
         val clientId = "client-id"
         val grantedScopes = listOf("read")
         val grantedScopeObjects = grantedScopes.map { mockkScope(it) }
-        val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId)
-        val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = listOf("read"))
-        val afterConsented = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = listOf("read"), consentedScopes = emptyList())
+        val onGoingAttempt = createOnGoingAuthorizeAttempt(userId = userId, consentedScopes = emptyList())
+        val afterGranted = createOnGoingAuthorizeAttempt(userId = userId, grantedScopes = listOf("read"), consentedScopes = emptyList())
         val completedAttempt = mockk<CompletedAuthorizeAttempt> {
             every { this@mockk.userId } returns userId
             every { this@mockk.clientId } returns clientId
             every { this@mockk.consentedScopes } returns emptyList()
         }
         val collectedClaims = listOf(mockk<CollectedClaim>())
-
-        coEvery { scopeManager.find(any()) } returns null
 
         val grantScopesResult = GrantScopesResult(
             requestedScopes = emptyList(),
@@ -242,10 +220,7 @@ class AuthorizationFlowManagerTest {
         coEvery {
             authorizeAttemptManager.setGrantedScopes(onGoingAttempt, grantedScopeObjects, any())
         } returns afterGranted
-        coEvery {
-            authorizeAttemptManager.setConsentedScopes(afterGranted, emptyList(), any())
-        } returns afterConsented
-        coEvery { authorizeAttemptManager.markAsComplete(afterConsented) } returns completedAttempt
+        coEvery { authorizeAttemptManager.markAsComplete(afterGranted) } returns completedAttempt
         coEvery { consentManager.saveGrantedConsent(userId, clientId, emptyList()) } returns mockk()
 
         val result = manager.completeAuthorization(onGoingAttempt, collectedClaims)
@@ -270,6 +245,8 @@ class AuthorizationFlowManagerTest {
             nonce = "nonce",
             userId = userId,
             consentedScopes = consentedScopes,
+            consentedAt = consentedScopes?.let { LocalDateTime.now() },
+            consentedBy = consentedScopes?.let { ConsentedBy.AUTO },
             grantedScopes = grantedScopes,
         )
     }


### PR DESCRIPTION
## Summary
- Move auto-consent of consentable scopes from `completeAuthorization` to `newAuthorizeAttempt`, setting consent fields directly on the entity at creation time
- Remove `ScopeManager` dependency from `AuthorizationFlowManager` since scope resolution for consent is no longer needed at completion
- This enables a future manual consent screen to modify consented scopes before flow completion

## Test plan
- [x] `./gradlew compileKotlin` — compiles successfully
- [x] `./gradlew test --tests com.sympauthy.business.manager.flow.AuthorizationFlowManagerTest` — all 6 tests pass
- [x] `./gradlew test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)