### PR TITLE
Implement Admin API provider link endpoints

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
@@ -1,0 +1,128 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.resource.admin.AdminUserProviderListResource
+import com.sympauthy.api.resource.admin.AdminUserProviderResource
+import com.sympauthy.api.resource.admin.AdminUserProviderUnlinkResource
+import com.sympauthy.api.util.orNotFound
+import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.security.SecurityRule.ADMIN_USERS_READ
+import com.sympauthy.security.SecurityRule.ADMIN_USERS_WRITE
+import io.micronaut.http.annotation.*
+import io.micronaut.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+import java.util.*
+
+@Controller("/api/v1/admin/users/{userId}/providers")
+class AdminUserProviderController(
+    @Inject private val userManager: UserManager,
+    @Inject private val providerClaimsManager: ProviderClaimsManager
+) {
+
+    @Operation(
+        description = "Retrieve a paginated list of external identity providers linked to a user.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "userId",
+                description = "Unique identifier of the user.",
+                schema = Schema(type = "string", format = "uuid")
+            ),
+            Parameter(
+                name = "page",
+                description = "Zero-indexed page number.",
+                schema = Schema(type = "integer", defaultValue = "0")
+            ),
+            Parameter(
+                name = "size",
+                description = "Number of results per page.",
+                schema = Schema(type = "integer", defaultValue = "20")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Paginated list of linked providers."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:read."
+            ),
+            ApiResponse(responseCode = "404", description = "No user found with the given identifier.")
+        ]
+    )
+    @Get
+    @Secured(ADMIN_USERS_READ)
+    suspend fun listProviders(
+        @PathVariable userId: UUID,
+        @QueryValue page: Int?,
+        @QueryValue size: Int?
+    ): AdminUserProviderListResource {
+        userManager.findByIdOrNull(userId).orNotFound()
+        val (page, size) = resolvePageParams(page, size)
+        val allProviders = providerClaimsManager.findByUserId(userId)
+        val paged = allProviders
+            .drop(page * size)
+            .take(size)
+            .map {
+                AdminUserProviderResource(
+                    providerId = it.providerId,
+                    subject = it.userInfo.subject,
+                    linkedAt = it.fetchDate
+                )
+            }
+        return AdminUserProviderListResource(
+            providers = paged,
+            page = page,
+            size = size,
+            total = allProviders.size
+        )
+    }
+
+    @Operation(
+        description = "Remove the link between a user and an external identity provider.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "userId",
+                description = "Unique identifier of the user.",
+                schema = Schema(type = "string", format = "uuid")
+            ),
+            Parameter(
+                name = "providerId",
+                description = "Identifier of the provider to unlink.",
+                schema = Schema(type = "string")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Provider unlinked successfully."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:write."
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "No user found with the given identifier, or no provider link found."
+            )
+        ]
+    )
+    @Delete("/{providerId}")
+    @Secured(ADMIN_USERS_WRITE)
+    suspend fun unlinkProvider(
+        @PathVariable userId: UUID,
+        @PathVariable providerId: String
+    ): AdminUserProviderUnlinkResource {
+        userManager.findByIdOrNull(userId).orNotFound()
+        providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, providerId).orNotFound()
+        providerClaimsManager.deleteProviderLink(userId, providerId)
+        return AdminUserProviderUnlinkResource(
+            userId = userId,
+            providerId = providerId,
+            unlinked = true
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderListResource.kt
@@ -1,0 +1,19 @@
+package com.sympauthy.api.resource.admin
+
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Paginated list of providers linked to a user."
+)
+@Serdeable
+data class AdminUserProviderListResource(
+    @get:Schema(description = "Array of linked provider records.")
+    val providers: List<AdminUserProviderResource>,
+    @get:Schema(description = "Current page number.")
+    val page: Int,
+    @get:Schema(description = "Number of results per page.")
+    val size: Int,
+    @get:Schema(description = "Total number of providers linked to this user.")
+    val total: Int
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderResource.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(
+    description = "Information about a provider linked to a user."
+)
+@Serdeable
+data class AdminUserProviderResource(
+    @get:Schema(description = "Identifier of the provider.")
+    @get:JsonProperty("provider_id")
+    val providerId: String,
+    @get:Schema(description = "The user's subject identifier at this provider.")
+    val subject: String,
+    @get:Schema(description = "The date and time (in UTC timezone) at which the provider was linked.")
+    @get:JsonProperty("linked_at")
+    val linkedAt: LocalDateTime
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderUnlinkResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderUnlinkResource.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    description = "Result of a provider unlink operation."
+)
+@Serdeable
+data class AdminUserProviderUnlinkResource(
+    @get:Schema(description = "Unique identifier of the user.")
+    @get:JsonProperty("user_id")
+    val userId: UUID,
+    @get:Schema(description = "Identifier of the unlinked provider.")
+    @get:JsonProperty("provider_id")
+    val providerId: String,
+    @get:Schema(description = "Whether the provider was successfully unlinked.")
+    val unlinked: Boolean
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/provider/ProviderClaimsManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/provider/ProviderClaimsManager.kt
@@ -35,6 +35,15 @@ class ProviderClaimsManager(
             .map(userInfoMapper::toProviderUserInfo)
     }
 
+    suspend fun findByUserIdAndProviderIdOrNull(userId: UUID, providerId: String): ProviderUserInfo? {
+        return userInfoRepository.findByProviderIdAndUserId(providerId, userId)
+            ?.let(userInfoMapper::toProviderUserInfo)
+    }
+
+    suspend fun deleteProviderLink(userId: UUID, providerId: String): Int {
+        return userInfoRepository.deleteByProviderIdAndUserId(providerId, userId)
+    }
+
     suspend fun fetchUserInfo(
         provider: EnabledProvider,
         credentials: ProviderCredentials

--- a/server/src/main/kotlin/com/sympauthy/data/repository/ProviderUserInfoRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/repository/ProviderUserInfoRepository.kt
@@ -12,4 +12,8 @@ interface ProviderUserInfoRepository : CoroutineCrudRepository<ProviderUserInfoE
     suspend fun findByUserId(userId: UUID): List<ProviderUserInfoEntity>
 
     suspend fun findByUserIdInList(userId: List<UUID>): List<ProviderUserInfoEntity>
+
+    suspend fun findByProviderIdAndUserId(providerId: String, userId: UUID): ProviderUserInfoEntity?
+
+    suspend fun deleteByProviderIdAndUserId(providerId: String, userId: UUID): Int
 }

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderControllerTest.kt
@@ -1,0 +1,145 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.exception.LocalizedHttpException
+import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.provider.ProviderUserInfo
+import com.sympauthy.business.model.user.RawProviderClaims
+import com.sympauthy.business.model.user.User
+import io.micronaut.http.HttpStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class AdminUserProviderControllerTest {
+
+    @MockK
+    lateinit var userManager: UserManager
+
+    @MockK
+    lateinit var providerClaimsManager: ProviderClaimsManager
+
+    @InjectMockKs
+    lateinit var controller: AdminUserProviderController
+
+    private val userId: UUID = UUID.randomUUID()
+    private val linkedAt: LocalDateTime = LocalDateTime.of(2026, 1, 15, 14, 30, 0)
+
+    private fun mockProviderUserInfo(
+        providerId: String = "discord",
+        subject: String = "123456789012345678"
+    ): ProviderUserInfo = ProviderUserInfo(
+        providerId = providerId,
+        userId = userId,
+        fetchDate = linkedAt,
+        changeDate = linkedAt,
+        userInfo = RawProviderClaims(subject = subject)
+    )
+
+    @Test
+    fun `listProviders - Returns paginated list of linked providers`() = runTest {
+        val providerInfo = mockProviderUserInfo()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { providerClaimsManager.findByUserId(userId) } returns listOf(providerInfo)
+
+        val result = controller.listProviders(userId, null, null)
+
+        assertEquals(1, result.providers.size)
+        assertEquals("discord", result.providers[0].providerId)
+        assertEquals("123456789012345678", result.providers[0].subject)
+        assertEquals(linkedAt, result.providers[0].linkedAt)
+        assertEquals(0, result.page)
+        assertEquals(20, result.size)
+        assertEquals(1, result.total)
+    }
+
+    @Test
+    fun `listProviders - Returns 404 when user not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.listProviders(userId, null, null)
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `listProviders - Returns empty list when user has no providers`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { providerClaimsManager.findByUserId(userId) } returns emptyList()
+
+        val result = controller.listProviders(userId, null, null)
+
+        assertTrue(result.providers.isEmpty())
+        assertEquals(0, result.total)
+    }
+
+    @Test
+    fun `listProviders - Respects pagination parameters`() = runTest {
+        val providers = listOf(
+            mockProviderUserInfo(providerId = "discord"),
+            mockProviderUserInfo(providerId = "google", subject = "109876543210"),
+            mockProviderUserInfo(providerId = "github", subject = "42")
+        )
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { providerClaimsManager.findByUserId(userId) } returns providers
+
+        val result = controller.listProviders(userId, 1, 2)
+
+        assertEquals(1, result.providers.size)
+        assertEquals("github", result.providers[0].providerId)
+        assertEquals(1, result.page)
+        assertEquals(2, result.size)
+        assertEquals(3, result.total)
+    }
+
+    @Test
+    fun `unlinkProvider - Deletes provider link and returns unlinked response`() = runTest {
+        val providerInfo = mockProviderUserInfo()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, "discord") } returns providerInfo
+        coEvery { providerClaimsManager.deleteProviderLink(userId, "discord") } returns 1
+
+        val result = controller.unlinkProvider(userId, "discord")
+
+        assertEquals(userId, result.userId)
+        assertEquals("discord", result.providerId)
+        assertTrue(result.unlinked)
+        coVerify { providerClaimsManager.deleteProviderLink(userId, "discord") }
+    }
+
+    @Test
+    fun `unlinkProvider - Returns 404 when user not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.unlinkProvider(userId, "discord")
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `unlinkProvider - Returns 404 when provider link not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, "discord") } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.unlinkProvider(userId, "discord")
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/admin/users/{userId}/providers` to list paginated provider links for a user
- Add `DELETE /api/v1/admin/users/{userId}/providers/{providerId}` to unlink a provider from a user
- Secured with `admin:users:read` and `admin:users:write` scopes respectively

Closes #166

## Test plan
- [x] Unit tests for both endpoints (7 tests covering pagination, 404 cases, successful operations)
- [x] Manual testing with a running instance and linked providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)