### PR TITLE
feat: Delegate authorization to external server via webhook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ allprojects {
         // Test dependencies
         set("junitJupiterVersion", "6.0.3")
         set("mockkVersion", "1.14.9")
+        set("mockWebServerVersion", "4.12.0")
     }
 
     repositories {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:${project.extra["junitJupiterVersion"]}")
     testImplementation("io.mockk:mockk:${project.extra["mockkVersion"]}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${project.extra["kotlinCoroutinesVersion"]}")
+    testImplementation("com.squareup.okhttp3:mockwebserver:${project.extra["mockWebServerVersion"]}")
     testImplementation(kotlin("test"))
 }
 

--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
@@ -12,6 +12,7 @@ import com.sympauthy.business.model.oauth2.Scope
 import com.sympauthy.business.model.user.CollectedClaim
 import com.sympauthy.client.authorization.webhook.AuthorizationWebhookClient
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
 import com.sympauthy.util.loggerForClass
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -63,52 +64,60 @@ class AuthorizationWebhookUserScopeGrantingManager(
             claims = collectedClaims.associate { it.claim.id to it.value }
         )
 
-        return try {
-            val response = authorizationWebhookClient.callWebhook(authorizationWebhook, request)
+        return when (val result = authorizationWebhookClient.callWebhook(authorizationWebhook, request)) {
+            is AuthorizationWebhookResult.Success -> {
+                val response = result.response
+                val granted = mutableListOf<Scope>()
+                val declined = mutableListOf<Scope>()
 
-            val granted = mutableListOf<Scope>()
-            val declined = mutableListOf<Scope>()
-
-            // Process requested scopes
-            requestedScopes.forEach { scope ->
-                when (response.scopes[scope.scope]) {
-                    GRANT -> granted.add(scope)
-                    else -> declined.add(scope)
-                }
-            }
-
-            // Process additional scopes granted by the webhook beyond the requested ones
-            val requestedScopeIds = requestedScopes.map { it.scope }.toSet()
-            val allowedScopeIds = client.allowedScopes?.map { it.scope }?.toSet()
-            response.scopes
-                .filter { (scopeId, decision) -> decision == GRANT && scopeId !in requestedScopeIds }
-                .forEach { (scopeId, _) ->
-                    val scope = scopeManager.find(scopeId)
-                    if (scope is GrantableUserScope && (allowedScopeIds == null || scopeId in allowedScopeIds)) {
-                        granted.add(scope)
+                // Process requested scopes
+                requestedScopes.forEach { scope ->
+                    when (response.scopes[scope.scope]) {
+                        GRANT -> granted.add(scope)
+                        else -> declined.add(scope)
                     }
                 }
 
-            logger.debug(
-                "Authorization webhook for client {} granted {} scope(s) and declined {} scope(s).",
-                client.id, granted.size, declined.size
-            )
+                // Process additional scopes granted by the webhook beyond the requested ones
+                val requestedScopeIds = requestedScopes.map { it.scope }.toSet()
+                val allowedScopeIds = client.allowedScopes?.map { it.scope }?.toSet()
+                response.scopes
+                    .filter { (scopeId, decision) -> decision == GRANT && scopeId !in requestedScopeIds }
+                    .forEach { (scopeId, _) ->
+                        val scope = scopeManager.find(scopeId)
+                        if (scope is GrantableUserScope && (allowedScopeIds == null || scopeId in allowedScopeIds)) {
+                            granted.add(scope)
+                        }
+                    }
 
-            ScopeGrantingMethodResult(source = GrantedBy.WEBHOOK, grantedScopes = granted, declinedScopes = declined)
-        } catch (e: Exception) {
-            logger.warn(
-                "Authorization webhook call to {} for client {} failed: {}",
-                authorizationWebhook.url, client.id, e.message
-            )
-            when (authorizationWebhook.onFailure) {
-                AuthorizationWebhookOnFailure.DENY_ALL -> ScopeGrantingMethodResult(
+                logger.debug(
+                    "Authorization webhook for client {} granted {} scope(s) and declined {} scope(s).",
+                    client.id, granted.size, declined.size
+                )
+
+                ScopeGrantingMethodResult(
                     source = GrantedBy.WEBHOOK,
-                    grantedScopes = emptyList(),
-                    declinedScopes = requestedScopes
+                    grantedScopes = granted,
+                    declinedScopes = declined
                 )
-                AuthorizationWebhookOnFailure.FALLBACK_TO_RULES -> ScopeGrantingMethodResult(
-                    source = GrantedBy.WEBHOOK
+            }
+
+            is AuthorizationWebhookResult.Failure -> {
+                logger.warn(
+                    "Authorization webhook call to {} for client {} failed: {}",
+                    authorizationWebhook.url, client.id, result.message
                 )
+                when (authorizationWebhook.onFailure) {
+                    AuthorizationWebhookOnFailure.DENY_ALL -> ScopeGrantingMethodResult(
+                        source = GrantedBy.WEBHOOK,
+                        grantedScopes = emptyList(),
+                        declinedScopes = requestedScopes
+                    )
+
+                    AuthorizationWebhookOnFailure.FALLBACK_TO_RULES -> ScopeGrantingMethodResult(
+                        source = GrantedBy.WEBHOOK
+                    )
+                }
             }
         }
     }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
@@ -15,6 +15,7 @@ import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequ
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
 import com.sympauthy.util.loggerForClass
 import jakarta.inject.Inject
+import jakarta.inject.Provider
 import jakarta.inject.Singleton
 
 /**
@@ -32,7 +33,7 @@ import jakarta.inject.Singleton
  */
 @Singleton
 class AuthorizationWebhookUserScopeGrantingManager(
-    @Inject private val clientManager: ClientManager,
+    @Inject private val clientManagerProvider: Provider<ClientManager>,
     @Inject private val scopeManager: ScopeManager,
     @Inject private val authorizationWebhookClient: AuthorizationWebhookClient
 ) {
@@ -53,7 +54,7 @@ class AuthorizationWebhookUserScopeGrantingManager(
         collectedClaims: List<CollectedClaim>
     ): ScopeGrantingMethodResult {
         val onGoingAttempt = authorizeAttempt as OnGoingAuthorizeAttempt
-        val client = clientManager.findClientById(onGoingAttempt.clientId)
+        val client = clientManagerProvider.get().findClientById(onGoingAttempt.clientId)
         val authorizationWebhook = client.authorizationWebhook
             ?: return ScopeGrantingMethodResult()
 

--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
@@ -6,6 +6,7 @@ import com.sympauthy.business.model.ScopeGrantingMethodResult
 import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
 import com.sympauthy.business.model.oauth2.AuthorizeAttempt
 import com.sympauthy.business.model.oauth2.GrantableUserScope
+import com.sympauthy.business.model.oauth2.GrantedBy
 import com.sympauthy.business.model.oauth2.OnGoingAuthorizeAttempt
 import com.sympauthy.business.model.oauth2.Scope
 import com.sympauthy.business.model.user.CollectedClaim
@@ -93,7 +94,7 @@ class AuthorizationWebhookUserScopeGrantingManager(
                 client.id, granted.size, declined.size
             )
 
-            ScopeGrantingMethodResult(grantedScopes = granted, declinedScopes = declined)
+            ScopeGrantingMethodResult(source = GrantedBy.WEBHOOK, grantedScopes = granted, declinedScopes = declined)
         } catch (e: Exception) {
             logger.warn(
                 "Authorization webhook call to {} for client {} failed: {}",
@@ -101,10 +102,13 @@ class AuthorizationWebhookUserScopeGrantingManager(
             )
             when (authorizationWebhook.onFailure) {
                 AuthorizationWebhookOnFailure.DENY_ALL -> ScopeGrantingMethodResult(
+                    source = GrantedBy.WEBHOOK,
                     grantedScopes = emptyList(),
                     declinedScopes = requestedScopes
                 )
-                AuthorizationWebhookOnFailure.FALLBACK_TO_RULES -> ScopeGrantingMethodResult()
+                AuthorizationWebhookOnFailure.FALLBACK_TO_RULES -> ScopeGrantingMethodResult(
+                    source = GrantedBy.WEBHOOK
+                )
             }
         }
     }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManager.kt
@@ -1,0 +1,115 @@
+package com.sympauthy.business.manager.auth
+
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.ScopeManager
+import com.sympauthy.business.model.ScopeGrantingMethodResult
+import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
+import com.sympauthy.business.model.oauth2.AuthorizeAttempt
+import com.sympauthy.business.model.oauth2.GrantableUserScope
+import com.sympauthy.business.model.oauth2.OnGoingAuthorizeAttempt
+import com.sympauthy.business.model.oauth2.Scope
+import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.client.authorization.webhook.AuthorizationWebhookClient
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
+import com.sympauthy.util.loggerForClass
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * Scope granting method that delegates authorization decisions to an external HTTP server
+ * via a synchronous webhook call.
+ *
+ * When a client has an [AuthorizationWebhook][com.sympauthy.business.model.client.AuthorizationWebhook] configured,
+ * this manager calls the webhook endpoint with the user context and requested scopes,
+ * and maps the response to grant or deny decisions.
+ *
+ * This method is inserted before the rule-based granting in the
+ * [UserScopeGrantingManager] pipeline.
+ *
+ * @see [UserScopeGrantingManager.getScopeGrantingMethods]
+ */
+@Singleton
+class AuthorizationWebhookUserScopeGrantingManager(
+    @Inject private val clientManager: ClientManager,
+    @Inject private val scopeManager: ScopeManager,
+    @Inject private val authorizationWebhookClient: AuthorizationWebhookClient
+) {
+
+    private val logger = loggerForClass()
+
+    /**
+     * Call the authorization webhook configured on the client to determine which scopes to grant or deny.
+     *
+     * If no webhook is configured on the client, returns an empty result so scopes flow to the next method.
+     *
+     * The webhook may grant additional grantable scopes beyond those requested, as long as they are within
+     * the client's `allowed-scopes` configuration.
+     */
+    suspend fun applyAuthorizationWebhookScopeGranting(
+        authorizeAttempt: AuthorizeAttempt,
+        requestedScopes: List<Scope>,
+        collectedClaims: List<CollectedClaim>
+    ): ScopeGrantingMethodResult {
+        val onGoingAttempt = authorizeAttempt as OnGoingAuthorizeAttempt
+        val client = clientManager.findClientById(onGoingAttempt.clientId)
+        val authorizationWebhook = client.authorizationWebhook
+            ?: return ScopeGrantingMethodResult()
+
+        val request = AuthorizationWebhookRequest(
+            userId = onGoingAttempt.userId.toString(),
+            clientId = onGoingAttempt.clientId,
+            requestedScopes = requestedScopes.map { it.scope },
+            claims = collectedClaims.associate { it.claim.id to it.value }
+        )
+
+        return try {
+            val response = authorizationWebhookClient.callWebhook(authorizationWebhook, request)
+
+            val granted = mutableListOf<Scope>()
+            val declined = mutableListOf<Scope>()
+
+            // Process requested scopes
+            requestedScopes.forEach { scope ->
+                when (response.scopes[scope.scope]) {
+                    GRANT -> granted.add(scope)
+                    else -> declined.add(scope)
+                }
+            }
+
+            // Process additional scopes granted by the webhook beyond the requested ones
+            val requestedScopeIds = requestedScopes.map { it.scope }.toSet()
+            val allowedScopeIds = client.allowedScopes?.map { it.scope }?.toSet()
+            response.scopes
+                .filter { (scopeId, decision) -> decision == GRANT && scopeId !in requestedScopeIds }
+                .forEach { (scopeId, _) ->
+                    val scope = scopeManager.find(scopeId)
+                    if (scope is GrantableUserScope && (allowedScopeIds == null || scopeId in allowedScopeIds)) {
+                        granted.add(scope)
+                    }
+                }
+
+            logger.debug(
+                "Authorization webhook for client {} granted {} scope(s) and declined {} scope(s).",
+                client.id, granted.size, declined.size
+            )
+
+            ScopeGrantingMethodResult(grantedScopes = granted, declinedScopes = declined)
+        } catch (e: Exception) {
+            logger.warn(
+                "Authorization webhook call to {} for client {} failed: {}",
+                authorizationWebhook.url, client.id, e.message
+            )
+            when (authorizationWebhook.onFailure) {
+                AuthorizationWebhookOnFailure.DENY_ALL -> ScopeGrantingMethodResult(
+                    grantedScopes = emptyList(),
+                    declinedScopes = requestedScopes
+                )
+                AuthorizationWebhookOnFailure.FALLBACK_TO_RULES -> ScopeGrantingMethodResult()
+            }
+        }
+    }
+
+    companion object {
+        private const val GRANT = "grant"
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/UserScopeGrantingManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/UserScopeGrantingManager.kt
@@ -9,6 +9,7 @@ import com.sympauthy.business.model.oauth2.GrantableUserScope
 import com.sympauthy.business.model.oauth2.OnGoingAuthorizeAttempt
 import com.sympauthy.business.model.oauth2.Scope
 import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.business.model.oauth2.GrantedBy
 import com.sympauthy.config.model.FeaturesConfig
 import com.sympauthy.config.model.orThrow
 import jakarta.inject.Inject
@@ -31,6 +32,7 @@ import jakarta.inject.Singleton
 @Singleton
 class UserScopeGrantingManager(
     @Inject private val scopeManager: ScopeManager,
+    @Inject private val authorizationWebhookScopeGrantingManager: AuthorizationWebhookUserScopeGrantingManager,
     @Inject private val scopeGrantingRuleManager: ScopeGrantingRuleManager,
     @Inject private val featuresConfig: FeaturesConfig
 ) {
@@ -94,6 +96,7 @@ class UserScopeGrantingManager(
      */
     internal fun getScopeGrantingMethods(): List<suspend (authorizeAttempt: AuthorizeAttempt, requestedScopes: List<Scope>, collectedClaims: List<CollectedClaim>) -> ScopeGrantingMethodResult> {
         return listOf(
+            authorizationWebhookScopeGrantingManager::applyAuthorizationWebhookScopeGranting,
             scopeGrantingRuleManager::applyUserScopeGrantingRules,
             this::applyDefaultBehavior
         )
@@ -153,4 +156,19 @@ data class UserGrantScopesResult(
      */
     val allAutoGranted: Boolean
         get() = results.drop(1).all { it.grantedScopes.isEmpty() }
+
+    /**
+     * Determines how the grantable scopes were granted.
+     * - [GrantedBy.AUTO] if only auto-granted scopes were granted.
+     * - [GrantedBy.WEBHOOK] if the authorization webhook contributed granted scopes.
+     * - [GrantedBy.RULE] otherwise (rules or default behavior contributed).
+     *
+     * Results order: [auto-granted, webhook, rules, default].
+     */
+    val grantedBy: GrantedBy
+        get() = when {
+            allAutoGranted -> GrantedBy.AUTO
+            results.getOrNull(1)?.grantedScopes?.isNotEmpty() == true -> GrantedBy.WEBHOOK
+            else -> GrantedBy.RULE
+        }
 }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/auth/UserScopeGrantingManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/auth/UserScopeGrantingManager.kt
@@ -122,11 +122,13 @@ class UserScopeGrantingManager(
         val grantUnhandledScopes = featuresConfig.orThrow().grantUnhandledScopes
         return if (grantUnhandledScopes) {
             ScopeGrantingMethodResult(
+                source = GrantedBy.RULE,
                 grantedScopes = requestedScopes,
                 declinedScopes = emptyList()
             )
         } else {
             ScopeGrantingMethodResult(
+                source = GrantedBy.RULE,
                 grantedScopes = emptyList(),
                 declinedScopes = requestedScopes
             )
@@ -151,24 +153,24 @@ data class UserGrantScopesResult(
 
     /**
      * True if all granted scopes were auto-granted (built-in scopes with autoGranted flag),
-     * meaning no granting rules or default behavior contributed any scopes.
-     * The first element in [results] is always the auto-granted partition.
+     * meaning no granting method (webhook, rules, default behavior) contributed any scopes.
      */
     val allAutoGranted: Boolean
-        get() = results.drop(1).all { it.grantedScopes.isEmpty() }
+        get() = results
+            .filter { it.source != null }
+            .all { it.grantedScopes.isEmpty() }
 
     /**
-     * Determines how the grantable scopes were granted.
+     * Determines how the grantable scopes were granted based on the [ScopeGrantingMethodResult.source]
+     * of each result that contributed granted scopes.
      * - [GrantedBy.AUTO] if only auto-granted scopes were granted.
      * - [GrantedBy.WEBHOOK] if the authorization webhook contributed granted scopes.
      * - [GrantedBy.RULE] otherwise (rules or default behavior contributed).
-     *
-     * Results order: [auto-granted, webhook, rules, default].
      */
     val grantedBy: GrantedBy
         get() = when {
             allAutoGranted -> GrantedBy.AUTO
-            results.getOrNull(1)?.grantedScopes?.isNotEmpty() == true -> GrantedBy.WEBHOOK
+            results.any { it.source == GrantedBy.WEBHOOK && it.grantedScopes.isNotEmpty() } -> GrantedBy.WEBHOOK
             else -> GrantedBy.RULE
         }
 }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManager.kt
@@ -12,7 +12,6 @@ import com.sympauthy.business.model.flow.AuthorizationFlow.Companion.DEFAULT_WEB
 import com.sympauthy.business.model.flow.WebAuthorizationFlow
 import com.sympauthy.business.model.oauth2.AuthorizeAttempt
 import com.sympauthy.business.model.oauth2.CompletedAuthorizeAttempt
-import com.sympauthy.business.model.oauth2.GrantedBy
 import com.sympauthy.business.model.oauth2.OnGoingAuthorizeAttempt
 import com.sympauthy.business.manager.user.CollectedClaimManager
 import com.sympauthy.config.model.AuthorizationFlowsConfig
@@ -125,7 +124,7 @@ class AuthorizationFlowManager(
         modifiedAuthorizedAttempt = authorizeAttemptManager.setGrantedScopes(
             authorizeAttempt = modifiedAuthorizedAttempt,
             grantedScopes = grantScopesResult.grantedScopes,
-            grantedBy = if (grantScopesResult.allAutoGranted) GrantedBy.AUTO else GrantedBy.RULE
+            grantedBy = grantScopesResult.grantedBy
         )
 
         val hasAnyScope = !modifiedAuthorizedAttempt.grantedScopes.isNullOrEmpty() ||

--- a/server/src/main/kotlin/com/sympauthy/business/manager/rule/ScopeGrantingRuleManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/rule/ScopeGrantingRuleManager.kt
@@ -5,6 +5,7 @@ import com.sympauthy.business.exception.internalBusinessExceptionOf
 import com.sympauthy.business.model.ScopeGrantingMethodResult
 import com.sympauthy.business.model.client.Client
 import com.sympauthy.business.model.oauth2.AuthorizeAttempt
+import com.sympauthy.business.model.oauth2.GrantedBy
 import com.sympauthy.business.model.oauth2.Scope
 import com.sympauthy.business.model.rule.ScopeGrantingRule
 import com.sympauthy.business.model.rule.ScopeGrantingRuleBehavior.DECLINE
@@ -172,6 +173,7 @@ class ScopeGrantingRuleManager(
         }
 
         return ScopeGrantingMethodResult(
+            source = GrantedBy.RULE,
             grantedScopes = grantedScopes.toList(),
             declinedScopes = declinedScopes.toList(),
         )

--- a/server/src/main/kotlin/com/sympauthy/business/model/ScopeGrantingMethodResult.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/ScopeGrantingMethodResult.kt
@@ -1,5 +1,6 @@
 package com.sympauthy.business.model
 
+import com.sympauthy.business.model.oauth2.GrantedBy
 import com.sympauthy.business.model.oauth2.Scope
 
 /**
@@ -8,6 +9,11 @@ import com.sympauthy.business.model.oauth2.Scope
  * @see [com.sympauthy.business.manager.rule.ScopeGrantingRuleManager.applyScopeGrantingRules]
  */
 data class ScopeGrantingMethodResult(
+    /**
+     * Identifies which granting method produced this result.
+     * null for the auto-granted partition which is not a granting method.
+     */
+    val source: GrantedBy? = null,
     val grantedScopes: List<Scope> = emptyList(),
     val declinedScopes: List<Scope> = emptyList()
 )

--- a/server/src/main/kotlin/com/sympauthy/business/model/client/AuthorizationWebhook.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/client/AuthorizationWebhook.kt
@@ -1,0 +1,37 @@
+package com.sympauthy.business.model.client
+
+import java.net.URI
+
+/**
+ * Configuration for delegating authorization decisions to an external HTTP server via webhook.
+ *
+ * When configured on a client, the authorization server will call the webhook endpoint
+ * to determine which scopes to grant or deny during the authorization flow.
+ */
+data class AuthorizationWebhook(
+    /**
+     * The URL of the external server's webhook endpoint.
+     */
+    val url: URI,
+    /**
+     * The HMAC-SHA256 signing key used to sign the request body.
+     * The signature is sent in the `X-SympAuthy-Signature` header.
+     */
+    val secret: String,
+    /**
+     * The behavior to adopt when the webhook call fails (network error, timeout, non-2xx response).
+     */
+    val onFailure: AuthorizationWebhookOnFailure,
+)
+
+enum class AuthorizationWebhookOnFailure {
+    /**
+     * Deny all requested scopes if the webhook call fails.
+     */
+    DENY_ALL,
+
+    /**
+     * Fall back to the standard scope granting rules if the webhook call fails.
+     */
+    FALLBACK_TO_RULES
+}

--- a/server/src/main/kotlin/com/sympauthy/business/model/client/Client.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/client/Client.kt
@@ -43,7 +43,13 @@ data class Client(
      * List of [Scope] that are issued by default to a token request by this [Client] if the [Client] did not provide
      * them explicitly to the authorization endpoint.
      */
-    val defaultScopes: List<Scope>? = null
+    val defaultScopes: List<Scope>? = null,
+
+    /**
+     * Optional webhook configuration for delegating authorization decisions to an external server.
+     * When set, the webhook is called before applying scope granting rules.
+     */
+    val authorizationWebhook: AuthorizationWebhook? = null
 ) {
     fun supportsGrantType(grantType: GrantType): Boolean = grantType in allowedGrantTypes
 }

--- a/server/src/main/kotlin/com/sympauthy/business/model/oauth2/GrantedBy.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/oauth2/GrantedBy.kt
@@ -12,5 +12,10 @@ enum class GrantedBy {
     /**
      * At least one scope was granted through granting rules or default behavior.
      */
-    RULE
+    RULE,
+
+    /**
+     * At least one scope was granted through an authorization webhook delegation.
+     */
+    WEBHOOK
 }

--- a/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClient.kt
+++ b/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClient.kt
@@ -3,6 +3,7 @@ package com.sympauthy.client.authorization.webhook
 import com.sympauthy.business.model.client.AuthorizationWebhook
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResponse
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
 import com.sympauthy.config.model.AdvancedConfig
 import com.sympauthy.config.model.orThrow
 import io.micronaut.http.HttpRequest
@@ -13,7 +14,6 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.time.withTimeout
-import kotlinx.coroutines.withTimeout
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -27,7 +27,7 @@ class AuthorizationWebhookClient(
     suspend fun callWebhook(
         authorizationWebhook: AuthorizationWebhook,
         request: AuthorizationWebhookRequest
-    ): AuthorizationWebhookResponse {
+    ): AuthorizationWebhookResult {
         val body = objectMapper.writeValueAsString(request)
         val signature = computeHmacSha256(authorizationWebhook.secret, body)
         val timeout = advancedConfig.orThrow().authorizationWebhook.timeout
@@ -38,9 +38,17 @@ class AuthorizationWebhookClient(
             .accept(APPLICATION_JSON)
             .header(SIGNATURE_HEADER, "$SIGNATURE_PREFIX$signature")
 
-        return withTimeout(timeout) {
-            httpClient.retrieve(httpRequest, AuthorizationWebhookResponse::class.java)
-                .awaitFirst()
+        return try {
+            val response = withTimeout(timeout) {
+                httpClient.retrieve(httpRequest, AuthorizationWebhookResponse::class.java)
+                    .awaitFirst()
+            }
+            AuthorizationWebhookResult.Success(response)
+        } catch (e: Exception) {
+            AuthorizationWebhookResult.Failure(
+                message = e.message ?: e::class.simpleName ?: "Unknown error",
+                cause = e
+            )
         }
     }
 
@@ -53,7 +61,7 @@ class AuthorizationWebhookClient(
 
     companion object {
         private const val HMAC_ALGORITHM = "HmacSHA256"
-        private const val SIGNATURE_HEADER = "X-SympAuthy-Signature"
-        private const val SIGNATURE_PREFIX = "sha256="
+        internal const val SIGNATURE_HEADER = "X-SympAuthy-Signature"
+        internal const val SIGNATURE_PREFIX = "sha256="
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClient.kt
+++ b/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClient.kt
@@ -17,6 +17,16 @@ import kotlinx.coroutines.time.withTimeout
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
+/**
+ * HTTP client responsible for calling the external authorization webhook endpoint.
+ *
+ * Serializes the [AuthorizationWebhookRequest] as JSON, signs the request body using HMAC-SHA256,
+ * and sends it as a POST request with the signature in the `X-SympAuthy-Signature` header.
+ *
+ * The call is subject to a configurable timeout (`advanced.authorization-webhook.timeout`).
+ * All failures (network errors, timeouts, non-2xx responses, invalid payloads) are returned
+ * as [AuthorizationWebhookResult.Failure] rather than thrown as exceptions.
+ */
 @Singleton
 class AuthorizationWebhookClient(
     @Inject private val httpClient: HttpClient,
@@ -24,6 +34,14 @@ class AuthorizationWebhookClient(
     @Inject private val advancedConfig: AdvancedConfig
 ) {
 
+    /**
+     * Call the authorization webhook endpoint and return the result.
+     *
+     * @param authorizationWebhook the webhook configuration containing the URL and signing secret.
+     * @param request the request payload with user context and requested scopes.
+     * @return [AuthorizationWebhookResult.Success] with the parsed response on success,
+     *         or [AuthorizationWebhookResult.Failure] on any error.
+     */
     suspend fun callWebhook(
         authorizationWebhook: AuthorizationWebhook,
         request: AuthorizationWebhookRequest

--- a/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClient.kt
+++ b/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClient.kt
@@ -1,0 +1,59 @@
+package com.sympauthy.client.authorization.webhook
+
+import com.sympauthy.business.model.client.AuthorizationWebhook
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResponse
+import com.sympauthy.config.model.AdvancedConfig
+import com.sympauthy.config.model.orThrow
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType.APPLICATION_JSON
+import io.micronaut.http.client.HttpClient
+import io.micronaut.serde.ObjectMapper
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.time.withTimeout
+import kotlinx.coroutines.withTimeout
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Singleton
+class AuthorizationWebhookClient(
+    @Inject private val httpClient: HttpClient,
+    @Inject private val objectMapper: ObjectMapper,
+    @Inject private val advancedConfig: AdvancedConfig
+) {
+
+    suspend fun callWebhook(
+        authorizationWebhook: AuthorizationWebhook,
+        request: AuthorizationWebhookRequest
+    ): AuthorizationWebhookResponse {
+        val body = objectMapper.writeValueAsString(request)
+        val signature = computeHmacSha256(authorizationWebhook.secret, body)
+        val timeout = advancedConfig.orThrow().authorizationWebhook.timeout
+
+        val httpRequest = HttpRequest
+            .POST(authorizationWebhook.url, body)
+            .contentType(APPLICATION_JSON)
+            .accept(APPLICATION_JSON)
+            .header(SIGNATURE_HEADER, "$SIGNATURE_PREFIX$signature")
+
+        return withTimeout(timeout) {
+            httpClient.retrieve(httpRequest, AuthorizationWebhookResponse::class.java)
+                .awaitFirst()
+        }
+    }
+
+    internal fun computeHmacSha256(secret: String, body: String): String {
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), HMAC_ALGORITHM))
+        val hash = mac.doFinal(body.toByteArray(Charsets.UTF_8))
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        private const val HMAC_ALGORITHM = "HmacSHA256"
+        private const val SIGNATURE_HEADER = "X-SympAuthy-Signature"
+        private const val SIGNATURE_PREFIX = "sha256="
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/model/AuthorizationWebhookRequest.kt
+++ b/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/model/AuthorizationWebhookRequest.kt
@@ -1,0 +1,15 @@
+package com.sympauthy.client.authorization.webhook.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+data class AuthorizationWebhookRequest(
+    @get:JsonProperty("user_id")
+    val userId: String,
+    @get:JsonProperty("client_id")
+    val clientId: String,
+    @get:JsonProperty("requested_scopes")
+    val requestedScopes: List<String>,
+    val claims: Map<String, Any?>
+)

--- a/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/model/AuthorizationWebhookResponse.kt
+++ b/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/model/AuthorizationWebhookResponse.kt
@@ -1,0 +1,8 @@
+package com.sympauthy.client.authorization.webhook.model
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+data class AuthorizationWebhookResponse(
+    val scopes: Map<String, String>
+)

--- a/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/model/AuthorizationWebhookResult.kt
+++ b/server/src/main/kotlin/com/sympauthy/client/authorization/webhook/model/AuthorizationWebhookResult.kt
@@ -1,0 +1,22 @@
+package com.sympauthy.client.authorization.webhook.model
+
+/**
+ * Result of calling the authorization webhook endpoint.
+ */
+sealed class AuthorizationWebhookResult {
+
+    /**
+     * The webhook responded with a valid 2xx response containing scope decisions.
+     */
+    data class Success(
+        val response: AuthorizationWebhookResponse
+    ) : AuthorizationWebhookResult()
+
+    /**
+     * The webhook call failed due to a network error, timeout, non-2xx response, or invalid response payload.
+     */
+    data class Failure(
+        val message: String,
+        val cause: Exception? = null
+    ) : AuthorizationWebhookResult()
+}

--- a/server/src/main/kotlin/com/sympauthy/config/factory/AdvancedConfigFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/factory/AdvancedConfigFactory.kt
@@ -12,6 +12,8 @@ import com.sympauthy.config.properties.HashConfigurationProperties
 import com.sympauthy.config.properties.HashConfigurationProperties.Companion.HASH_KEY
 import com.sympauthy.config.properties.JwtConfigurationProperties
 import com.sympauthy.config.properties.JwtConfigurationProperties.Companion.JWT_KEY
+import com.sympauthy.config.properties.AuthorizationWebhookConfigurationProperties
+import com.sympauthy.config.properties.AuthorizationWebhookConfigurationProperties.Companion.AUTHORIZATION_WEBHOOK_KEY
 import com.sympauthy.config.properties.ValidationCodeConfigurationProperties
 import com.sympauthy.config.properties.ValidationCodeConfigurationProperties.Companion.VALIDATION_CODE_KEY
 import io.micronaut.context.annotation.Factory
@@ -29,6 +31,7 @@ class AdvancedConfigFactory(
         jwtProperties: JwtConfigurationProperties,
         hashProperties: HashConfigurationProperties,
         validationCodeProperties: ValidationCodeConfigurationProperties,
+        authorizationWebhookProperties: AuthorizationWebhookConfigurationProperties,
         keyGenerationStrategies: Map<String, CryptoKeysGenerationStrategy>,
     ): AdvancedConfig {
         val errors = mutableListOf<ConfigurationException>()
@@ -70,6 +73,13 @@ class AdvancedConfigFactory(
         val (validationCodeConfig, validationCodeErrors) = getValidationCodeConfig(validationCodeProperties)
         errors.addAll(validationCodeErrors)
 
+        val authorizationWebhookConfig = try {
+            getAuthorizationWebhookConfig(authorizationWebhookProperties)
+        } catch (e: ConfigurationException) {
+            errors.add(e)
+            null
+        }
+
         return if (errors.isEmpty()) {
             return EnabledAdvancedConfig(
                 keysGenerationStrategy = keysGenerationStrategy!!,
@@ -78,6 +88,7 @@ class AdvancedConfigFactory(
                 privateJwtAlgorithm = privateJwtAlgorithm!!,
                 hashConfig = hashConfig!!,
                 validationCode = validationCodeConfig!!,
+                authorizationWebhook = authorizationWebhookConfig!!,
             )
         } else {
             DisabledAdvancedConfig(errors)
@@ -264,6 +275,20 @@ class AdvancedConfigFactory(
     }
 
     private fun isPowerOf2(var0: Int): Boolean = (var0 and var0 - 1) == 0
+
+    private fun getAuthorizationWebhookConfig(
+        properties: AuthorizationWebhookConfigurationProperties
+    ): AuthorizationWebhookAdvancedConfig {
+        val timeout = parser.getDuration(
+            properties, "$AUTHORIZATION_WEBHOOK_KEY.timeout",
+            AuthorizationWebhookConfigurationProperties::timeout
+        ) ?: DEFAULT_WEBHOOK_TIMEOUT
+        return AuthorizationWebhookAdvancedConfig(timeout = timeout)
+    }
+
+    companion object {
+        private val DEFAULT_WEBHOOK_TIMEOUT = java.time.Duration.ofSeconds(5)
+    }
 
     private fun getValidationCodeConfig(
         properties: ValidationCodeConfigurationProperties

--- a/server/src/main/kotlin/com/sympauthy/config/factory/ClientsConfigFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/factory/ClientsConfigFactory.kt
@@ -2,6 +2,8 @@ package com.sympauthy.config.factory
 
 import com.sympauthy.business.manager.ScopeManager
 import com.sympauthy.business.manager.flow.AuthorizationFlowManager
+import com.sympauthy.business.model.client.AuthorizationWebhook
+import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
 import com.sympauthy.business.model.client.Client
 import com.sympauthy.business.model.client.GrantType
 import com.sympauthy.business.model.flow.AuthorizationFlow
@@ -16,6 +18,7 @@ import com.sympauthy.config.model.EnabledClientsConfig
 import com.sympauthy.config.model.EnabledUrlsConfig
 import com.sympauthy.config.model.UrlsConfig
 import com.sympauthy.config.properties.ClientConfigurationProperties
+import com.sympauthy.config.properties.ClientConfigurationProperties.AuthorizationWebhookConfig
 import com.sympauthy.config.properties.ClientConfigurationProperties.Companion.CLIENTS_KEY
 import com.sympauthy.config.properties.ClientConfigurationProperties.Companion.DEFAULT
 import io.micronaut.context.annotation.Factory
@@ -160,6 +163,17 @@ class ClientsConfigFactory(
             null
         }
 
+        val authorizationWebhook = try {
+            getAuthorizationWebhook(
+                properties = properties,
+                webhookConfig = properties.authorizationWebhook ?: defaultProperties?.authorizationWebhook,
+                errors = clientErrors
+            )
+        } catch (e: ConfigurationException) {
+            clientErrors.add(e)
+            null
+        }
+
         return if (clientErrors.isEmpty()) {
             Client(
                 id = properties.id,
@@ -169,7 +183,8 @@ class ClientsConfigFactory(
                 authorizationFlow = authorizationFlow,
                 allowedRedirectUris = allowedRedirectUris!!,
                 allowedScopes = allowedScopes,
-                defaultScopes = defaultScopes
+                defaultScopes = defaultScopes,
+                authorizationWebhook = authorizationWebhook
             )
         } else {
             errors.addAll(clientErrors)
@@ -289,6 +304,61 @@ class ClientsConfigFactory(
         }
     }
 
+    private fun getAuthorizationWebhook(
+        properties: ClientConfigurationProperties,
+        webhookConfig: AuthorizationWebhookConfig?,
+        errors: MutableList<ConfigurationException>
+    ): AuthorizationWebhook? {
+        if (webhookConfig == null) {
+            return null
+        }
+
+        val configKey = "$CLIENTS_KEY.${properties.id}.authorization-webhook"
+        val webhookErrors = mutableListOf<ConfigurationException>()
+
+        val url = try {
+            parser.getAbsoluteUriOrThrow(
+                webhookConfig, "$configKey.url",
+                AuthorizationWebhookConfig::url
+            )
+        } catch (e: ConfigurationException) {
+            webhookErrors.add(e)
+            null
+        }
+
+        val secret = try {
+            parser.getStringOrThrow(
+                webhookConfig, "$configKey.secret",
+                AuthorizationWebhookConfig::secret
+            )
+        } catch (e: ConfigurationException) {
+            webhookErrors.add(e)
+            null
+        }
+
+        val onFailure = try {
+            parser.getEnum(
+                webhookConfig, "$configKey.on-failure",
+                AuthorizationWebhookOnFailure.DENY_ALL,
+                AuthorizationWebhookConfig::onFailure
+            )
+        } catch (e: ConfigurationException) {
+            webhookErrors.add(e)
+            null
+        }
+
+        return if (webhookErrors.isEmpty()) {
+            AuthorizationWebhook(
+                url = url!!,
+                secret = secret!!,
+                onFailure = onFailure!!,
+            )
+        } else {
+            errors.addAll(webhookErrors)
+            null
+        }
+    }
+
     private suspend fun getScopes(
         key: String,
         scopes: List<String>?,
@@ -320,4 +390,5 @@ class ClientsConfigFactory(
             null
         }
     }
+
 }

--- a/server/src/main/kotlin/com/sympauthy/config/model/AdvancedConfig.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/model/AdvancedConfig.kt
@@ -16,6 +16,7 @@ data class EnabledAdvancedConfig(
     val privateJwtAlgorithm: JwtAlgorithm,
     val hashConfig: HashConfig,
     val validationCode: ValidationCodeConfig,
+    val authorizationWebhook: AuthorizationWebhookAdvancedConfig,
 ) : AdvancedConfig()
 
 class DisabledAdvancedConfig(
@@ -40,6 +41,10 @@ data class ValidationCodeConfig(
     val length: Int,
     val resendDelay: Duration?,
     val expiration: Duration,
+)
+
+data class AuthorizationWebhookAdvancedConfig(
+    val timeout: Duration,
 )
 
 fun AdvancedConfig.orThrow(): EnabledAdvancedConfig {

--- a/server/src/main/kotlin/com/sympauthy/config/properties/AuthorizationWebhookConfigurationProperties.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/properties/AuthorizationWebhookConfigurationProperties.kt
@@ -1,0 +1,14 @@
+package com.sympauthy.config.properties
+
+import com.sympauthy.config.properties.AdvancedConfigurationProperties.Companion.ADVANCED_KEY
+import com.sympauthy.config.properties.AuthorizationWebhookConfigurationProperties.Companion.AUTHORIZATION_WEBHOOK_KEY
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties(AUTHORIZATION_WEBHOOK_KEY)
+interface AuthorizationWebhookConfigurationProperties {
+    val timeout: String?
+
+    companion object {
+        const val AUTHORIZATION_WEBHOOK_KEY = "$ADVANCED_KEY.authorization-webhook"
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/config/properties/ClientConfigurationProperties.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/properties/ClientConfigurationProperties.kt
@@ -1,6 +1,7 @@
 package com.sympauthy.config.properties
 
 import com.sympauthy.config.properties.ClientConfigurationProperties.Companion.CLIENTS_KEY
+import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.context.annotation.EachProperty
 import io.micronaut.context.annotation.Parameter
 
@@ -19,6 +20,14 @@ class ClientConfigurationProperties(
     var allowedRedirectUris: List<String>? = null
     var allowedScopes: List<String>? = null
     var defaultScopes: List<String>? = null
+    var authorizationWebhook: AuthorizationWebhookConfig? = null
+
+    @ConfigurationProperties("authorization-webhook")
+    interface AuthorizationWebhookConfig {
+        val url: String?
+        val secret: String?
+        val onFailure: String?
+    }
 
     companion object {
         const val CLIENTS_KEY = "clients"

--- a/server/src/main/resources/application-default.yml
+++ b/server/src/main/resources/application-default.yml
@@ -2,6 +2,8 @@
 # additional configurations.
 
 advanced:
+  authorization-webhook:
+    timeout: 5s
   hash:
     block-size: 8
     cost-parameter: 16_384

--- a/server/src/test/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManagerTest.kt
@@ -12,6 +12,7 @@ import com.sympauthy.business.model.oauth2.Scope
 import com.sympauthy.client.authorization.webhook.AuthorizationWebhookClient
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResponse
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -100,8 +101,10 @@ class AuthorizationWebhookUserScopeGrantingManagerTest {
         coEvery { clientManager.findClientById("test-client") } returns client
         coEvery {
             authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
-        } returns AuthorizationWebhookResponse(
-            scopes = mapOf("scope1" to "grant", "scope2" to "deny")
+        } returns AuthorizationWebhookResult.Success(
+            AuthorizationWebhookResponse(
+                scopes = mapOf("scope1" to "grant", "scope2" to "deny")
+            )
         )
 
         val result = manager.applyAuthorizationWebhookScopeGranting(
@@ -119,8 +122,10 @@ class AuthorizationWebhookUserScopeGrantingManagerTest {
         coEvery { clientManager.findClientById("test-client") } returns client
         coEvery {
             authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
-        } returns AuthorizationWebhookResponse(
-            scopes = mapOf("scope1" to "grant")
+        } returns AuthorizationWebhookResult.Success(
+            AuthorizationWebhookResponse(
+                scopes = mapOf("scope1" to "grant")
+            )
         )
 
         val result = manager.applyAuthorizationWebhookScopeGranting(
@@ -132,42 +137,44 @@ class AuthorizationWebhookUserScopeGrantingManagerTest {
     }
 
     @Test
-    fun `applyAuthorizationWebhookScopeGranting - declines all scopes on failure when onFailure is DENY_ALL`() = runTest {
-        val attempt = mockAuthorizeAttempt()
-        val client = mockClient(
-            authorizationWebhook = mockWebhookConfig(onFailure = AuthorizationWebhookOnFailure.DENY_ALL)
-        )
-        coEvery { clientManager.findClientById("test-client") } returns client
-        coEvery {
-            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
-        } throws RuntimeException("Connection refused")
+    fun `applyAuthorizationWebhookScopeGranting - declines all scopes on failure when onFailure is DENY_ALL`() =
+        runTest {
+            val attempt = mockAuthorizeAttempt()
+            val client = mockClient(
+                authorizationWebhook = mockWebhookConfig(onFailure = AuthorizationWebhookOnFailure.DENY_ALL)
+            )
+            coEvery { clientManager.findClientById("test-client") } returns client
+            coEvery {
+                authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+            } returns AuthorizationWebhookResult.Failure(message = "Connection refused")
 
-        val result = manager.applyAuthorizationWebhookScopeGranting(
-            attempt, listOf(scope1, scope2), emptyList()
-        )
+            val result = manager.applyAuthorizationWebhookScopeGranting(
+                attempt, listOf(scope1, scope2), emptyList()
+            )
 
-        assertTrue(result.grantedScopes.isEmpty())
-        assertEquals(listOf(scope1, scope2), result.declinedScopes)
-    }
+            assertTrue(result.grantedScopes.isEmpty())
+            assertEquals(listOf(scope1, scope2), result.declinedScopes)
+        }
 
     @Test
-    fun `applyAuthorizationWebhookScopeGranting - returns empty result on failure when onFailure is FALLBACK_TO_RULES`() = runTest {
-        val attempt = mockAuthorizeAttempt()
-        val client = mockClient(
-            authorizationWebhook = mockWebhookConfig(onFailure = AuthorizationWebhookOnFailure.FALLBACK_TO_RULES)
-        )
-        coEvery { clientManager.findClientById("test-client") } returns client
-        coEvery {
-            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
-        } throws RuntimeException("Connection refused")
+    fun `applyAuthorizationWebhookScopeGranting - returns empty result on failure when onFailure is FALLBACK_TO_RULES`() =
+        runTest {
+            val attempt = mockAuthorizeAttempt()
+            val client = mockClient(
+                authorizationWebhook = mockWebhookConfig(onFailure = AuthorizationWebhookOnFailure.FALLBACK_TO_RULES)
+            )
+            coEvery { clientManager.findClientById("test-client") } returns client
+            coEvery {
+                authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+            } returns AuthorizationWebhookResult.Failure(message = "Connection refused")
 
-        val result = manager.applyAuthorizationWebhookScopeGranting(
-            attempt, listOf(scope1, scope2), emptyList()
-        )
+            val result = manager.applyAuthorizationWebhookScopeGranting(
+                attempt, listOf(scope1, scope2), emptyList()
+            )
 
-        assertTrue(result.grantedScopes.isEmpty())
-        assertTrue(result.declinedScopes.isEmpty())
-    }
+            assertTrue(result.grantedScopes.isEmpty())
+            assertTrue(result.declinedScopes.isEmpty())
+        }
 
     @Test
     fun `applyAuthorizationWebhookScopeGranting - grants additional scopes within allowed-scopes`() = runTest {
@@ -181,8 +188,10 @@ class AuthorizationWebhookUserScopeGrantingManagerTest {
         coEvery { scopeManager.find("extra-scope") } returns extraScope
         coEvery {
             authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
-        } returns AuthorizationWebhookResponse(
-            scopes = mapOf("scope1" to "grant", "extra-scope" to "grant")
+        } returns AuthorizationWebhookResult.Success(
+            AuthorizationWebhookResponse(
+                scopes = mapOf("scope1" to "grant", "extra-scope" to "grant")
+            )
         )
 
         val result = manager.applyAuthorizationWebhookScopeGranting(
@@ -204,8 +213,10 @@ class AuthorizationWebhookUserScopeGrantingManagerTest {
         coEvery { scopeManager.find("extra-scope") } returns extraScope
         coEvery {
             authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
-        } returns AuthorizationWebhookResponse(
-            scopes = mapOf("scope1" to "grant", "extra-scope" to "grant")
+        } returns AuthorizationWebhookResult.Success(
+            AuthorizationWebhookResponse(
+                scopes = mapOf("scope1" to "grant", "extra-scope" to "grant")
+            )
         )
 
         val result = manager.applyAuthorizationWebhookScopeGranting(

--- a/server/src/test/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManagerTest.kt
@@ -15,11 +15,11 @@ import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResp
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
@@ -39,8 +39,16 @@ class AuthorizationWebhookUserScopeGrantingManagerTest {
     @MockK
     lateinit var authorizationWebhookClient: AuthorizationWebhookClient
 
-    @InjectMockKs
     lateinit var manager: AuthorizationWebhookUserScopeGrantingManager
+
+    @BeforeEach
+    fun setUp() {
+        manager = AuthorizationWebhookUserScopeGrantingManager(
+            clientManagerProvider = { clientManager },
+            scopeManager = scopeManager,
+            authorizationWebhookClient = authorizationWebhookClient
+        )
+    }
 
     private val scope1 = GrantableUserScope("scope1", discoverable = false)
     private val scope2 = GrantableUserScope("scope2", discoverable = false)

--- a/server/src/test/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/auth/AuthorizationWebhookUserScopeGrantingManagerTest.kt
@@ -1,0 +1,217 @@
+package com.sympauthy.business.manager.auth
+
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.ScopeManager
+import com.sympauthy.business.model.client.AuthorizationWebhook
+import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
+import com.sympauthy.business.model.client.Client
+import com.sympauthy.business.model.client.GrantType
+import com.sympauthy.business.model.oauth2.GrantableUserScope
+import com.sympauthy.business.model.oauth2.OnGoingAuthorizeAttempt
+import com.sympauthy.business.model.oauth2.Scope
+import com.sympauthy.client.authorization.webhook.AuthorizationWebhookClient
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResponse
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExtendWith(MockKExtension::class)
+class AuthorizationWebhookUserScopeGrantingManagerTest {
+
+    @MockK
+    lateinit var clientManager: ClientManager
+
+    @MockK
+    lateinit var scopeManager: ScopeManager
+
+    @MockK
+    lateinit var authorizationWebhookClient: AuthorizationWebhookClient
+
+    @InjectMockKs
+    lateinit var manager: AuthorizationWebhookUserScopeGrantingManager
+
+    private val scope1 = GrantableUserScope("scope1", discoverable = false)
+    private val scope2 = GrantableUserScope("scope2", discoverable = false)
+
+    private fun mockAuthorizeAttempt(
+        clientId: String = "test-client",
+        userId: UUID = UUID.randomUUID()
+    ): OnGoingAuthorizeAttempt {
+        val attempt = mockk<OnGoingAuthorizeAttempt>()
+        every { attempt.clientId } returns clientId
+        every { attempt.userId } returns userId
+        return attempt
+    }
+
+    private fun mockClient(
+        id: String = "test-client",
+        authorizationWebhook: AuthorizationWebhook? = null,
+        allowedScopes: Set<Scope>? = null
+    ): Client {
+        return Client(
+            id = id,
+            secret = "secret",
+            allowedGrantTypes = setOf(GrantType.AUTHORIZATION_CODE),
+            authorizationFlow = null,
+            authorizationWebhook = authorizationWebhook,
+            allowedScopes = allowedScopes
+        )
+    }
+
+    private fun mockWebhookConfig(
+        onFailure: AuthorizationWebhookOnFailure = AuthorizationWebhookOnFailure.DENY_ALL
+    ): AuthorizationWebhook {
+        return AuthorizationWebhook(
+            url = URI.create("https://example.com/webhook"),
+            secret = "test-secret",
+            onFailure = onFailure,
+        )
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - returns empty result when no webhook configured`() = runTest {
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient()
+        coEvery { clientManager.findClientById("test-client") } returns client
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1, scope2), emptyList()
+        )
+
+        assertTrue(result.grantedScopes.isEmpty())
+        assertTrue(result.declinedScopes.isEmpty())
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - grants and denies scopes based on webhook response`() = runTest {
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient(authorizationWebhook = mockWebhookConfig())
+        coEvery { clientManager.findClientById("test-client") } returns client
+        coEvery {
+            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+        } returns AuthorizationWebhookResponse(
+            scopes = mapOf("scope1" to "grant", "scope2" to "deny")
+        )
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1, scope2), emptyList()
+        )
+
+        assertEquals(listOf(scope1), result.grantedScopes)
+        assertEquals(listOf(scope2), result.declinedScopes)
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - unspecified scopes in response default to deny`() = runTest {
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient(authorizationWebhook = mockWebhookConfig())
+        coEvery { clientManager.findClientById("test-client") } returns client
+        coEvery {
+            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+        } returns AuthorizationWebhookResponse(
+            scopes = mapOf("scope1" to "grant")
+        )
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1, scope2), emptyList()
+        )
+
+        assertEquals(listOf(scope1), result.grantedScopes)
+        assertEquals(listOf(scope2), result.declinedScopes)
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - declines all scopes on failure when onFailure is DENY_ALL`() = runTest {
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient(
+            authorizationWebhook = mockWebhookConfig(onFailure = AuthorizationWebhookOnFailure.DENY_ALL)
+        )
+        coEvery { clientManager.findClientById("test-client") } returns client
+        coEvery {
+            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+        } throws RuntimeException("Connection refused")
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1, scope2), emptyList()
+        )
+
+        assertTrue(result.grantedScopes.isEmpty())
+        assertEquals(listOf(scope1, scope2), result.declinedScopes)
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - returns empty result on failure when onFailure is FALLBACK_TO_RULES`() = runTest {
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient(
+            authorizationWebhook = mockWebhookConfig(onFailure = AuthorizationWebhookOnFailure.FALLBACK_TO_RULES)
+        )
+        coEvery { clientManager.findClientById("test-client") } returns client
+        coEvery {
+            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+        } throws RuntimeException("Connection refused")
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1, scope2), emptyList()
+        )
+
+        assertTrue(result.grantedScopes.isEmpty())
+        assertTrue(result.declinedScopes.isEmpty())
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - grants additional scopes within allowed-scopes`() = runTest {
+        val extraScope = GrantableUserScope("extra-scope", discoverable = false)
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient(
+            authorizationWebhook = mockWebhookConfig(),
+            allowedScopes = setOf(scope1, scope2, extraScope)
+        )
+        coEvery { clientManager.findClientById("test-client") } returns client
+        coEvery { scopeManager.find("extra-scope") } returns extraScope
+        coEvery {
+            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+        } returns AuthorizationWebhookResponse(
+            scopes = mapOf("scope1" to "grant", "extra-scope" to "grant")
+        )
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1), emptyList()
+        )
+
+        assertEquals(listOf(scope1, extraScope), result.grantedScopes)
+    }
+
+    @Test
+    fun `applyAuthorizationWebhookScopeGranting - does not grant scopes outside allowed-scopes`() = runTest {
+        val extraScope = GrantableUserScope("extra-scope", discoverable = false)
+        val attempt = mockAuthorizeAttempt()
+        val client = mockClient(
+            authorizationWebhook = mockWebhookConfig(),
+            allowedScopes = setOf(scope1)
+        )
+        coEvery { clientManager.findClientById("test-client") } returns client
+        coEvery { scopeManager.find("extra-scope") } returns extraScope
+        coEvery {
+            authorizationWebhookClient.callWebhook(any(), any<AuthorizationWebhookRequest>())
+        } returns AuthorizationWebhookResponse(
+            scopes = mapOf("scope1" to "grant", "extra-scope" to "grant")
+        )
+
+        val result = manager.applyAuthorizationWebhookScopeGranting(
+            attempt, listOf(scope1), emptyList()
+        )
+
+        assertEquals(listOf(scope1), result.grantedScopes)
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/auth/UserScopeGrantingManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/auth/UserScopeGrantingManagerTest.kt
@@ -29,6 +29,9 @@ class UserScopeGrantingManagerTest {
     lateinit var scopeManager: ScopeManager
 
     @MockK
+    lateinit var authorizationWebhookScopeGrantingManager: AuthorizationWebhookUserScopeGrantingManager
+
+    @MockK
     lateinit var scopeGrantingRuleManager: ScopeGrantingRuleManager
 
     @MockK

--- a/server/src/test/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClientTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClientTest.kt
@@ -1,0 +1,54 @@
+package com.sympauthy.client.authorization.webhook
+
+import com.sympauthy.config.model.AdvancedConfig
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.micronaut.http.client.HttpClient
+import io.micronaut.serde.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+
+@ExtendWith(MockKExtension::class)
+class AuthorizationWebhookClientTest {
+
+    @MockK
+    lateinit var httpClient: HttpClient
+
+    @MockK
+    lateinit var objectMapper: ObjectMapper
+
+    @MockK
+    lateinit var advancedConfig: AdvancedConfig
+
+    @InjectMockKs
+    lateinit var client: AuthorizationWebhookClient
+
+    @Test
+    fun `computeHmacSha256 - produces correct signature for known input`() {
+        // Known test vector: HMAC-SHA256("secret", "message")
+        val signature = client.computeHmacSha256("secret", "message")
+
+        assertEquals(
+            "8b5f48702995c1598c573db1e21866a9b825d4a794d169d7060a03605796360b",
+            signature
+        )
+    }
+
+    @Test
+    fun `computeHmacSha256 - different secrets produce different signatures`() {
+        val sig1 = client.computeHmacSha256("secret1", "body")
+        val sig2 = client.computeHmacSha256("secret2", "body")
+
+        assert(sig1 != sig2) { "Different secrets should produce different signatures" }
+    }
+
+    @Test
+    fun `computeHmacSha256 - different bodies produce different signatures`() {
+        val sig1 = client.computeHmacSha256("secret", "body1")
+        val sig2 = client.computeHmacSha256("secret", "body2")
+
+        assert(sig1 != sig2) { "Different bodies should produce different signatures" }
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClientTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClientTest.kt
@@ -4,21 +4,19 @@ import com.sympauthy.business.model.client.AuthorizationWebhook
 import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
 import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
+import com.sympauthy.config.model.AdvancedConfig
 import com.sympauthy.config.model.AuthorizationWebhookAdvancedConfig
-import com.sympauthy.config.model.EnabledAdvancedConfig
+import com.sympauthy.config.model.orThrow
 import io.micronaut.http.client.HttpClient
 import io.micronaut.serde.ObjectMapper
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -26,13 +24,18 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-@ExtendWith(MockKExtension::class)
+@MicronautTest(
+    environments = ["default", "test"],
+    startApplication = false
+)
 class AuthorizationWebhookClientTest {
 
-    @MockK
+    @Inject
     lateinit var objectMapper: ObjectMapper
 
-    private lateinit var advancedConfig: EnabledAdvancedConfig
+    @Inject
+    lateinit var advancedConfig: AdvancedConfig
+
     private lateinit var mockWebServer: MockWebServer
     private lateinit var client: AuthorizationWebhookClient
 
@@ -41,7 +44,6 @@ class AuthorizationWebhookClientTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
-        advancedConfig = mockAdvancedConfig()
         val httpClient = HttpClient.create(mockWebServer.url("/").toUrl())
         client = AuthorizationWebhookClient(httpClient, objectMapper, advancedConfig)
     }
@@ -50,9 +52,6 @@ class AuthorizationWebhookClientTest {
     fun tearDown() {
         mockWebServer.shutdown()
     }
-
-    private val requestBody =
-        """{"user_id":"user-1","client_id":"client-1","requested_scopes":["scope1"],"claims":{}}"""
 
     private val request = AuthorizationWebhookRequest(
         userId = "user-1",
@@ -69,18 +68,8 @@ class AuthorizationWebhookClientTest {
         )
     }
 
-    private fun mockAdvancedConfig(
-        timeout: Duration = Duration.ofSeconds(5)
-    ): EnabledAdvancedConfig {
-        val enabledConfig = mockk<EnabledAdvancedConfig>()
-        every { enabledConfig.authorizationWebhook } returns AuthorizationWebhookAdvancedConfig(timeout = timeout)
-        return enabledConfig
-    }
-
     @Test
     fun `callWebhook - returns Success with granted scopes on valid response`() = runBlocking<Unit> {
-        every { objectMapper.writeValueAsString(request) } returns requestBody
-
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(200)
@@ -100,15 +89,21 @@ class AuthorizationWebhookClientTest {
                 .startsWith(AuthorizationWebhookClient.SIGNATURE_PREFIX)
         )
         assertEquals("application/json", recordedRequest.getHeader("Content-Type"))
-        assertEquals(requestBody, recordedRequest.body.readUtf8())
+
+        // Verify the body is valid JSON with expected fields
+        val body = recordedRequest.body.readUtf8()
+        assertTrue(body.contains("\"user_id\""))
+        assertTrue(body.contains("\"client_id\""))
+        assertTrue(body.contains("\"requested_scopes\""))
     }
 
     @Test
     fun `callWebhook - returns Failure on timeout`() = runBlocking<Unit> {
-        val shortTimeoutConfig = mockAdvancedConfig(timeout = Duration.ofMillis(100))
+        val shortTimeoutConfig = AuthorizationWebhookAdvancedConfig(timeout = Duration.ofMillis(100))
+        val timeoutAdvancedConfig = io.mockk.mockk<com.sympauthy.config.model.EnabledAdvancedConfig>()
+        io.mockk.every { timeoutAdvancedConfig.authorizationWebhook } returns shortTimeoutConfig
         val httpClient = HttpClient.create(mockWebServer.url("/").toUrl())
-        val timeoutClient = AuthorizationWebhookClient(httpClient, objectMapper, shortTimeoutConfig)
-        every { objectMapper.writeValueAsString(request) } returns requestBody
+        val timeoutClient = AuthorizationWebhookClient(httpClient, objectMapper, timeoutAdvancedConfig)
 
         mockWebServer.enqueue(
             MockResponse()
@@ -125,8 +120,6 @@ class AuthorizationWebhookClientTest {
 
     @Test
     fun `callWebhook - returns Failure on client error response`() = runBlocking<Unit> {
-        every { objectMapper.writeValueAsString(request) } returns requestBody
-
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(400)
@@ -141,8 +134,6 @@ class AuthorizationWebhookClientTest {
 
     @Test
     fun `callWebhook - returns Failure on invalid response payload`() = runBlocking<Unit> {
-        every { objectMapper.writeValueAsString(request) } returns requestBody
-
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(200)

--- a/server/src/test/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClientTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/client/authorization/webhook/AuthorizationWebhookClientTest.kt
@@ -1,33 +1,162 @@
 package com.sympauthy.client.authorization.webhook
 
-import com.sympauthy.config.model.AdvancedConfig
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.MockKExtension
+import com.sympauthy.business.model.client.AuthorizationWebhook
+import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookRequest
+import com.sympauthy.client.authorization.webhook.model.AuthorizationWebhookResult
+import com.sympauthy.config.model.AuthorizationWebhookAdvancedConfig
+import com.sympauthy.config.model.EnabledAdvancedConfig
 import io.micronaut.http.client.HttpClient
 import io.micronaut.serde.ObjectMapper
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class AuthorizationWebhookClientTest {
 
     @MockK
-    lateinit var httpClient: HttpClient
-
-    @MockK
     lateinit var objectMapper: ObjectMapper
 
-    @MockK
-    lateinit var advancedConfig: AdvancedConfig
+    private lateinit var advancedConfig: EnabledAdvancedConfig
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var client: AuthorizationWebhookClient
 
-    @InjectMockKs
-    lateinit var client: AuthorizationWebhookClient
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        advancedConfig = mockAdvancedConfig()
+        val httpClient = HttpClient.create(mockWebServer.url("/").toUrl())
+        client = AuthorizationWebhookClient(httpClient, objectMapper, advancedConfig)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    private val requestBody =
+        """{"user_id":"user-1","client_id":"client-1","requested_scopes":["scope1"],"claims":{}}"""
+
+    private val request = AuthorizationWebhookRequest(
+        userId = "user-1",
+        clientId = "client-1",
+        requestedScopes = listOf("scope1"),
+        claims = emptyMap()
+    )
+
+    private fun mockAuthorizationWebhook(): AuthorizationWebhook {
+        return AuthorizationWebhook(
+            url = URI.create(mockWebServer.url("/webhook").toString()),
+            secret = "test-secret",
+            onFailure = AuthorizationWebhookOnFailure.DENY_ALL,
+        )
+    }
+
+    private fun mockAdvancedConfig(
+        timeout: Duration = Duration.ofSeconds(5)
+    ): EnabledAdvancedConfig {
+        val enabledConfig = mockk<EnabledAdvancedConfig>()
+        every { enabledConfig.authorizationWebhook } returns AuthorizationWebhookAdvancedConfig(timeout = timeout)
+        return enabledConfig
+    }
+
+    @Test
+    fun `callWebhook - returns Success with granted scopes on valid response`() = runBlocking<Unit> {
+        every { objectMapper.writeValueAsString(request) } returns requestBody
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"scopes":{"scope1":"grant"}}""")
+        )
+
+        val result = client.callWebhook(mockAuthorizationWebhook(), request)
+
+        assertIs<AuthorizationWebhookResult.Success>(result)
+        assertEquals(mapOf("scope1" to "grant"), result.response.scopes)
+
+        val recordedRequest = mockWebServer.takeRequest()
+        assertEquals("POST", recordedRequest.method)
+        assertTrue(
+            recordedRequest.getHeader(AuthorizationWebhookClient.SIGNATURE_HEADER)!!
+                .startsWith(AuthorizationWebhookClient.SIGNATURE_PREFIX)
+        )
+        assertEquals("application/json", recordedRequest.getHeader("Content-Type"))
+        assertEquals(requestBody, recordedRequest.body.readUtf8())
+    }
+
+    @Test
+    fun `callWebhook - returns Failure on timeout`() = runBlocking<Unit> {
+        val shortTimeoutConfig = mockAdvancedConfig(timeout = Duration.ofMillis(100))
+        val httpClient = HttpClient.create(mockWebServer.url("/").toUrl())
+        val timeoutClient = AuthorizationWebhookClient(httpClient, objectMapper, shortTimeoutConfig)
+        every { objectMapper.writeValueAsString(request) } returns requestBody
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"scopes":{"scope1":"grant"}}""")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        )
+
+        val result = timeoutClient.callWebhook(mockAuthorizationWebhook(), request)
+
+        assertIs<AuthorizationWebhookResult.Failure>(result)
+    }
+
+    @Test
+    fun `callWebhook - returns Failure on client error response`() = runBlocking<Unit> {
+        every { objectMapper.writeValueAsString(request) } returns requestBody
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":"bad request"}""")
+        )
+
+        val result = client.callWebhook(mockAuthorizationWebhook(), request)
+
+        assertIs<AuthorizationWebhookResult.Failure>(result)
+    }
+
+    @Test
+    fun `callWebhook - returns Failure on invalid response payload`() = runBlocking<Unit> {
+        every { objectMapper.writeValueAsString(request) } returns requestBody
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""not valid json""")
+        )
+
+        val result = client.callWebhook(mockAuthorizationWebhook(), request)
+
+        assertIs<AuthorizationWebhookResult.Failure>(result)
+    }
 
     @Test
     fun `computeHmacSha256 - produces correct signature for known input`() {
-        // Known test vector: HMAC-SHA256("secret", "message")
         val signature = client.computeHmacSha256("secret", "message")
 
         assertEquals(


### PR DESCRIPTION
## Summary

- Add per-client webhook authorization delegation that calls an external HTTP server to determine scope grant/deny decisions
- Webhook is inserted before rule-based granting in the `UserScopeGrantingManager` pipeline, with HMAC-SHA256 request signing
- Supports `deny_all` (default) and `fallback_to_rules` failure modes, and can grant additional scopes beyond those requested
- Webhook timeout is configurable globally via `advanced.authorization-webhook.timeout` (default 5s)

Closes #119

## Test plan

- [x] Unit tests for `AuthorizationWebhookClient` (HMAC signature computation)
- [x] Unit tests for `AuthorizationWebhookUserScopeGrantingManager` (grant/deny mapping, failure modes, extra scopes, pass-through when unconfigured)
- [x] Existing `UserScopeGrantingManagerTest` and `AuthorizationFlowManagerTest` pass with new webhook in pipeline
- [ ] Manual test: configure a client with `authorization-webhook` block, verify webhook is called and scopes are granted/denied accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)