### PR TITLE
Echo the OIDC nonce in the id_token

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowManager.kt
@@ -180,6 +180,7 @@ class WebAuthorizationFlowManager(
         val authorizeAttempt = authorizeAttemptManager.newAuthorizeAttempt(
             client = client,
             clientState = uncheckedClientState,
+            clientNonce = uncheckedClientNonce,
             authorizationFlow = flow,
             scopes = scopes,
             redirectUri = redirectUri,

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/WebAuthorizationFlowManagerTest.kt
@@ -876,6 +876,41 @@ class WebAuthorizationFlowManagerTest {
         assertEquals("my-state-value", stateSlot.captured)
     }
 
+    @Test
+    fun `startAuthorizationWith - Passes nonce to newAuthorizeAttempt`() = runTest {
+        val client = mockk<Client> {
+            every { authorizationFlow } returns null
+            every { `public` } returns false
+            every { supportsGrantType(any()) } returns true
+        }
+        setupDefaultFlow()
+        setupValidClient(client)
+        val nonceSlot = slot<String?>()
+        coEvery {
+            authorizeAttemptManager.newAuthorizeAttempt(
+                client = any(),
+                clientState = any(),
+                clientNonce = captureNullable(nonceSlot),
+                authorizationFlow = any(),
+                scopes = any(),
+                redirectUri = any(),
+                codeChallenge = any(),
+                codeChallengeMethod = any(),
+                error = any()
+            )
+        } returns mockk()
+
+        manager.startAuthorizationWith(
+            uncheckedClientId = "client",
+            uncheckedClientState = null,
+            uncheckedClientNonce = "my-nonce-value",
+            uncheckedScopes = null,
+            uncheckedRedirectUri = "https://example.com/callback"
+        )
+
+        assertEquals("my-nonce-value", nonceSlot.captured)
+    }
+
     // --- parseRequestedRedirectUri tests ---
 
     @Test


### PR DESCRIPTION
## Problem

The OpenID Connect `nonce` sent to the authorization endpoint is accepted but never returned in the `id_token`.

`WebAuthorizationFlowManager.startAuthorizationWith` receives the client-supplied nonce (`uncheckedClientNonce`) but never passes it to `newAuthorizeAttempt`, so it is dropped and never stored on the authorize attempt. Since the `id_token` is built from `AuthorizeAttempt.nonce`, it never carries a `nonce` claim.

This violates OpenID Connect Core 1.0 §3.1.3.6 — *"Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request"* — and weakens `id_token` replay/injection protection: a client that sent a `nonce` can no longer verify it.

## Fix

Pass `clientNonce = uncheckedClientNonce` to `newAuthorizeAttempt`. The rest of the plumbing (`newAuthorizeAttempt(clientNonce)` → `AuthorizeAttempt.nonce` → `IdTokenGenerator`) was already correct — only this one hand-off was missing.

Adds a unit test asserting the nonce reaches `newAuthorizeAttempt`.

## How it was found

The end-to-end security integration tests (#262) added an `IdTokenCarriesNonceIT` scenario, which failed against the server because the `nonce` claim came back `null`. That test is held in #262 until this fix lands, then will verify the behaviour on the native image against H2 and PostgreSQL.

## Verification

- `WebAuthorizationFlowManagerTest` (full class) — green.
- `./gradlew :server:compileKotlin` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
