### PR TITLE
Add admin API to list and retrieve configured audiences

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminAudienceController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminAudienceController.kt
@@ -1,0 +1,101 @@
+package com.sympauthy.api.controller.admin
+
+import com.sympauthy.api.mapper.admin.AdminAudienceResourceMapper
+import com.sympauthy.api.resource.admin.AdminAudienceListResource
+import com.sympauthy.api.resource.admin.AdminAudienceResource
+import com.sympauthy.api.util.orNotFound
+import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.AudienceManager
+import com.sympauthy.business.model.oauth2.AdminScopeId
+import com.sympauthy.security.SecurityRule.ADMIN_CONFIG_READ
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import jakarta.inject.Inject
+
+@Controller("/api/v1/admin/audiences")
+@Secured(ADMIN_CONFIG_READ)
+@SecurityRequirement(name = "admin", scopes = [AdminScopeId.CONFIG_READ])
+class AdminAudienceController(
+    @Inject private val audienceManager: AudienceManager,
+    @Inject private val audienceMapper: AdminAudienceResourceMapper
+) {
+
+    @Operation(
+        description = "Retrieve all configured audiences. Since audiences are defined in configuration files, this endpoint exposes them as read-only resources.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "page",
+                description = "Zero-indexed page number.",
+                schema = Schema(type = "integer", defaultValue = "0")
+            ),
+            Parameter(
+                name = "size",
+                description = "Number of results per page.",
+                schema = Schema(type = "integer", defaultValue = "20")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Paginated list of audiences."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:config:read."
+            )
+        ]
+    )
+    @Get
+    suspend fun listAudiences(
+        @QueryValue page: Int?,
+        @QueryValue size: Int?
+    ): AdminAudienceListResource {
+        val (page, size) = resolvePageParams(page, size)
+        val audiences = audienceManager.listAudiences()
+        val paged = audiences
+            .drop(page * size)
+            .take(size)
+            .map(audienceMapper::toResource)
+        return AdminAudienceListResource(
+            audiences = paged,
+            page = page,
+            size = size,
+            total = audiences.size
+        )
+    }
+
+    @Operation(
+        description = "Retrieve details for a specific audience by its identifier.",
+        tags = ["admin"],
+        parameters = [
+            Parameter(
+                name = "audienceId",
+                description = "Unique identifier of the audience.",
+                schema = Schema(type = "string")
+            )
+        ],
+        responses = [
+            ApiResponse(responseCode = "200", description = "Audience details."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:config:read."
+            ),
+            ApiResponse(responseCode = "404", description = "No audience found with the given identifier.")
+        ]
+    )
+    @Get("/{audienceId}")
+    suspend fun getAudience(
+        @PathVariable audienceId: String
+    ): AdminAudienceResource {
+        val audience = audienceManager.findAudienceByIdOrNull(audienceId).orNotFound()
+        return audienceMapper.toResource(audience)
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminApiMapperFactory.kt
@@ -24,4 +24,8 @@ class AdminApiMapperFactory {
     @Singleton
     fun mfaMethodResourceMapper(): AdminUserMfaMethodResourceMapper =
         Mappers.getMapper(AdminUserMfaMethodResourceMapper::class.java)
+
+    @Singleton
+    fun audienceResourceMapper(): AdminAudienceResourceMapper =
+        Mappers.getMapper(AdminAudienceResourceMapper::class.java)
 }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminAudienceResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminAudienceResourceMapper.kt
@@ -1,0 +1,16 @@
+package com.sympauthy.api.mapper.admin
+
+import com.sympauthy.api.mapper.config.OutputResourceMapperConfig
+import com.sympauthy.api.resource.admin.AdminAudienceResource
+import com.sympauthy.business.model.audience.Audience
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+
+@Mapper(
+    config = OutputResourceMapperConfig::class
+)
+abstract class AdminAudienceResourceMapper {
+
+    @Mapping(source = "id", target = "audienceId")
+    abstract fun toResource(audience: Audience): AdminAudienceResource
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAudienceListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAudienceListResource.kt
@@ -1,0 +1,19 @@
+package com.sympauthy.api.resource.admin
+
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Paginated list of audiences."
+)
+@Serdeable
+data class AdminAudienceListResource(
+    @get:Schema(description = "Array of audience records.")
+    val audiences: List<AdminAudienceResource>,
+    @get:Schema(description = "Current page number.")
+    val page: Int,
+    @get:Schema(description = "Number of results per page.")
+    val size: Int,
+    @get:Schema(description = "Total number of audiences.")
+    val total: Int
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAudienceResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAudienceResource.kt
@@ -1,0 +1,22 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Information about a configured audience."
+)
+@Serdeable
+data class AdminAudienceResource(
+    @get:Schema(
+        description = "Unique identifier of the audience, as defined in the YAML configuration key."
+    )
+    @get:JsonProperty("audience_id")
+    val audienceId: String,
+    @get:Schema(
+        description = "Value used as the aud claim in access and refresh tokens issued for clients belonging to this audience. Defaults to the audience identifier when not explicitly configured."
+    )
+    @get:JsonProperty("token_audience")
+    val tokenAudience: String
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/AudienceManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/AudienceManager.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.business.manager
+
+import com.sympauthy.business.model.audience.Audience
+import com.sympauthy.config.model.AudiencesConfig
+import com.sympauthy.config.model.orThrow
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Singleton
+class AudienceManager(
+    @Inject private val audiencesConfig: AudiencesConfig
+) {
+
+    fun listAudiences(): List<Audience> {
+        return audiencesConfig.orThrow().audiences
+    }
+
+    fun findAudienceByIdOrNull(id: String): Audience? {
+        return listAudiences().firstOrNull { it.id == id }
+    }
+}

--- a/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
@@ -26,6 +26,15 @@
     ]
   },
   {
+    "name": "com.sympauthy.api.mapper.admin.AdminAudienceResourceMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sympauthy.api.mapper.admin.AdminClientResourceMapperImpl",
     "methods": [
       {


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/admin/audiences` (paginated list) and `GET /api/v1/admin/audiences/{audienceId}` (detail) endpoints
- New `AudienceManager` wrapping `AudiencesConfig` for business-layer access to audiences
- MapStruct mapper registered in `reflect-config.json` for native image support

Closes #225

## Test plan
- [x] `compileKotlin` passes
- [x] All existing tests pass
- [ ] Manual test: start app, call `GET /api/v1/admin/audiences` — verify paginated response
- [ ] Manual test: call `GET /api/v1/admin/audiences/{id}` with valid/invalid IDs — verify 200/404
- [ ] Manual test: call endpoints without token or with insufficient scope — verify 401/403

🤖 Generated with [Claude Code](https://claude.com/claude-code)