### PR TITLE
Migrate to Micronaut 5.0.5 and Gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,9 @@
-buildscript {
-    val kotlinVersion = project.findProperty("kotlinVersion")
-    val micronautPluginVersion = project.findProperty("micronautPluginVersion")
-    val kspGradlePluginVersion = project.findProperty("kspGradlePluginVersion")
-
-    repositories {
-        gradlePluginPortal()
-    }
-
-    dependencies {
-        classpath("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:$kotlinVersion")
-        classpath("org.jetbrains.kotlin.kapt:org.jetbrains.kotlin.kapt.gradle.plugin:$kotlinVersion")
-        classpath("org.jetbrains.kotlin.plugin.allopen:org.jetbrains.kotlin.plugin.allopen.gradle.plugin:$kotlinVersion")
-        classpath("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$kspGradlePluginVersion")
-        classpath("io.micronaut.gradle:micronaut-gradle-plugin:$micronautPluginVersion")
-    }
+plugins {
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.kotlin.allopen) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.micronaut.application) apply false
 }
 
 allprojects {
@@ -21,21 +11,6 @@ allprojects {
 
     version = "0.5.0"
     group = "com.sympauthy"
-
-    extra.apply {
-        set("kotlinVersion", project.findProperty("kotlinVersion"))
-        set("kotlinCoroutinesVersion", "1.11.0")
-        set("mapStructVersion", "1.6.3")
-        set("jsonPathVersion", "3.0.0")
-        set("bouncyCastleVersion", "1.85")
-        set("freemarkerVersion", "2.3.34")
-        set("evalExVersion", "3.7.0")
-
-        // Test dependencies
-        set("junitJupiterVersion", "6.1.2")
-        set("mockkVersion", "1.14.11")
-        set("mockWebServerVersion", "5.4.0")
-    }
 
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,3 @@
-micronautPluginVersion=5.0.2
-micronautVersion=4.10.6
-kotlinVersion=2.4.10
-kspGradlePluginVersion=2.3.10
 kapt.use.k2=true
 ksp.incremental=false
 org.gradle.jvmargs=-Xmx2g -Xms512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,45 @@
+[versions]
+# Platform / framework
+micronaut = "5.0.5"
+# Gradle plugins
+micronaut-plugin = "5.0.2"
+kotlin = "2.4.10"
+ksp = "2.3.10"
+# Pinned third-party libraries
+kotlinx-coroutines = "1.11.0"
+mapstruct = "1.6.3"
+json-path = "3.0.0"
+bouncycastle = "1.85"
+freemarker = "2.3.34"
+evalex = "3.7.0"
+jakarta-persistence = "3.2.0"
+# Test
+junit-jupiter = "6.1.2"
+mockk = "1.14.11"
+mock-webserver = "5.4.0"
+
+[libraries]
+# Platform BOM — the Micronaut Gradle plugin resolves the platform version from this "micronaut-platform" alias.
+micronaut-platform = { module = "io.micronaut.platform:micronaut-platform", version.ref = "micronaut" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-rx3 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx3", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jakarta-persistence" }
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
+mapstruct = { module = "org.mapstruct:mapstruct", version.ref = "mapstruct" }
+mapstruct-processor = { module = "org.mapstruct:mapstruct-processor", version.ref = "mapstruct" }
+json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "json-path" }
+evalex = { module = "com.ezylang:EvalEx", version.ref = "evalex" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mock-webserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mock-webserver" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+micronaut-application = { id = "io.micronaut.application", version.ref = "micronaut-plugin" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -2,19 +2,19 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.kotlin.kapt")
-    id("org.jetbrains.kotlin.plugin.allopen")
-    id("com.google.devtools.ksp")
-    id("io.micronaut.application")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.allopen)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.micronaut.application)
 }
 
 dependencies {
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-reflect:${project.extra["kotlinVersion"]}")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${project.extra["kotlinVersion"]}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutinesVersion"]}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx3:${project.extra["kotlinCoroutinesVersion"]}")
+    implementation(libs.kotlin.reflect)
+    implementation(libs.kotlin.stdlib.jdk8)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.rx3)
     implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
     implementation("io.micronaut.kotlin:micronaut-kotlin-extension-functions") {
         // micronaut-kotlin-extension-functions transitively pulls in micronaut-jackson-databind, which ships a
@@ -30,7 +30,7 @@ dependencies {
 
     // R2DBC Database
     api("io.micronaut.data:micronaut-data-r2dbc")
-    api("jakarta.persistence:jakarta.persistence-api:3.2.0")
+    api(libs.jakarta.persistence.api)
     ksp("io.micronaut.data:micronaut-data-processor")
 
     // Database migration
@@ -56,11 +56,11 @@ dependencies {
     implementation("io.micronaut.validation:micronaut-validation")
 
     // Security
-    ksp("io.micronaut.security:micronaut-security-annotations")
+    ksp("io.micronaut.security:micronaut-security-processor")
     implementation("io.micronaut.security:micronaut-security")
     implementation("io.micronaut.security:micronaut-security-oauth2")
     implementation("io.micronaut.security:micronaut-security-jwt")
-    implementation("org.bouncycastle:bcprov-jdk18on:${project.extra["bouncyCastleVersion"]}")
+    implementation(libs.bouncycastle.bcprov)
 
     // Reactive programming
     implementation("io.micronaut.rxjava3:micronaut-rxjava3")
@@ -71,15 +71,15 @@ dependencies {
 
     // Mail templating
     implementation("io.micronaut.email:micronaut-email-template")
-    runtimeOnly("org.freemarker:freemarker:${project.extra["freemarkerVersion"]}")
+    runtimeOnly(libs.freemarker)
 
     // Mail sending (SMTP)
     implementation("io.micronaut.email:micronaut-email-javamail")
     runtimeOnly("org.eclipse.angus:angus-mail")
 
     // Object mapping
-    api("org.mapstruct:mapstruct:${project.extra["mapStructVersion"]}")
-    kapt("org.mapstruct:mapstruct-processor:${project.extra["mapStructVersion"]}")
+    api(libs.mapstruct)
+    kapt(libs.mapstruct.processor)
 
     // Serialization/Deserialization
     ksp("io.micronaut.serde:micronaut-serde-processor")
@@ -99,21 +99,21 @@ dependencies {
     runtimeOnly("org.yaml:snakeyaml")
 
     // JsonPath: for user info extraction
-    implementation("com.jayway.jsonpath:json-path:${project.extra["jsonPathVersion"]}")
+    implementation(libs.json.path)
 
     // Health & Liveness endpoints
     implementation("io.micronaut:micronaut-management")
 
     // Expression evaluation: for scope granting rules
-    implementation("com.ezylang:EvalEx:${project.extra["evalExVersion"]}")
+    implementation(libs.evalex)
 
     // Testing
     kspTest("io.micronaut:micronaut-inject-java")
     testImplementation("io.micronaut.test:micronaut-test-junit5")
-    testImplementation("org.junit.jupiter:junit-jupiter:${project.extra["junitJupiterVersion"]}")
-    testImplementation("io.mockk:mockk:${project.extra["mockkVersion"]}")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${project.extra["kotlinCoroutinesVersion"]}")
-    testImplementation("com.squareup.okhttp3:mockwebserver:${project.extra["mockWebServerVersion"]}")
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mock.webserver)
     testImplementation(kotlin("test"))
 }
 

--- a/server/src/main/kotlin/com/sympauthy/api/controller/oauth2/util/ClientAuthenticationUtil.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/oauth2/util/ClientAuthenticationUtil.kt
@@ -47,7 +47,7 @@ class ClientAuthenticationUtil(
                 ?: throw oauth2ExceptionOf(INVALID_GRANT, "authentication.wrong", "description.authentication.wrong")
         }
         if (clientId != null) {
-            return clientManager.authenticateClientOrNull(clientId, clientSecret ?: "")
+            return clientManager.authenticateClientOrNull(clientId, clientSecret)
                 ?: throw oauth2ExceptionOf(INVALID_GRANT, "authentication.wrong", "description.authentication.wrong")
         }
         throw oauth2ExceptionOf(

--- a/server/src/main/kotlin/com/sympauthy/business/manager/ClientManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/ClientManager.kt
@@ -73,9 +73,15 @@ class ClientManager(
 
     /**
      * Return the [Client] identified by [clientId] if the [clientSecret] matches the one configured.
-     * Otherwise, return null whether no client matches or the secret does not match.
+     * Otherwise, return null whether a credential is missing, no client matches or the secret does not match.
+     *
+     * This method is reserved for confidential (private) clients: since it returns null when no [clientSecret] is
+     * provided, it cannot authenticate public clients. Use [findPublicClientByIdOrNull] to resolve a public client.
      */
-    suspend fun authenticateClientOrNull(clientId: String, clientSecret: String): Client? {
+    suspend fun authenticateClientOrNull(clientId: String?, clientSecret: String?): Client? {
+        if (clientId == null || clientSecret == null) {
+            return null
+        }
         return listClients().firstOrNull { it.id == clientId && it.secret == clientSecret }
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/business/model/provider/ProviderCredentials.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/provider/ProviderCredentials.kt
@@ -4,5 +4,5 @@ import io.micronaut.http.MutableHttpRequest
 
 interface ProviderCredentials {
 
-    fun <T> authenticate(httpRequest: MutableHttpRequest<T>)
+    fun <T : Any> authenticate(httpRequest: MutableHttpRequest<T>)
 }

--- a/server/src/main/kotlin/com/sympauthy/business/model/provider/oauth2/ProviderOAuth2Tokens.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/provider/oauth2/ProviderOAuth2Tokens.kt
@@ -9,7 +9,7 @@ data class ProviderOAuth2Tokens(
     val idToken: String? = null
 ) : ProviderCredentials {
 
-    override fun <T> authenticate(httpRequest: MutableHttpRequest<T>) {
+    override fun <T : Any> authenticate(httpRequest: MutableHttpRequest<T>) {
         httpRequest.bearerAuth(accessToken)
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/security/AccessTokenValidator.kt
+++ b/server/src/main/kotlin/com/sympauthy/security/AccessTokenValidator.kt
@@ -35,7 +35,7 @@ class AccessTokenValidator<T>(
     @Inject private val jwtManager: JwtManager
 ) : TokenValidator<T> {
 
-    override fun validateToken(token: String, request: T): Publisher<Authentication> = publish {
+    override fun validateToken(token: String, request: T?): Publisher<Authentication> = publish {
         val decodedToken = try {
             jwtManager.decodeAndVerify(ACCESS_KEY, token)
         } catch (e: LocalizedException) {

--- a/server/src/test/kotlin/com/sympauthy/security/StateAuthenticationFetcherTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/security/StateAuthenticationFetcherTest.kt
@@ -77,7 +77,7 @@ class StateAuthenticationFetcherTest {
         val request = mockk<HttpRequest<*>>()
         every { request.path } returns "/api/v1/flow/sign-in"
         every { request.method } returns HttpMethod.POST
-        every { request.headers.authorization } returns null
+        every { request.headers.authorization } returns Optional.empty()
 
         val result = fetcher.fetchAuthentication(request).asFlow().toList()
 


### PR DESCRIPTION
## Summary

Two combined changes:
1. **Gradle version catalog** — move all dependency version management into a new `gradle/libs.versions.toml` (single source of truth for plugin + third-party versions).
2. **Micronaut Platform 4.10.6 → 5.0.5** (latest major).

## Version catalog
- Root `build.gradle.kts`: `buildscript{}` classpath + `extra{}` block → catalog-driven `plugins { alias(...) apply false }`.
- `server/build.gradle.kts`: plugins via `alias(libs.plugins.*)`, deps via `libs.*` accessors.
- `gradle.properties`: trimmed to build-execution settings (`kapt.use.k2`, `ksp.incremental`, `org.gradle.jvmargs`).
- `settings.gradle.kts`: unchanged — Gradle auto-detects the catalog; the platform BOM version resolves from the `micronaut-platform` catalog alias (no `micronautVersion` property needed).
- BOM-managed `io.micronaut.*` modules stay versionless (governed by the platform BOM).

## Micronaut 5 source changes
- `ksp` processor rename: `micronaut-security-annotations` → `micronaut-security-processor`.
- `ClientManager.authenticateClientOrNull` now takes nullable credentials and returns `null` when either is missing (confidential-clients only); call sites drop the `?: ""` fallbacks.
- JSpecify nullability: `MutableHttpRequest<T : Any>` bound (`ProviderCredentials`, `ProviderOAuth2Tokens`), `TokenValidator.validateToken(request: T?)` (`AccessTokenValidator`), and `HttpHeaders.authorization` is now a non-null `Optional` (test mock uses `Optional.empty()`).

No changes needed for Jackson (annotations only, via `micronaut-serde`), RxJava (already v3), or the `@Embeddable` entity (already pins columns via `@MappedProperty`). The `micronaut-jackson-databind` exclude is retained.

## Verification
- `./gradlew help` — catalog + plugins resolve ✅
- Platform BOM resolves to **5.0.5** (`micronaut-core:5.0.6`) ✅
- `:server:compileKotlin` clean ✅
- `:server:test` — **630 tests, 0 failures** ✅
- `application.yml` `${version}` expansion intact ✅
- ⚠️ `:server:nativeCompile` **not run locally** (no GraalVM/`native-image` toolchain in the dev environment) — please confirm the native image gate in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)