### PR TITLE
Extract sign-in capabilities into dedicated GET /flow/sign-in API

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/ConfigurationController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/ConfigurationController.kt
@@ -1,18 +1,10 @@
 package com.sympauthy.api.controller.flow
 
-import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_AUTHORIZE_ENDPOINT
-import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_ENDPOINTS
 import com.sympauthy.api.controller.flow.util.WebAuthorizationFlowControllerUtil
 import com.sympauthy.api.resource.flow.*
-import com.sympauthy.business.manager.ClientManager
 import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.ClientManager
 import com.sympauthy.business.manager.flow.WebAuthorizationFlowPasswordManager
-import com.sympauthy.business.manager.provider.ProviderManager
-import com.sympauthy.business.model.provider.EnabledProvider
-import com.sympauthy.config.model.EnabledUrlsConfig
-import com.sympauthy.config.model.UrlsConfig
-import com.sympauthy.config.model.getUri
-import com.sympauthy.config.model.orThrow
 import com.sympauthy.security.SecurityRule.HAS_STATE
 import com.sympauthy.security.stateOrNull
 import com.sympauthy.server.DisplayMessages
@@ -25,8 +17,6 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.inject.Inject
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import java.util.*
 
 @Secured(HAS_STATE)
@@ -35,9 +25,7 @@ class ConfigurationController(
     @Inject private val claimManager: ClaimManager,
     @Inject private val clientManager: ClientManager,
     @Inject private val passwordFlowManager: WebAuthorizationFlowPasswordManager,
-    @Inject private val providerManager: ProviderManager,
     @Inject private val webAuthorizationFlowControllerUtil: WebAuthorizationFlowControllerUtil,
-    @Inject private val uncheckedUrlsConfig: UrlsConfig,
     @Inject @param:DisplayMessages private val displayMessageSource: MessageSource
 ) {
 
@@ -45,7 +33,7 @@ class ConfigurationController(
         description = """
 Return the configuration of the authentication flow associated to the client. It exposes information such as:
 - features that are enabled for the client.
-- third party providers that can be used to authenticate the end-user.
+- claims collectable by the authorization server.
 - etc.
 
 This configuration only contains information that are associated to this authorization server and the client,
@@ -60,30 +48,15 @@ they can be cached across the different end-users trying to authenticate.
     ): ConfigurationResource = webAuthorizationFlowControllerUtil.fetchOnGoingAttemptThenRun(
         state = authentication.stateOrNull
     ) { authorizeAttempt, _ ->
-        coroutineScope {
-            val locale = httpRequest.locale.orDefault()
-            val urlsConfig = uncheckedUrlsConfig.orThrow()
+        val locale = httpRequest.locale.orDefault()
 
-            val client = clientManager.findClientByIdOrNull(authorizeAttempt.clientId)
-            val audience = client?.audience
+        val client = clientManager.findClientByIdOrNull(authorizeAttempt.clientId)
+        val audience = client?.audience
 
-            val deferredClaims = async {
-                getCollectableClaims(locale)
-            }
-            val features = getFeatures(audience)
-            val deferredProviders = async {
-                providerManager.listEnabledProviders()
-                    .takeIf(List<EnabledProvider>::isNotEmpty)
-                    ?.map { getProvider(it, urlsConfig) }
-            }
-
-            ConfigurationResource(
-                claims = deferredClaims.await(),
-                features = features,
-                password = getPassword(),
-                providers = deferredProviders.await()
-            )
-        }
+        ConfigurationResource(
+            claims = getCollectableClaims(locale),
+            features = getFeatures(audience)
+        )
     }
 
     private fun getCollectableClaims(locale: Locale): List<CollectableClaimConfigurationResource> {
@@ -102,31 +75,9 @@ they can be cached across the different end-users trying to authenticate.
         audience: com.sympauthy.business.model.audience.Audience?
     ): FeaturesResource {
         return FeaturesResource(
-            passwordSignIn = passwordFlowManager.signInEnabled,
             signUp = passwordFlowManager.signUpEnabled,
             signUpEnabled = audience?.signUpEnabled ?: true,
             invitationEnabled = audience?.invitationEnabled ?: false,
-        )
-    }
-
-    private fun getPassword(): PasswordConfigurationResource {
-        return PasswordConfigurationResource(
-            identifierClaims = claimManager.listIdentifierClaims().map { it.id }
-        )
-    }
-
-    private fun getProvider(
-        provider: EnabledProvider,
-        urlsConfig: EnabledUrlsConfig
-    ): ProviderConfigurationResource {
-        val authorizeUrl = urlsConfig.getUri(
-            FLOW_PROVIDER_ENDPOINTS + FLOW_PROVIDER_AUTHORIZE_ENDPOINT,
-            "providerId" to provider.id
-        )
-        return ProviderConfigurationResource(
-            id = provider.id,
-            name = provider.name,
-            authorizeUrl = authorizeUrl.toString()
         )
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignInController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignInController.kt
@@ -1,26 +1,76 @@
 package com.sympauthy.api.controller.flow
 
+import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_AUTHORIZE_ENDPOINT
+import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_ENDPOINTS
 import com.sympauthy.api.controller.flow.util.WebAuthorizationFlowControllerUtil
+import com.sympauthy.api.resource.flow.PasswordConfigurationResource
+import com.sympauthy.api.resource.flow.ProviderConfigurationResource
+import com.sympauthy.api.resource.flow.SignInConfigurationResource
 import com.sympauthy.api.resource.flow.SignInInputResource
 import com.sympauthy.api.resource.flow.SimpleFlowResource
+import com.sympauthy.business.manager.ClaimManager
 import com.sympauthy.business.manager.flow.WebAuthorizationFlowPasswordManager
+import com.sympauthy.business.manager.provider.ProviderManager
+import com.sympauthy.business.model.provider.EnabledProvider
+import com.sympauthy.config.model.EnabledUrlsConfig
+import com.sympauthy.config.model.UrlsConfig
+import com.sympauthy.config.model.getUri
+import com.sympauthy.config.model.orThrow
 import com.sympauthy.security.SecurityRule.HAS_STATE
 import com.sympauthy.security.stateOrNull
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 
 @Controller("/api/v1/flow/sign-in")
 @Secured(HAS_STATE)
 class SignInController(
+    @Inject private val claimManager: ClaimManager,
     @Inject private val passwordFlowManager: WebAuthorizationFlowPasswordManager,
-    @Inject private val webAuthorizationFlowControllerUtil: WebAuthorizationFlowControllerUtil
+    @Inject private val providerManager: ProviderManager,
+    @Inject private val webAuthorizationFlowControllerUtil: WebAuthorizationFlowControllerUtil,
+    @Inject private val uncheckedUrlsConfig: UrlsConfig
 ) {
+
+    @Operation(
+        description = """
+Return the sign-in capabilities of this authorization server: the authentication methods the
+end-user can use to sign in, such as password-based authentication and the third-party providers
+that can be used to authenticate the end-user.
+
+This configuration only contains information that is associated to this authorization server and the
+client, they can be cached across the different end-users trying to authenticate.
+        """,
+        tags = ["flow"]
+    )
+    @Get
+    suspend fun getSignInConfiguration(
+        authentication: Authentication
+    ): SignInConfigurationResource = webAuthorizationFlowControllerUtil.fetchOnGoingAttemptThenRun(
+        state = authentication.stateOrNull
+    ) { _, _ ->
+        coroutineScope {
+            val urlsConfig = uncheckedUrlsConfig.orThrow()
+            val deferredProviders = async {
+                providerManager.listEnabledProviders()
+                    .takeIf(List<EnabledProvider>::isNotEmpty)
+                    ?.map { getProvider(it, urlsConfig) }
+            }
+            SignInConfigurationResource(
+                passwordSignIn = passwordFlowManager.signInEnabled,
+                password = getPassword(),
+                providers = deferredProviders.await()
+            )
+        }
+    }
 
     @Operation(
         description = "Sign-in using a login and a password.",
@@ -49,4 +99,28 @@ class SignInController(
             },
             mapRedirectUriToResource = { redirectUri -> SimpleFlowResource(redirectUri.toString()) }
         )
+
+    private fun getPassword(): PasswordConfigurationResource? {
+        if (!passwordFlowManager.signInEnabled) {
+            return null
+        }
+        return PasswordConfigurationResource(
+            identifierClaims = claimManager.listIdentifierClaims().map { it.id }
+        )
+    }
+
+    private fun getProvider(
+        provider: EnabledProvider,
+        urlsConfig: EnabledUrlsConfig
+    ): ProviderConfigurationResource {
+        val authorizeUrl = urlsConfig.getUri(
+            FLOW_PROVIDER_ENDPOINTS + FLOW_PROVIDER_AUTHORIZE_ENDPOINT,
+            "providerId" to provider.id
+        )
+        return ProviderConfigurationResource(
+            id = provider.id,
+            name = provider.name,
+            authorizeUrl = authorizeUrl.toString()
+        )
+    }
 }

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/ConfigurationResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/ConfigurationResource.kt
@@ -16,12 +16,7 @@ data class ConfigurationResource(
         description = "List of claims collectable by the authorization server."
     )
     val claims: List<CollectableClaimConfigurationResource>,
-    val features: FeaturesResource,
-    val password: PasswordConfigurationResource?,
-    @get:Schema(
-        description = "List of configuration of third-party providers."
-    )
-    val providers: List<ProviderConfigurationResource>?
+    val features: FeaturesResource
 )
 
 @Schema(
@@ -84,11 +79,6 @@ Ex. first name & last name are related to the identity of the end-user.
 @Serdeable
 data class FeaturesResource(
     @get:Schema(
-        description = "Authentication of the end-user using a login and a password couple."
-    )
-    @get:JsonProperty("password_sign_in")
-    val passwordSignIn: Boolean,
-    @get:Schema(
         description = "End-user account creation."
     )
     @get:JsonProperty("sign_up")
@@ -103,44 +93,4 @@ data class FeaturesResource(
     )
     @get:JsonProperty("invitation_enabled")
     val invitationEnabled: Boolean = false,
-)
-
-@Schema(
-    description = "Configuration related to a third-party provider that can be used by the end-user to authenticate."
-)
-@Serdeable
-data class ProviderConfigurationResource(
-    @get:Schema(
-        description = "Identifier of the third-party provider."
-    )
-    @get:JsonProperty("id")
-    val id: String,
-    @get:Schema(
-        description = "Name of the third-party provider as it should be displayed to the end-user."
-    )
-    @get:JsonProperty("name")
-    val name: String,
-    @get:Schema(
-        name = "authorize_url",
-        description = """
-URL to redirect the end-user to to initiate a authorization grant flow with the third-party provider.
-        """
-    )
-    @get:JsonProperty("authorize_url")
-    val authorizeUrl: String
-)
-
-@Schema(
-    description = """
-If null or not present, the authentication by password is disabled by the authorization server.
-"""
-)
-@Serdeable
-data class PasswordConfigurationResource(
-    @get:Schema(
-        name = "identifier_claims",
-        description = "List of claims that uniquely identify a user. Used as login for sign-in and as required claims for sign-up."
-    )
-    @get:JsonProperty("identifier_claims")
-    val identifierClaims: List<String>,
 )

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/SignInConfigurationResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/SignInConfigurationResource.kt
@@ -1,0 +1,68 @@
+package com.sympauthy.api.resource.flow
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = """
+Sign-in capabilities exposed by this authorization server: the authentication methods the end-user
+can use to sign in (password and/or third-party providers).
+
+For ALL URLs contained in this configuration, the state query param must be added by the client
+before using any of those urls.
+    """
+)
+@Serdeable
+data class SignInConfigurationResource(
+    @get:Schema(
+        description = "Authentication of the end-user using a login and a password couple."
+    )
+    @get:JsonProperty("password_sign_in")
+    val passwordSignIn: Boolean,
+    val password: PasswordConfigurationResource?,
+    @get:Schema(
+        description = "List of configuration of third-party providers."
+    )
+    val providers: List<ProviderConfigurationResource>?
+)
+
+@Schema(
+    description = """
+If null or not present, the authentication by password is disabled by the authorization server.
+"""
+)
+@Serdeable
+data class PasswordConfigurationResource(
+    @get:Schema(
+        name = "identifier_claims",
+        description = "List of claims that uniquely identify a user. Used as login for sign-in and as required claims for sign-up."
+    )
+    @get:JsonProperty("identifier_claims")
+    val identifierClaims: List<String>,
+)
+
+@Schema(
+    description = "Configuration related to a third-party provider that can be used by the end-user to authenticate."
+)
+@Serdeable
+data class ProviderConfigurationResource(
+    @get:Schema(
+        description = "Identifier of the third-party provider."
+    )
+    @get:JsonProperty("id")
+    val id: String,
+    @get:Schema(
+        description = "Name of the third-party provider as it should be displayed to the end-user."
+    )
+    @get:JsonProperty("name")
+    val name: String,
+    @get:Schema(
+        name = "authorize_url",
+        description = """
+URL to redirect the end-user to to initiate a authorization grant flow with the third-party provider.
+        """
+    )
+    @get:JsonProperty("authorize_url")
+    val authorizeUrl: String
+)


### PR DESCRIPTION
## Context

Today the front-end learns *which authentication methods are available* (password sign-in, identifier/login fields, social providers) by calling `GET /api/v1/flow/configuration`. That endpoint bundles four unrelated concerns into one `ConfigurationResource`:

- `claims` — collectable claims for the claim-collection step (not sign-in)
- `features` — `password_sign_in`, `sign_up`, `sign_up_enabled`, `invitation_enabled`
- `password` — `identifier_claims` (the login fields)
- `providers` — social sign-in buttons + `authorize_url`

Because the sign-in capability description is trapped inside this generic "flow configuration" object, nothing except the flow-configuration page can consume it, and there is no dedicated sign-in contract that can be evolved/reused independently.

## What changed

Sign-in gets its own API surface. The sign-in capability description (`password_sign_in`, `identifier_claims`, `providers`) moves out of `/flow/configuration` into a new `GET /api/v1/flow/sign-in` endpoint on the existing `SignInController` (which already owns that path for the `POST` sign-in action).

- **New** `SignInConfigurationResource { password_sign_in, password?, providers? }`; `PasswordConfigurationResource` / `ProviderConfigurationResource` relocated next to it.
- **`SignInController`** — new `GET /api/v1/flow/sign-in` (providers fetched concurrently); moved `getPassword()` / `getProvider()` helpers.
- **`ConfigurationResource`** — dropped `password` / `providers`; `FeaturesResource` no longer carries `password_sign_in`.
- **`ConfigurationController`** — removed the provider/password logic, the `providerManager` / `urlsConfig` injections and the now-unneeded `coroutineScope` / `async`.

The endpoint stays inside the web authorization flow (still `@Secured(HAS_STATE)`, still validates the ongoing authorize attempt via `state`) — this is an API reorganization, not a decoupling of the sign-in mechanism.

Small behavioral fix folded in: `password` is now `null` when password sign-in is disabled, matching the resource's own schema doc (previously it was always returned non-null).

## ⚠️ Breaking change

The external front-end must read `password` / `providers` / `password_sign_in` from `GET /api/v1/flow/sign-in` instead of `GET /api/v1/flow/configuration`. `/flow/configuration` still returns `claims` and the sign-up flags.

## Verification

- `./gradlew compileKotlin` — clean
- `./gradlew test` — full suite green
- No existing tests referenced the affected controllers/resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)