### PR TITLE
Add registration flags and clients count to admin audience API

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminAudienceController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminAudienceController.kt
@@ -6,6 +6,7 @@ import com.sympauthy.api.resource.admin.AdminAudienceResource
 import com.sympauthy.api.util.orNotFound
 import com.sympauthy.api.util.resolvePageParams
 import com.sympauthy.business.manager.AudienceManager
+import com.sympauthy.business.manager.ClientManager
 import com.sympauthy.business.model.oauth2.AdminScopeId
 import com.sympauthy.security.SecurityRule.ADMIN_CONFIG_READ
 import io.micronaut.http.annotation.Controller
@@ -25,6 +26,7 @@ import jakarta.inject.Inject
 @SecurityRequirement(name = "admin", scopes = [AdminScopeId.CONFIG_READ])
 class AdminAudienceController(
     @Inject private val audienceManager: AudienceManager,
+    @Inject private val clientManager: ClientManager,
     @Inject private val audienceMapper: AdminAudienceResourceMapper
 ) {
 
@@ -59,10 +61,11 @@ class AdminAudienceController(
     ): AdminAudienceListResource {
         val (page, size) = resolvePageParams(page, size)
         val audiences = audienceManager.listAudiences()
+        val clientCountsByAudienceId = clientManager.countClientsByAudienceId()
         val paged = audiences
             .drop(page * size)
             .take(size)
-            .map(audienceMapper::toResource)
+            .map { audienceMapper.toResource(it, clientCountsByAudienceId[it.id] ?: 0) }
         return AdminAudienceListResource(
             audiences = paged,
             page = page,
@@ -96,6 +99,7 @@ class AdminAudienceController(
         @PathVariable audienceId: String
     ): AdminAudienceResource {
         val audience = audienceManager.findAudienceByIdOrNull(audienceId).orNotFound()
-        return audienceMapper.toResource(audience)
+        val clientsCount = clientManager.countClientsByAudienceId()[audience.id] ?: 0
+        return audienceMapper.toResource(audience, clientsCount)
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminAudienceResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminAudienceResourceMapper.kt
@@ -11,6 +11,6 @@ import org.mapstruct.Mapping
 )
 abstract class AdminAudienceResourceMapper {
 
-    @Mapping(source = "id", target = "audienceId")
-    abstract fun toResource(audience: Audience): AdminAudienceResource
+    @Mapping(source = "audience.id", target = "audienceId")
+    abstract fun toResource(audience: Audience, clientsCount: Int): AdminAudienceResource
 }

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAudienceResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAudienceResource.kt
@@ -18,5 +18,20 @@ data class AdminAudienceResource(
         description = "Value used as the aud claim in access and refresh tokens issued for clients belonging to this audience. Defaults to the audience identifier when not explicitly configured."
     )
     @get:JsonProperty("token_audience")
-    val tokenAudience: String
+    val tokenAudience: String,
+    @get:Schema(
+        description = "Whether open registration is enabled for this audience. When true, any user can create an account through the sign-up flow."
+    )
+    @get:JsonProperty("sign_up_enabled")
+    val signUpEnabled: Boolean,
+    @get:Schema(
+        description = "Whether invitation-based registration is enabled for this audience. When true, invitations can be created and used to register."
+    )
+    @get:JsonProperty("invitation_enabled")
+    val invitationEnabled: Boolean,
+    @get:Schema(
+        description = "Number of clients configured for this audience."
+    )
+    @get:JsonProperty("clients_count")
+    val clientsCount: Int
 )

--- a/server/src/main/kotlin/com/sympauthy/business/manager/ClientManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/ClientManager.kt
@@ -20,6 +20,13 @@ class ClientManager(
     }
 
     /**
+     * Return the number of clients grouped by their audience identifier.
+     */
+    suspend fun countClientsByAudienceId(): Map<String, Int> {
+        return listClients().groupBy { it.audience.id }.mapValues { it.value.size }
+    }
+
+    /**
      * Return the [Client] identified by [id]. Otherwise, return null if no client matches.
      */
     suspend fun findClientByIdOrNull(id: String): Client? {


### PR DESCRIPTION
## Summary
- Expose `sign_up_enabled` and `invitation_enabled` boolean flags in the admin audience resource so the frontend can derive and display the registration mode label
- Add `clients_count` field showing the number of clients configured for each audience
- Add `ClientManager.countClientsByAudienceId()` to compute client counts per audience

Relates to: sympauthy/sympauthy-admin#61

## Test plan
- [ ] `./gradlew compileKotlin` passes
- [ ] `./gradlew test` passes
- [ ] `GET /api/v1/admin/audiences` returns `sign_up_enabled`, `invitation_enabled`, and `clients_count` for each audience
- [ ] `GET /api/v1/admin/audiences/{id}` returns the same enriched fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)