### PR TITLE
Add end-to-end integration tests: native image on H2 and PostgreSQL (#259)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,115 @@
+# Integration tests — boots the SympAuthy native image (as a Docker container, via testcontainers-sympauthy)
+# and exercises it over real HTTP against H2 and PostgreSQL. See integration-tests/README.md.
+#
+# Reusable from release.yml / nightly-binaries.yml, where the Linux native binary already exists: pass
+# its artifact name via `binary-artifact` to skip a duplicate native build. Standalone (workflow_dispatch)
+# runs build the native image from source.
+
+name: Integration tests
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git reference to check out (must match the commit the binary was built from).
+        type: string
+        required: false
+        default: main
+      binary-artifact:
+        description: >-
+          Name of a pre-built Linux native binary artifact from this run to reuse (e.g.
+          sympauthy-linux-x64). When empty, the native image is built from source in this job.
+        type: string
+        required: false
+        default: ''
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git reference to build and test.
+        type: string
+        default: main
+
+permissions:
+  contents: read
+  # Required to resolve the testcontainers-sympauthy dependency from GitHub Packages. The package and
+  # the sympauthy/sympauthy repo are in the same org; if resolution is denied, grant this repo read
+  # access to the package (or use a PAT with read:packages).
+  packages: read
+
+jobs:
+  integration-test:
+    name: Native image + H2/PostgreSQL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Extract Java version from build script
+        id: java-version
+        shell: bash
+        run: |
+          VERSION=$(grep -E 'JavaVersion\.VERSION_[0-9]+' server/build.gradle.kts | grep -oE '[0-9]+$')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # --- Reuse a pre-built native binary (release / nightly) ------------------------------------
+      - name: Download pre-built native binary
+        if: inputs.binary-artifact != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.binary-artifact }}
+          path: .github/docker
+
+      - name: Stage downloaded binary for the Dockerfile
+        if: inputs.binary-artifact != ''
+        shell: bash
+        run: mv ".github/docker/${{ inputs.binary-artifact }}" .github/docker/sympauthy
+
+      - name: Setup JDK ${{ steps.java-version.outputs.version }}
+        if: inputs.binary-artifact != ''
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ steps.java-version.outputs.version }}
+          distribution: temurin
+
+      # --- Build the native image from source (standalone workflow_dispatch) ----------------------
+      - name: Create empty frontend resource dirs
+        if: inputs.binary-artifact == ''
+        shell: bash
+        # The flow driver hits SympAuthy's JSON API, not the bundled UI, so empty frontend bundles are fine.
+        run: mkdir -p server/src/main/resources/sympauthy-flow server/src/main/resources/sympauthy-admin
+
+      - name: Setup GraalVM for JDK ${{ steps.java-version.outputs.version }}
+        if: inputs.binary-artifact == ''
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: ${{ steps.java-version.outputs.version }}
+          distribution: graalvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build native image
+        if: inputs.binary-artifact == ''
+        shell: bash
+        run: |
+          ./gradlew :server:nativeCompile
+          cp server/build/native/nativeCompile/server .github/docker/sympauthy
+
+      # --- Package as a Docker image and run the suite against it ----------------------------------
+      - name: Build SympAuthy Docker image under test
+        shell: bash
+        run: docker build -t sympauthy:it -f .github/docker/Dockerfile .github/docker
+
+      - name: Run integration tests (H2 + PostgreSQL)
+        shell: bash
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :integration-tests:integrationTest -Dsympauthy.image=sympauthy:it
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-test-report
+          path: integration-tests/build/reports/tests/integrationTest
+          if-no-files-found: ignore

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -52,7 +52,16 @@ jobs:
           VERSION=$(grep -E 'JavaVersion\.VERSION_[0-9]+' server/build.gradle.kts | grep -oE '[0-9]+$')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      # --- Reuse a pre-built native binary (release / nightly) ------------------------------------
+      # Single toolchain for both paths: GraalVM runs Gradle for the integration tests, and provides
+      # native-image for the build-from-source path below.
+      - name: Setup GraalVM for JDK ${{ steps.java-version.outputs.version }}
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: ${{ steps.java-version.outputs.version }}
+          distribution: graalvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Provide the binary: reuse a pre-built one (release / nightly) ... -----------------------
       - name: Download pre-built native binary
         if: inputs.binary-artifact != ''
         uses: actions/download-artifact@v8
@@ -65,27 +74,12 @@ jobs:
         shell: bash
         run: mv ".github/docker/${{ inputs.binary-artifact }}" .github/docker/sympauthy
 
-      - name: Setup JDK ${{ steps.java-version.outputs.version }}
-        if: inputs.binary-artifact != ''
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ steps.java-version.outputs.version }}
-          distribution: temurin
-
-      # --- Build the native image from source (standalone workflow_dispatch) ----------------------
+      # --- ... or build the native image from source (standalone workflow_dispatch) ----------------
       - name: Create empty frontend resource dirs
         if: inputs.binary-artifact == ''
         shell: bash
         # The flow driver hits SympAuthy's JSON API, not the bundled UI, so empty frontend bundles are fine.
         run: mkdir -p server/src/main/resources/sympauthy-flow server/src/main/resources/sympauthy-admin
-
-      - name: Setup GraalVM for JDK ${{ steps.java-version.outputs.version }}
-        if: inputs.binary-artifact == ''
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: ${{ steps.java-version.outputs.version }}
-          distribution: graalvm
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build native image
         if: inputs.binary-artifact == ''

--- a/.github/workflows/nightly-binaries.yml
+++ b/.github/workflows/nightly-binaries.yml
@@ -116,6 +116,17 @@ jobs:
       runner: ${{ matrix.runner }}
       platform: ${{ matrix.platform }}
 
+  # Publication gate: publish_docker and publish_release depend on this job, so a failing integration
+  # run blocks the nightly image and release. Reuses the linux-x64 binary built above.
+  integration_test:
+    name: Integration tests
+    needs: [ should_build, build_linux_binary ]
+    if: needs.should_build.outputs.result == '1'
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      ref: ${{ inputs.ref || 'main' }}
+      binary-artifact: sympauthy-linux-x64
+
   build_macos_binary:
     needs: [ should_build, build_flow, build_admin ]
     if: needs.should_build.outputs.result == '1'
@@ -138,7 +149,7 @@ jobs:
       platform: ${{ matrix.platform }}
 
   publish_docker:
-    needs: [ should_build, build_linux_binary ]
+    needs: [ should_build, build_linux_binary, integration_test ]
     if: needs.should_build.outputs.result == '1'
     strategy:
       fail-fast: false
@@ -193,7 +204,7 @@ jobs:
 
   publish_release:
     name: Publish to nightly release
-    needs: [ should_build, build_linux_binary, build_macos_binary ]
+    needs: [ should_build, build_linux_binary, build_macos_binary, integration_test ]
     if: needs.should_build.outputs.result == '1'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,18 @@ jobs:
       runner: ${{ matrix.runner }}
       platform: ${{ matrix.platform }}
 
-  publish_docker:
+  # Publication gate: publish_docker and publish_release depend on this job, so a failing integration
+  # run blocks the release (image, binaries and version bump). Reuses the linux-x64 binary built above.
+  integration_test:
+    name: Integration tests
     needs: [ read_version, build_binary ]
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      ref: ${{ github.ref_name }}
+      binary-artifact: sympauthy-linux-x64
+
+  publish_docker:
+    needs: [ read_version, build_binary, integration_test ]
     strategy:
       fail-fast: false
       matrix:
@@ -191,7 +201,7 @@ jobs:
 
   publish_release:
     name: Publish GitHub release
-    needs: [ read_version, build_binary ]
+    needs: [ read_version, build_binary, integration_test ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,11 +17,10 @@ jakarta-persistence = "3.2.0"
 junit-jupiter = "6.1.2"
 mockk = "1.14.11"
 mock-webserver = "5.4.0"
-# Integration tests (integration-tests module)
-testcontainers = "2.0.5"
+# Integration tests (integration-tests module). testcontainers, nimbus-jose-jwt and slf4j are
+# intentionally unversioned: the module imports the Micronaut Platform BOM so those stay in sync with
+# the server. Only testcontainers-sympauthy (absent from the BOM) is pinned here.
 testcontainers-sympauthy = "0.1.0"
-nimbus-jose-jwt = "10.9.1"
-slf4j = "2.0.16"
 
 [libraries]
 # Platform BOM — the Micronaut Gradle plugin resolves the platform version from this "micronaut-platform" alias.
@@ -44,12 +43,12 @@ mock-webserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = 
 # Integration tests (integration-tests module)
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
-testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers-sympauthy = { module = "com.sympauthy:testcontainers-sympauthy", version.ref = "testcontainers-sympauthy" }
+# Versions supplied by the Micronaut Platform BOM (see integration-tests/build.gradle.kts).
 testcontainers = { module = "org.testcontainers:testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
-testcontainers-sympauthy = { module = "com.sympauthy:testcontainers-sympauthy", version.ref = "testcontainers-sympauthy" }
-nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ mock-webserver = "5.4.0"
 # Integration tests (integration-tests module). testcontainers, nimbus-jose-jwt and slf4j are
 # intentionally unversioned: the module imports the Micronaut Platform BOM so those stay in sync with
 # the server. Only testcontainers-sympauthy (absent from the BOM) is pinned here.
-testcontainers-sympauthy = "0.1.0"
+testcontainers-sympauthy = "0.1.1"
 
 [libraries]
 # Platform BOM — the Micronaut Gradle plugin resolves the platform version from this "micronaut-platform" alias.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,11 @@ jakarta-persistence = "3.2.0"
 junit-jupiter = "6.1.2"
 mockk = "1.14.11"
 mock-webserver = "5.4.0"
+# Integration tests (integration-tests module)
+testcontainers = "2.0.5"
+testcontainers-sympauthy = "0.1.0"
+nimbus-jose-jwt = "10.9.1"
+slf4j = "2.0.16"
 
 [libraries]
 # Platform BOM — the Micronaut Gradle plugin resolves the platform version from this "micronaut-platform" alias.
@@ -36,6 +41,15 @@ evalex = { module = "com.ezylang:EvalEx", version.ref = "evalex" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mock-webserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mock-webserver" }
+# Integration tests (integration-tests module)
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers = { module = "org.testcontainers:testcontainers" }
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
+testcontainers-sympauthy = { module = "com.sympauthy:testcontainers-sympauthy", version.ref = "testcontainers-sympauthy" }
+nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,95 @@
+# integration-tests
+
+End-to-end integration tests for SympAuthy. Each test boots the **SympAuthy native image as a Docker
+container** — via the [`testcontainers-sympauthy`](https://github.com/sympauthy/testcontainers-sympauthy)
+library — and drives it over real HTTP, against **each supported database (H2 and PostgreSQL)**.
+
+Unlike the unit tests in `:server` (JVM, mocked collaborators), these exercise the actual compiled
+binary end to end: native-image reflection/resource config, Flyway migrations, token signing, and the
+R2DBC dialect differences between H2 and PostgreSQL. They are therefore slower and require Docker, so
+they run **only** via the `integrationTest` task — never as part of `build`, `check` or `test`.
+
+## Layout
+
+```
+src/integrationTest/kotlin/com/sympauthy/it/
+├── SympauthyImage.kt       # resolves the image under test (system property → env var → nightly default)
+├── Database.kt             # database matrix: H2 and a PostgreSQL companion container
+├── AbstractSympauthyIT.kt  # shared config, container lifecycle, HTTP/JWKS/PKCE helpers
+├── feature/                # one class per user-facing flow, tagged "feature"
+│   └── AuthorizationCodeFeatureIT.kt         # authorization-code + PKCE flow yields signed tokens
+└── security/               # one class per risk scenario, tagged "security"
+    ├── Authorize303SeeOtherIT.kt             # authorize redirects with 303, never 307
+    └── TokenEndpointRejectsUnknownCodeIT.kt  # unknown authorization code is rejected with invalid_grant
+```
+
+**One scenario per class.** Each `*IT` class covers a single feature or risk and carries a class-level
+KDoc of *what* it exercises and, for security, *why it matters*. The test is a `@ParameterizedTest`
+over `@EnumSource(Database::class)`, so it runs once per database, and is tagged `feature` / `security`.
+
+**Comment convention.** The one-line descriptions in this tree are terse labels — a **lowercase,
+present-tense phrase with no trailing period** — stating a file's responsibility or the behaviour a
+scenario verifies (for security, the risk). Fuller prose (with normal capitalisation and punctuation)
+belongs in each class's KDoc, not the tree.
+
+## Requirements
+
+- **Docker** (or a compatible runtime: Podman, Colima, Rancher Desktop). Issuer/discovery URLs are
+  pinned to `http://localhost:<port>`, so a host-reachable daemon is assumed.
+- **JDK 25** (matches `:server`).
+- **A GitHub token with `read:packages`.** `testcontainers-sympauthy` is published to GitHub Packages,
+  which requires authentication even for public packages. Provide credentials via env vars
+  (`GITHUB_ACTOR` + `GITHUB_TOKEN`) or Gradle properties (`gpr.user` + `gpr.token`). The `gh` CLI token
+  works: `export GITHUB_TOKEN=$(gh auth token)`.
+
+## Running
+
+```bash
+export GITHUB_ACTOR=<your-github-username>
+export GITHUB_TOKEN=$(gh auth token)
+
+# Runs feature + security scenarios against H2 and PostgreSQL.
+./gradlew :integration-tests:integrationTest
+```
+
+By default the tests run against the **published nightly image**
+(`ghcr.io/sympauthy/sympauthy-nightly:latest`), which lets you run the harness without a GraalVM
+toolchain. Run a single scenario class with Gradle's test filter:
+
+```bash
+./gradlew :integration-tests:integrationTest --tests '*OAuth2SecurityIT'
+```
+
+### Testing a specific image
+
+Point the tests at any SympAuthy image with `-Dsympauthy.image=<ref>` (or the `SYMPAUTHY_IMAGE` env
+var). This is how CI validates the current commit: it builds the native binary, packages it as
+`sympauthy:it`, and runs the suite against that image. To reproduce locally (requires a GraalVM
+toolchain able to run `nativeCompile`):
+
+```bash
+# 1. Native build needs the frontend resource dirs to exist (empty is fine — the flow driver hits the
+#    JSON API, not the UI).
+mkdir -p server/src/main/resources/sympauthy-flow server/src/main/resources/sympauthy-admin
+
+# 2. Build the native binary and package it as a Docker image using the release Dockerfile.
+./gradlew :server:nativeCompile
+cp server/build/native/nativeCompile/server .github/docker/sympauthy
+docker build -t sympauthy:it .github/docker
+
+# 3. Run the suite against it.
+./gradlew :integration-tests:integrationTest -Dsympauthy.image=sympauthy:it
+```
+
+## Adding a scenario
+
+1. Create a new `*IT` class per scenario, extending `AbstractSympauthyIT`, with a class-level KDoc
+   stating the feature (or, for security, the risk being tested) and citing its **source** — the RFC
+   section, specification, or GitHub issue it comes from. Tag it `@Tag("feature")` or
+   `@Tag("security")` and make the test a `@ParameterizedTest @EnumSource(Database::class)`.
+2. Use `withContainer(database) { sympauthy, registry -> … }` to get a started container plus the mock
+   flow frontend; it tears everything down and dumps container logs on failure.
+3. Drive OAuth flows with `registry.newFlow()…run().exchange()`, or hit endpoints directly with the
+   `httpGet` / `httpPostForm` / `discovery` / `verifyIdTokenSignature` helpers.
+
+On failure, the SympAuthy container's logs are printed to stderr to make CI diagnostics actionable.

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,0 +1,81 @@
+import org.gradle.api.tasks.testing.logging.TestLogEvent.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+// End-to-end integration tests: boot the SympAuthy native image (as a Docker container, via the
+// `testcontainers-sympauthy` library) and exercise it over real HTTP against each supported database
+// (H2 and PostgreSQL). These tests require Docker and a published/built SympAuthy image, so they live
+// in a dedicated `integrationTest` source set and run only via `./gradlew :integration-tests:integrationTest`
+// — never as part of the default `build`/`check`/`test` lifecycle.
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+repositories {
+    mavenCentral()
+    // testcontainers-sympauthy is published to GitHub Packages. Even for public packages, GitHub
+    // requires an authenticated token with `read:packages`. Locally, export GITHUB_ACTOR + GITHUB_TOKEN
+    // (a PAT, e.g. `GITHUB_TOKEN=$(gh auth token)`); in CI the workflow's GITHUB_TOKEN is used.
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/sympauthy/testcontainers-sympauthy")
+        credentials {
+            username = System.getenv("GITHUB_ACTOR") ?: (findProperty("gpr.user") as String?)
+            password = System.getenv("GITHUB_TOKEN") ?: (findProperty("gpr.token") as String?)
+        }
+    }
+}
+
+// Container-starting tests live in their own source set so they never run under the default `test`
+// task (and therefore never under `check`/`build`), keeping Docker off the regular build path.
+val integrationTest: SourceSet = sourceSets.create("integrationTest")
+
+configurations["integrationTestImplementation"].extendsFrom(configurations["testImplementation"])
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
+
+dependencies {
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(platform(libs.testcontainers.bom))
+
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.sympauthy)
+    // Parse the OIDC discovery document and verify id_token signatures against the server's JWKS.
+    testImplementation(libs.nimbus.jose.jwt)
+
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.slf4j.simple)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+}
+
+tasks {
+    compileTestKotlin {
+        compilerOptions { jvmTarget.set(JvmTarget.JVM_25) }
+    }
+    named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileIntegrationTestKotlin") {
+        compilerOptions { jvmTarget.set(JvmTarget.JVM_25) }
+    }
+}
+
+// The integration-test task. Requires Docker. Point it at a specific image with
+// `-Dsympauthy.image=<ref>` (default: the published nightly image — see SympauthyImage).
+tasks.register<Test>("integrationTest") {
+    description = "Runs end-to-end integration tests that start the SympAuthy container (requires Docker)."
+    group = "verification"
+    useJUnitPlatform()
+    testClassesDirs = integrationTest.output.classesDirs
+    classpath = integrationTest.runtimeClasspath
+    // Forward the image override to the test JVM so `-Dsympauthy.image=…` on the Gradle command line works.
+    systemProperty("sympauthy.image", System.getProperty("sympauthy.image", ""))
+    shouldRunAfter("test")
+    testLogging {
+        // Container logs are dumped explicitly on failure (see AbstractSympauthyIT), so keep the
+        // default test output focused on outcomes rather than streaming every container log line.
+        events(PASSED, SKIPPED, FAILED)
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+}

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -34,8 +34,9 @@ configurations["integrationTestImplementation"].extendsFrom(configurations["test
 configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
 
 dependencies {
+    // Micronaut Platform BOM governs testcontainers, nimbus-jose-jwt and slf4j so they match the server.
+    testImplementation(platform(libs.micronaut.platform))
     testImplementation(platform(libs.junit.bom))
-    testImplementation(platform(libs.testcontainers.bom))
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.testcontainers)

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
@@ -1,0 +1,174 @@
+package com.sympauthy.it
+
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder
+import com.nimbusds.jose.proc.JWSVerificationKeySelector
+import com.nimbusds.jose.proc.SecurityContext
+import com.nimbusds.jose.util.JSONObjectUtils
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import com.sympauthy.testcontainers.SympauthyContainer
+import com.sympauthy.testcontainers.flow.InteractiveFlowRegistry
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * Shared support for the container-starting integration tests: a minimal SympAuthy configuration
+ * (password auth + email identifier + a public client wired to the mock frontend), container
+ * lifecycle with log capture on failure, and small HTTP/JWT helpers used by the scenarios.
+ *
+ * Each scenario boots a fresh container per [Database] so H2 and PostgreSQL are exercised identically.
+ */
+abstract class AbstractSympauthyIT {
+
+    protected val clientId: String = "test-app"
+
+    /**
+     * Password auth with an email identifier, plus the public client the tests own — wired to the mock
+     * frontend's callback and flow id. Only the `flows.<id>` definition is contributed by `withFlows`.
+     */
+    protected fun config(registry: InteractiveFlowRegistry): Map<String, Any> = mapOf(
+        "auth" to mapOf(
+            "by-password" to mapOf("enabled" to true),
+            "identifier-claims" to listOf("email"),
+        ),
+        "claims" to mapOf("email" to mapOf("enabled" to true)),
+        "clients" to mapOf(
+            registry.clientId() to mapOf(
+                "public" to true,
+                "authorizationFlow" to registry.flowId(),
+                "allowed-grant-types" to listOf("authorization_code"),
+                "allowed-scopes" to listOf("openid"),
+                "allowed-redirect-uris" to listOf(registry.redirectUri()),
+            ),
+        ),
+    )
+
+    /** A configured, not-yet-started container backed by [fixture] and wired to [registry]. */
+    private fun newContainer(
+        fixture: DatabaseFixture,
+        registry: InteractiveFlowRegistry,
+    ): SympauthyContainer = fixture
+        .applyTo(SympauthyContainer(SympauthyImage.resolve()).withConfig(config(registry)))
+        .withFlows(registry)
+
+    /**
+     * Starts a SympAuthy container backed by [database] with the mock flow frontend attached, runs
+     * [block] against it, and always tears both down. Dumps the container logs to stderr on failure to
+     * make CI diagnostics actionable.
+     */
+    protected fun withContainer(
+        database: Database,
+        block: (SympauthyContainer, InteractiveFlowRegistry) -> Unit,
+    ) {
+        database.createFixture().use { fixture ->
+            InteractiveFlowRegistry.forClient(clientId).withScopes("openid").use { registry ->
+                newContainer(fixture, registry).use { sympauthy ->
+                    sympauthy.start()
+                    try {
+                        block(sympauthy, registry)
+                    } catch (failure: Throwable) {
+                        System.err.println("=== SYMPAUTHY CONTAINER LOGS ===")
+                        System.err.println(runCatching { sympauthy.logs }.getOrElse { "(logs unavailable: $it)" })
+                        throw failure
+                    }
+                }
+            }
+        }
+    }
+
+    // --- HTTP / JWT helpers -------------------------------------------------------------------------
+
+    /** The parsed OpenID Connect discovery document served by [sympauthy]. */
+    protected fun discovery(sympauthy: SympauthyContainer): Map<String, Any?> {
+        val response = httpGet(sympauthy.openIdConfigurationUrl, followRedirects = true)
+        check(response.statusCode() == 200) {
+            "discovery returned HTTP ${response.statusCode()}: ${response.body()}"
+        }
+        return JSONObjectUtils.parse(response.body())
+    }
+
+    /**
+     * Verifies [idToken] is genuinely signed by the key set [sympauthy] advertises at its `jwks_uri`,
+     * returning the validated claims. Throws if the signature does not verify against the JWKS.
+     */
+    protected fun verifyIdTokenSignature(sympauthy: SympauthyContainer, idToken: String): JWTClaimsSet {
+        val jwksUri = URI.create(discovery(sympauthy)["jwks_uri"] as String).toURL()
+        val signedJwt = SignedJWT.parse(idToken)
+        val jwkSource = JWKSourceBuilder.create<SecurityContext>(jwksUri).build()
+        val processor = DefaultJWTProcessor<SecurityContext>().apply {
+            jwsKeySelector = JWSVerificationKeySelector(signedJwt.header.algorithm, jwkSource)
+        }
+        return processor.process(signedJwt, null)
+    }
+
+    /**
+     * Builds a valid authorization request URL for the mock frontend's public client (with a fresh
+     * PKCE challenge). Pass [overrides] to change individual query parameters for a specific scenario.
+     */
+    protected fun authorizeUrl(
+        sympauthy: SympauthyContainer,
+        registry: InteractiveFlowRegistry,
+        overrides: Map<String, String> = emptyMap(),
+    ): String {
+        val params = linkedMapOf(
+            "response_type" to "code",
+            "client_id" to registry.clientId(),
+            "redirect_uri" to registry.redirectUri(),
+            "scope" to "openid",
+            "state" to "integration-test-state",
+            "code_challenge" to generatePkce().challenge,
+            "code_challenge_method" to "S256",
+        )
+        params.putAll(overrides)
+        val query = params.entries.joinToString("&") { (key, value) -> "${encode(key)}=${encode(value)}" }
+        return "${discovery(sympauthy)["authorization_endpoint"]}?$query"
+    }
+
+    protected fun httpGet(url: String, followRedirects: Boolean = false): HttpResponse<String> =
+        client(followRedirects).send(
+            HttpRequest.newBuilder(URI.create(url)).header("Accept", "application/json").GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    protected fun httpPostForm(url: String, form: Map<String, String>): HttpResponse<String> =
+        client(followRedirects = false).send(
+            HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(formEncode(form)))
+                .build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun client(followRedirects: Boolean): HttpClient = HttpClient.newBuilder()
+        .followRedirects(if (followRedirects) HttpClient.Redirect.NORMAL else HttpClient.Redirect.NEVER)
+        .build()
+
+    protected fun formEncode(form: Map<String, String>): String =
+        form.entries.joinToString("&") { (key, value) -> "${encode(key)}=${encode(value)}" }
+
+    protected fun encode(value: String): String =
+        java.net.URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    /** A PKCE verifier/challenge pair (S256), matching what a public client must send. */
+    protected fun generatePkce(): Pkce {
+        val verifier = base64Url(ByteArray(32).also { SecureRandom().nextBytes(it) })
+        val challenge = base64Url(
+            MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(StandardCharsets.US_ASCII)),
+        )
+        return Pkce(verifier, challenge)
+    }
+
+    private fun base64Url(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    /** A PKCE verifier and its S256 challenge. */
+    protected data class Pkce(val verifier: String, val challenge: String, val method: String = "S256")
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/Database.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/Database.kt
@@ -1,0 +1,72 @@
+package com.sympauthy.it
+
+import com.sympauthy.testcontainers.SympauthyContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.postgresql.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * A database backing a [SympauthyContainer] for a single test run. Each scenario runs against every
+ * [Database] via `@EnumSource`, so the same behaviour is exercised on both supported datasources.
+ */
+enum class Database(private val fixtureFactory: () -> DatabaseFixture) {
+
+    /** SympAuthy's default in-memory H2 datasource — nothing extra to start. */
+    H2({ DatabaseFixture.H2 }),
+
+    /** A companion PostgreSQL container SympAuthy reaches over a shared Docker network. */
+    POSTGRES({ DatabaseFixture.Postgres() });
+
+    fun createFixture(): DatabaseFixture = fixtureFactory()
+}
+
+/**
+ * Wires a database into a [SympauthyContainer] before it starts, and owns the lifecycle of any
+ * companion container. Close it (after the SympAuthy container) to release those resources.
+ */
+sealed interface DatabaseFixture : AutoCloseable {
+
+    /** Applies datasource/network settings to [container] before startup, returning it for chaining. */
+    fun applyTo(container: SympauthyContainer): SympauthyContainer
+
+    /** Default in-memory H2 (the container's own default): nothing to wire, nothing to close. */
+    data object H2 : DatabaseFixture {
+        override fun applyTo(container: SympauthyContainer): SympauthyContainer = container
+        override fun close() = Unit
+    }
+
+    /**
+     * A PostgreSQL container on a dedicated network; SympAuthy joins the same network and connects via
+     * the [ALIAS] network alias (host `localhost` port mappings are not reachable between containers).
+     */
+    class Postgres : DatabaseFixture {
+
+        private val network: Network = Network.newNetwork()
+
+        private val postgres: PostgreSQLContainer = PostgreSQLContainer(DockerImageName.parse(IMAGE))
+            .withNetwork(network)
+            .withNetworkAliases(ALIAS)
+            .withDatabaseName(DATABASE)
+            .withUsername(USERNAME)
+            .withPassword(PASSWORD)
+            .also { it.start() }
+
+        override fun applyTo(container: SympauthyContainer): SympauthyContainer = container
+            .withNetwork(network)
+            .withDatasource("r2dbc:postgresql://$ALIAS:$PORT/$DATABASE", USERNAME, PASSWORD)
+
+        override fun close() {
+            postgres.stop()
+            network.close()
+        }
+
+        private companion object {
+            const val IMAGE = "postgres:17-alpine"
+            const val ALIAS = "postgres"
+            const val PORT = 5432
+            const val DATABASE = "sympauthy"
+            const val USERNAME = "sympauthy"
+            const val PASSWORD = "sympauthy"
+        }
+    }
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/SympauthyImage.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/SympauthyImage.kt
@@ -1,0 +1,35 @@
+package com.sympauthy.it
+
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Resolves the SympAuthy Docker image the integration tests run against.
+ *
+ * Resolution order (first non-blank wins):
+ *  1. the `sympauthy.image` system property (e.g. `-Dsympauthy.image=sympauthy:it`),
+ *  2. the `SYMPAUTHY_IMAGE` environment variable,
+ *  3. the published nightly image [DEFAULT_IMAGE].
+ *
+ * CI builds a `sympauthy:it` image from the current commit's native binary and passes it via the
+ * system property, so the pipeline validates the code under test. Locally, the default nightly image
+ * lets the harness run without a GraalVM toolchain.
+ */
+object SympauthyImage {
+
+    /** Published image the library declares its container compatible with; also the default we run. */
+    const val DEFAULT_IMAGE = "ghcr.io/sympauthy/sympauthy-nightly:latest"
+
+    /** Repository any override image must be declared a compatible substitute for. */
+    private const val COMPATIBLE_REPOSITORY = "ghcr.io/sympauthy/sympauthy-nightly"
+
+    fun resolve(): DockerImageName {
+        val reference = System.getProperty("sympauthy.image").orNull()
+            ?: System.getenv("SYMPAUTHY_IMAGE").orNull()
+            ?: DEFAULT_IMAGE
+        // A locally built image (e.g. `sympauthy:it`) has a different repository, so it must be
+        // explicitly declared a compatible substitute or SympauthyContainer's constructor rejects it.
+        return DockerImageName.parse(reference).asCompatibleSubstituteFor(COMPATIBLE_REPOSITORY)
+    }
+
+    private fun String?.orNull(): String? = this?.trim()?.takeIf { it.isNotEmpty() }
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AuthorizationCodeFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AuthorizationCodeFeatureIT.kt
@@ -28,14 +28,12 @@ class AuthorizationCodeFeatureIT : AbstractSympauthyIT() {
     @EnumSource(Database::class)
     fun signsUpAndExchangesCodeForSignedTokens(database: Database) {
         withContainer(database) { sympauthy, registry ->
-            val steps = mutableListOf<FlowStep.Type>()
             val flow = registry.newFlow()
                 .withSignUpHandler { mapOf("email" to "ada@example.com", "password" to "Str0ngP@ssw0rd!") }
-                .withStepListener { steps.add(it.type()) }
 
             val result = flow.run()
 
-            assertEquals(listOf(FlowStep.Type.SIGN_UP, FlowStep.Type.COMPLETED), steps)
+            assertEquals(listOf(FlowStep.Type.SIGN_UP, FlowStep.Type.COMPLETED), flow.stepTypes())
             assertNotNull(result.code(), "should receive an authorization code")
 
             val tokens = result.exchange()

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AuthorizationCodeFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AuthorizationCodeFeatureIT.kt
@@ -1,0 +1,55 @@
+package com.sympauthy.it.feature
+
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import com.sympauthy.testcontainers.flow.FlowStep
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Feature scenario — **OAuth 2.1 authorization-code grant with PKCE, from sign-up to signed tokens.**
+ *
+ * A user signs up through the mock interactive frontend, the captured authorization code is exchanged
+ * at the token endpoint, and the returned id_token is verified against the key set the server
+ * advertises at its `jwks_uri`. This proves the end-to-end flow, token issuance and JWT signing all
+ * work on the running native image, against each supported database.
+ *
+ * Reference: [RFC 7636 (PKCE)](https://datatracker.ietf.org/doc/html/rfc7636) and
+ * [OpenID Connect Core 1.0, ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken).
+ */
+@Tag("feature")
+class AuthorizationCodeFeatureIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "authorization code + PKCE yields a signed id_token on {0}")
+    @EnumSource(Database::class)
+    fun signsUpAndExchangesCodeForSignedTokens(database: Database) {
+        withContainer(database) { sympauthy, registry ->
+            val steps = mutableListOf<FlowStep.Type>()
+            val flow = registry.newFlow()
+                .withSignUpHandler { mapOf("email" to "ada@example.com", "password" to "Str0ngP@ssw0rd!") }
+                .withStepListener { steps.add(it.type()) }
+
+            val result = flow.run()
+
+            assertEquals(listOf(FlowStep.Type.SIGN_UP, FlowStep.Type.COMPLETED), steps)
+            assertNotNull(result.code(), "should receive an authorization code")
+
+            val tokens = result.exchange()
+            assertNotNull(tokens.accessToken(), "token response should carry an access token")
+            assertNotNull(tokens.idToken(), "the openid scope should yield an id_token")
+
+            // Verify the id_token is genuinely signed by the key the server publishes at its jwks_uri.
+            val claims = verifyIdTokenSignature(sympauthy, tokens.idToken())
+            assertEquals(sympauthy.issuerUrl, claims.issuer, "id_token should be issued by this container")
+            assertTrue(
+                claims.audience.contains(clientId),
+                "id_token audience should be the client, was: ${claims.audience}",
+            )
+            assertNotNull(claims.subject, "id_token should identify a subject")
+        }
+    }
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/Authorize303SeeOtherIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/Authorize303SeeOtherIT.kt
@@ -1,0 +1,42 @@
+package com.sympauthy.it.security
+
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Security scenario — **the authorization endpoint must redirect with `303 See Other`, never a
+ * `307 Temporary Redirect`.**
+ *
+ * Risk: OAuth 2.1 forbids 307 on the authorization endpoint because a 307 preserves the original HTTP
+ * method and body, so a browser would **re-submit the POST body — including credentials — to the
+ * redirect target**. A 303 forces the user-agent to follow up with a GET, dropping the body. Regressing
+ * this (e.g. returning 302/307) would leak credentials to downstream URLs.
+ *
+ * This verifies a valid authorize request on the running native image is answered with a 303, on each
+ * supported database.
+ *
+ * Source: [OAuth 2.1, HTTP 307 Redirect](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-http-307-redirect).
+ */
+@Tag("security")
+class Authorize303SeeOtherIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "authorize redirects with 303 See Other (never 307) on {0}")
+    @EnumSource(Database::class)
+    fun authorizeRedirectsWith303SeeOther(database: Database) {
+        withContainer(database) { sympauthy, registry ->
+            val response = httpGet(authorizeUrl(sympauthy, registry), followRedirects = false)
+
+            assertEquals(
+                303,
+                response.statusCode(),
+                "authorize must redirect with 303 See Other (OAuth 2.1 forbids 307), was ${response.statusCode()}",
+            )
+            assertNotEquals(307, response.statusCode(), "authorize must never use a 307 Temporary Redirect")
+        }
+    }
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenEndpointRejectsUnknownCodeIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenEndpointRejectsUnknownCodeIT.kt
@@ -1,0 +1,51 @@
+package com.sympauthy.it.security
+
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Security scenario — **the token endpoint must reject an authorization code it never issued with
+ * `invalid_grant` (HTTP 400), not mint tokens.**
+ *
+ * Risk: the authorization-code grant is the linchpin of the flow. If the token endpoint accepted (or
+ * leaked information about) codes it did not issue, an attacker could forge or brute-force codes to
+ * obtain tokens without ever authenticating a user. Per RFC 6749 an unknown/expired/revoked code must
+ * be answered with `invalid_grant`.
+ *
+ * This posts a made-up code to the token endpoint of the running native image and asserts a 400
+ * `invalid_grant`, on each supported database.
+ *
+ * Source: [RFC 6749 §5.2 (invalid_grant)](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2)
+ * and [§10.5 (authorization code security)](https://datatracker.ietf.org/doc/html/rfc6749#section-10.5).
+ */
+@Tag("security")
+class TokenEndpointRejectsUnknownCodeIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "token endpoint rejects an unknown code with invalid_grant on {0}")
+    @EnumSource(Database::class)
+    fun tokenEndpointRejectsUnknownCodeWithInvalidGrant(database: Database) {
+        withContainer(database) { sympauthy, registry ->
+            val response = httpPostForm(
+                discovery(sympauthy)["token_endpoint"] as String,
+                mapOf(
+                    "grant_type" to "authorization_code",
+                    "code" to "this-code-was-never-issued",
+                    "redirect_uri" to registry.redirectUri(),
+                    "client_id" to registry.clientId(),
+                    "code_verifier" to generatePkce().verifier,
+                ),
+            )
+
+            assertEquals(400, response.statusCode(), "unknown code must be rejected, body=${response.body()}")
+            assertTrue(
+                response.body().contains("invalid_grant"),
+                "expected an invalid_grant error, was: ${response.body()}",
+            )
+        }
+    }
+}

--- a/integration-tests/src/integrationTest/resources/simplelogger.properties
+++ b/integration-tests/src/integrationTest/resources/simplelogger.properties
@@ -1,0 +1,9 @@
+# Keep integration-test output readable: Testcontainers logs container pulls, wait-strategy retries and
+# lifecycle at INFO (with stack traces on transient startup polls). Raise its floor to WARN; the
+# SympAuthy container's own logs are still fetched and printed on failure (see AbstractSympauthyIT).
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.log.org.testcontainers=warn
+org.slf4j.simpleLogger.log.tc=warn
+org.slf4j.simpleLogger.log.com.github.dockerjava=warn
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,3 +2,4 @@
 rootProject.name = "sympauthy"
 
 include("server")
+include("integration-tests")


### PR DESCRIPTION
Closes #259.

Walking skeleton for end-to-end integration tests: a new `integration-tests` Kotlin module boots the
**SympAuthy native image as a Docker container** (via [`testcontainers-sympauthy`](https://github.com/sympauthy/testcontainers-sympauthy))
and drives it over real HTTP against **each supported database — H2 and PostgreSQL**.

## What's included

- **New `integration-tests` module** — wired into the version catalog and `settings.gradle.kts`, kept
  **off the default `build`/`check`/`test` path** (own `integrationTest` task, requires Docker). Verified
  `:integration-tests:check` is `NO-SOURCE`.
- **Feature scenario** (`@Tag("feature")`) — authorization-code + PKCE, sign-up → token exchange, with
  the id_token verified against the server's advertised JWKS.
- **Security scenarios** (`@Tag("security")`, one class each, each citing its RFC/spec source):
  - `Authorize303SeeOtherIT` — the authorize endpoint redirects with **303**, never **307** (OAuth 2.1).
  - `TokenEndpointRejectsUnknownCodeIT` — an unknown authorization code is rejected with `invalid_grant`.
- Every scenario is a `@ParameterizedTest` over `@EnumSource(Database::class)`, so it runs on **H2 and
  PostgreSQL** (a companion `PostgreSQLContainer` on a shared Docker network).
- **CI** — reusable `integration-test.yml` builds the native image, packages it as `sympauthy:it` and runs
  the suite (reusing the already-built Linux binary in release/nightly). Wired into `release.yml` and
  `nightly-binaries.yml` as a **publication gate**: a failing run blocks both the Docker image and the
  release.

## Image under test

Tests default to the published nightly image and accept `-Dsympauthy.image=<ref>`; CI builds an image from
the commit under test and passes `-Dsympauthy.image=sympauthy:it`. See `integration-tests/README.md`.

## Verification

Ran the full suite locally against `ghcr.io/sympauthy/sympauthy-nightly:latest` — **all 6 executions green**
(feature + both security scenarios, each on H2 and PostgreSQL). The current-commit native build can only run
in CI (no local GraalVM).

## CI-only caveat

Resolving `testcontainers-sympauthy` from GitHub Packages in CI relies on the Actions `GITHUB_TOKEN` having
cross-repo `read:packages` within the org. If denied, grant this repo read access to the package (or use a
PAT). Flagged in a comment in `integration-test.yml`.

## Follow-ups (separate issues)

Broader feature matrix (refresh/client-credentials/token-exchange/introspection/userinfo/MFA/admin) and
security matrix (redirect_uri exact-match, scope escalation, JWKS tamper, state/nonce, client auth, token
revocation cascade), plus additional databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)