### PR TITLE
Add missing fields to admin client API

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClientController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClientController.kt
@@ -62,7 +62,7 @@ class AdminClientController(
         val paged = clients
             .drop(page * size)
             .take(size)
-            .map(clientMapper::toResource)
+            .map(clientMapper::toSummaryResource)
         return AdminClientListResource(
             clients = paged,
             page = page,

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminClientResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/admin/AdminClientResourceMapper.kt
@@ -1,8 +1,13 @@
 package com.sympauthy.api.mapper.admin
 
 import com.sympauthy.api.mapper.config.OutputResourceMapperConfig
+import com.sympauthy.api.resource.admin.AdminAuthorizationWebhookResource
 import com.sympauthy.api.resource.admin.AdminClientResource
+import com.sympauthy.api.resource.admin.AdminClientSummaryResource
+import com.sympauthy.business.model.client.AuthorizationWebhook
+import com.sympauthy.business.model.client.AuthorizationWebhookOnFailure
 import com.sympauthy.business.model.client.Client
+import com.sympauthy.business.model.client.GrantType
 import com.sympauthy.business.model.oauth2.Scope
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
@@ -16,10 +21,33 @@ abstract class AdminClientResourceMapper {
 
     @Mapping(source = "id", target = "clientId")
     @Mapping(source = "public", target = "type", qualifiedByName = ["toClientType"])
+    @Mapping(source = "audience.id", target = "audienceId")
+    abstract fun toSummaryResource(client: Client): AdminClientSummaryResource
+
+    @Mapping(source = "id", target = "clientId")
+    @Mapping(source = "public", target = "type", qualifiedByName = ["toClientType"])
+    @Mapping(source = "audience.id", target = "audienceId")
+    @Mapping(source = "authorizationFlow.id", target = "authorizationFlowId")
     abstract fun toResource(client: Client): AdminClientResource
 
     @org.mapstruct.Named("toClientType")
     fun toClientType(public: Boolean): String = if (public) "public" else "confidential"
 
     fun toScope(scope: Scope): String = scope.scope
+
+    fun toGrantType(grantType: GrantType): String = grantType.value
+
+    fun toWebhookResource(webhook: AuthorizationWebhook?): AdminAuthorizationWebhookResource? {
+        return webhook?.let {
+            AdminAuthorizationWebhookResource(
+                url = it.url.toString(),
+                onFailure = toOnFailure(it.onFailure)
+            )
+        }
+    }
+
+    private fun toOnFailure(onFailure: AuthorizationWebhookOnFailure): String = when (onFailure) {
+        AuthorizationWebhookOnFailure.DENY_ALL -> "deny_all"
+        AuthorizationWebhookOnFailure.FALLBACK_TO_RULES -> "fallback_to_rules"
+    }
 }

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAuthorizationWebhookResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminAuthorizationWebhookResource.kt
@@ -1,0 +1,20 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Webhook configuration for delegating authorization decisions."
+)
+@Serdeable
+data class AdminAuthorizationWebhookResource(
+    @get:Schema(description = "URL of the webhook endpoint.")
+    val url: String,
+    @get:Schema(
+        description = "Behavior when the webhook call fails.",
+        allowableValues = ["deny_all", "fallback_to_rules"]
+    )
+    @get:JsonProperty("on_failure")
+    val onFailure: String
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientListResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientListResource.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Serdeable
 data class AdminClientListResource(
     @get:Schema(description = "Array of client records.")
-    val clients: List<AdminClientResource>,
+    val clients: List<AdminClientSummaryResource>,
     @get:Schema(description = "Current page number.")
     val page: Int,
     @get:Schema(description = "Number of results per page.")

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientResource.kt
@@ -5,7 +5,7 @@ import io.micronaut.serde.annotation.Serdeable
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
-    description = "Information about a client."
+    description = "Detailed information about a client."
 )
 @Serdeable
 data class AdminClientResource(
@@ -17,13 +17,28 @@ data class AdminClientResource(
         allowableValues = ["public", "confidential"]
     )
     val type: String,
+    @get:Schema(description = "Identifier of the audience this client belongs to.")
+    @get:JsonProperty("audience_id")
+    val audienceId: String,
+    @get:Schema(
+        description = "OAuth2 grant types this client is allowed to use.",
+        allowableValues = ["authorization_code", "refresh_token", "client_credentials"]
+    )
+    @get:JsonProperty("allowed_grant_types")
+    val allowedGrantTypes: List<String>,
+    @get:Schema(description = "Identifier of the authorization flow configured for this client.")
+    @get:JsonProperty("authorization_flow_id")
+    val authorizationFlowId: String?,
     @get:Schema(description = "Scopes the client is allowed to request.")
     @get:JsonProperty("allowed_scopes")
     val allowedScopes: List<String>,
-    @get:Schema(description = "Scopes granted by default when the client does not explicitly request any.")
+    @get:Schema(description = "Scopes requested by default when the client does not explicitly specify any in the authorization request.")
     @get:JsonProperty("default_scopes")
     val defaultScopes: List<String>,
     @get:Schema(description = "Redirect URIs the client is allowed to use during authorization.")
     @get:JsonProperty("allowed_redirect_uris")
-    val allowedRedirectUris: List<String>
+    val allowedRedirectUris: List<String>,
+    @get:Schema(description = "Webhook configuration for delegating authorization decisions.")
+    @get:JsonProperty("authorization_webhook")
+    val authorizationWebhook: AdminAuthorizationWebhookResource?
 )

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientSummaryResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminClientSummaryResource.kt
@@ -1,0 +1,26 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Summary information about a client."
+)
+@Serdeable
+data class AdminClientSummaryResource(
+    @get:Schema(description = "Unique identifier of the client, as defined in configuration.")
+    @get:JsonProperty("client_id")
+    val clientId: String,
+    @get:Schema(
+        description = "Type of the client as defined by the OAuth 2.1 specification.",
+        allowableValues = ["public", "confidential"]
+    )
+    val type: String,
+    @get:Schema(description = "Identifier of the audience this client belongs to.")
+    @get:JsonProperty("audience_id")
+    val audienceId: String,
+    @get:Schema(description = "Redirect URIs the client is allowed to use during authorization.")
+    @get:JsonProperty("allowed_redirect_uris")
+    val allowedRedirectUris: List<String>
+)

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminClientControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminClientControllerTest.kt
@@ -3,6 +3,7 @@ package com.sympauthy.api.controller.admin
 import com.sympauthy.api.exception.LocalizedHttpException
 import com.sympauthy.api.mapper.admin.AdminClientResourceMapper
 import com.sympauthy.api.resource.admin.AdminClientResource
+import com.sympauthy.api.resource.admin.AdminClientSummaryResource
 import com.sympauthy.api.util.DEFAULT_PAGE
 import com.sympauthy.api.util.DEFAULT_PAGE_SIZE
 import com.sympauthy.business.manager.ClientManager
@@ -36,24 +37,35 @@ class AdminClientControllerTest {
         every { this@mockk.id } returns id
     }
 
+    private fun mockSummaryResource(clientId: String): AdminClientSummaryResource = AdminClientSummaryResource(
+        clientId = clientId,
+        type = "confidential",
+        audienceId = "default",
+        allowedRedirectUris = emptyList()
+    )
+
     private fun mockResource(clientId: String): AdminClientResource = AdminClientResource(
         clientId = clientId,
         type = "confidential",
+        audienceId = "default",
+        allowedGrantTypes = listOf("authorization_code"),
+        authorizationFlowId = null,
         allowedScopes = emptyList(),
         defaultScopes = emptyList(),
-        allowedRedirectUris = emptyList()
+        allowedRedirectUris = emptyList(),
+        authorizationWebhook = null
     )
 
     @Test
     fun `listClients - Return paginated list with defaults`() = runTest {
         val client1 = mockClient("c1")
         val client2 = mockClient("c2")
-        val resource1 = mockResource("c1")
-        val resource2 = mockResource("c2")
+        val resource1 = mockSummaryResource("c1")
+        val resource2 = mockSummaryResource("c2")
 
         coEvery { clientManager.listClients() } returns listOf(client1, client2)
-        every { clientMapper.toResource(client1) } returns resource1
-        every { clientMapper.toResource(client2) } returns resource2
+        every { clientMapper.toSummaryResource(client1) } returns resource1
+        every { clientMapper.toSummaryResource(client2) } returns resource2
 
         val result = controller.listClients(null, null)
 
@@ -68,11 +80,11 @@ class AdminClientControllerTest {
     @Test
     fun `listClients - Apply page and size`() = runTest {
         val clients = (1..5).map { mockClient("c$it") }
-        val resources = (1..5).map { mockResource("c$it") }
+        val resources = (1..5).map { mockSummaryResource("c$it") }
 
         coEvery { clientManager.listClients() } returns clients
         clients.forEachIndexed { i, client ->
-            every { clientMapper.toResource(client) } returns resources[i]
+            every { clientMapper.toSummaryResource(client) } returns resources[i]
         }
 
         val result = controller.listClients(1, 2)


### PR DESCRIPTION
## Summary
- Slim down the list endpoint (`GET /api/v1/admin/clients`) to only return client_id, type, audience_id, and allowed_redirect_uris
- Enrich the details endpoint (`GET /api/v1/admin/clients/{clientId}`) with audience_id, allowed_grant_types, authorization_flow_id, and authorization_webhook

Closes #236

## Test plan
- [x] `GET /api/v1/admin/clients` returns the slimmed-down summary fields only
- [x] `GET /api/v1/admin/clients/{clientId}` returns all new fields (grant types, flow id, webhook)
- [x] Webhook secret is never exposed in the response
- [x] Compile and run tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)