### PR TITLE
IT: sign-up collecting all OpenID claims, verified via admin API

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -63,23 +63,26 @@ toolchain. Run a single scenario class with Gradle's test filter:
 ### Testing a specific image
 
 Point the tests at any SympAuthy image with `-Dsympauthy.image=<ref>` (or the `SYMPAUTHY_IMAGE` env
-var). This is how CI validates the current commit: it builds the native binary, packages it as
-`sympauthy:it`, and runs the suite against that image. To reproduce locally (requires a GraalVM
-toolchain able to run `nativeCompile`):
+var). To validate the current commit locally, build a **JVM image** from the working tree — it needs no
+GraalVM toolchain and builds in seconds:
 
 ```bash
-# 1. Native build needs the frontend resource dirs to exist (empty is fine — the flow driver hits the
-#    JSON API, not the UI).
-mkdir -p server/src/main/resources/sympauthy-flow server/src/main/resources/sympauthy-admin
+# 1. Build a JVM Docker image from the current code (Micronaut tags it `server:latest`).
+./gradlew :server:dockerBuild
 
-# 2. Build the native binary and package it as a Docker image using the release Dockerfile.
-./gradlew :server:nativeCompile
-cp server/build/native/nativeCompile/server .github/docker/sympauthy
-docker build -t sympauthy:it .github/docker
-
-# 3. Run the suite against it.
-./gradlew :integration-tests:integrationTest -Dsympauthy.image=sympauthy:it
+# 2. Run the suite against it.
+./gradlew :integration-tests:integrationTest -Dsympauthy.image=server:latest
 ```
+
+> **JVM image vs. native image — mind the gap.** The default nightly image, and the `sympauthy:it`
+> image CI builds from each commit, are **GraalVM native images**; the `server:latest` image above runs
+> the same code on the **JVM**. They share all the application logic, so the JVM image is the fast way to
+> iterate on an integration test locally — but they are *not* the same runtime, and a scenario can pass
+> on one while failing on the other. Native compilation is closed-world: it strips anything not provably
+> reachable, so reflection, resource loading, dynamic proxies and serialization only work when declared
+> in the native metadata (`reflect-config.json` / `resource-config.json` — e.g. every MapStruct `*Impl`).
+> Missing metadata throws only at native runtime; on the JVM, which reflects freely, the same code just
+> works. Treat a green JVM run as necessary but not sufficient — CI's native run is the source of truth.
 
 ## Adding a scenario
 

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
@@ -119,16 +119,49 @@ abstract class AbstractSympauthyIT {
         database.createFixture().use { fixture ->
             InteractiveFlowRegistry.forClient(client).withScopes("openid").use { registry ->
                 newContainer(fixture, registry, extraConfig).use { sympauthy ->
-                    sympauthy.start()
-                    try {
-                        block(sympauthy, registry)
-                    } catch (failure: Throwable) {
-                        System.err.println("=== SYMPAUTHY CONTAINER LOGS ===")
-                        System.err.println(runCatching { sympauthy.logs }.getOrElse { "(logs unavailable: $it)" })
-                        throw failure
-                    }
+                    runStarted(sympauthy, registry, block)
                 }
             }
+        }
+    }
+
+    /**
+     * Starts a caller-configured container against [database], runs [block], and always tears down —
+     * dumping the container logs on failure like [withContainer]. Use this when a scenario must configure
+     * the container itself (the admin environment, an admin client, bootstrap invitations, a non-default
+     * claim set) rather than the shared [config]/public-client setup [withContainer] provides. [build]
+     * receives the created [DatabaseFixture] and the registry (whose client is [client]) and must return the
+     * fully configured, not-yet-started container — typically
+     * `fixture.applyTo(SympauthyContainer(SympauthyImage.resolve()).…)`.
+     */
+    protected fun withCustomContainer(
+        database: Database,
+        client: Client = Client.publicClient(clientId),
+        build: (DatabaseFixture, InteractiveFlowRegistry) -> SympauthyContainer,
+        block: (SympauthyContainer, InteractiveFlowRegistry) -> Unit,
+    ) {
+        database.createFixture().use { fixture ->
+            InteractiveFlowRegistry.forClient(client).use { registry ->
+                build(fixture, registry).use { sympauthy ->
+                    runStarted(sympauthy, registry, block)
+                }
+            }
+        }
+    }
+
+    /** Starts [sympauthy], runs [block], and dumps the container logs to stderr on any failure. */
+    private fun runStarted(
+        sympauthy: SympauthyContainer,
+        registry: InteractiveFlowRegistry,
+        block: (SympauthyContainer, InteractiveFlowRegistry) -> Unit,
+    ) {
+        sympauthy.start()
+        try {
+            block(sympauthy, registry)
+        } catch (failure: Throwable) {
+            System.err.println("=== SYMPAUTHY CONTAINER LOGS ===")
+            System.err.println(runCatching { sympauthy.logs }.getOrElse { "(logs unavailable: $it)" })
+            throw failure
         }
     }
 

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/SignUpWithAllOpenIdClaimFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/SignUpWithAllOpenIdClaimFeatureIT.kt
@@ -1,0 +1,154 @@
+package com.sympauthy.it.feature
+
+import com.nimbusds.jose.util.JSONObjectUtils
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import com.sympauthy.it.SympauthyImage
+import com.sympauthy.testcontainers.SympauthyContainer
+import com.sympauthy.testcontainers.flow.FlowStep
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Feature scenario — **sign up while collecting every standard OpenID claim, then verify each stored value.**
+ *
+ * A user signs up through the interactive flow with every standard OpenID claim enabled and required: the
+ * sign-up step takes the identifier + password, a single collect-claims step gathers all the remaining
+ * OpenID claims, and the flow completes and issues tokens. Every collected claim is then read back and
+ * asserted against the value it was signed up with. This proves end-to-end sign-up, multi-scope consent, the
+ * collect-claims step with per-type claim validation, and claim persistence all work on the running native
+ * image, against each supported database.
+ *
+ * The claims are read back through the admin user API (`GET /api/v1/admin/users/{userId}/claims`) — the most
+ * direct way to see every stored claim. Reaching that API needs an access token carrying the admin scopes, so
+ * the sign-up runs in the `admin` environment ([SympauthyContainer.withAdmin]) and redeems its `first-admin`
+ * bootstrap invitation: the invitation marks the new user `is_sympauthy_admin=true`, a scope-granting rule
+ * turns that into the admin scopes, and the flow's own access token can then call the admin API. The
+ * invitation is only the means to that assertion, not the subject of the test.
+ *
+ * Reference: [OpenID Connect Core 1.0, Standard Claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims).
+ */
+@Tag("feature")
+class SignUpWithAllOpenIdClaimFeatureIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "sign-up collects and verifies all OpenID claims on {0}")
+    @EnumSource(Database::class)
+    fun signsUpCollectingAllOpenIdClaims(database: Database) {
+        withCustomContainer(
+            database,
+            build = { fixture, registry ->
+                fixture.applyTo(
+                    SympauthyContainer(SympauthyImage.resolve())
+                        .withAdmin()
+                        .withConfig(passwordAndAllClaimsConfig())
+                        .withFlows(registry)
+                        .withAdminClient(registry, "profile", "email", "phone", "address", "admin:users:read"),
+                )
+            },
+        ) { sympauthy, registry ->
+            // Redeem the first-admin bootstrap invitation: sign up (identifier + password), then a single
+            // collect-claims step gathers every other required OpenID claim.
+            val invitationToken = sympauthy.getBootstrapInvitationToken("first-admin")
+            val flow = registry.newFlow()
+                .withInvitationToken(invitationToken)
+                .withSignUpHandler { mapOf("email" to EXPECTED.getValue("email"), "password" to PASSWORD) }
+                .withClaimsHandler { requested -> requested.associate { it.id() to EXPECTED.getValue(it.id()) } }
+
+            val result = flow.run()
+
+            assertEquals(
+                listOf(FlowStep.Type.SIGN_UP, FlowStep.Type.CLAIMS, FlowStep.Type.COMPLETED),
+                flow.stepTypes(),
+                "invitation routes to sign-up, then one collect-claims step, then completion",
+            )
+
+            val tokens = result.exchange()
+            assertNotNull(tokens.accessToken(), "token response should carry an access token")
+            assertTrue(
+                tokens.scope()?.split(" ")?.contains("admin:users:read") == true,
+                "the is_sympauthy_admin rule should grant the admin read scope, was: ${tokens.scope()}",
+            )
+
+            // The id_token subject is the user id; verifying it also proves the token is genuinely signed.
+            val idToken = requireNotNull(tokens.idToken()) { "the openid scope should yield an id_token" }
+            val userId = verifyIdTokenSignature(sympauthy, idToken).subject
+
+            // Read every collected claim back through the admin API using the token the flow just issued.
+            val response = httpGet(
+                "${sympauthy.baseUrl}/api/v1/admin/users/$userId/claims?size=100",
+                headers = mapOf("Authorization" to "Bearer ${tokens.accessToken()}"),
+            )
+            assertEquals(
+                200, response.statusCode(),
+                "admin claims API should authorize the granted token: ${response.body()}",
+            )
+
+            val values = (JSONObjectUtils.parse(response.body())["claims"] as List<*>)
+                .filterIsInstance<Map<String, Any?>>()
+                .associate { it["claim_id"] as String to it["value"] }
+
+            EXPECTED.forEach { (id, value) ->
+                assertEquals(value, values[id], "claim '$id' read back through the admin user API")
+            }
+            assertEquals(userId, values["sub"], "the generated 'sub' claim should equal the user id")
+            assertEquals(
+                "true", values["is_sympauthy_admin"],
+                "the invitation should have marked the user as an admin",
+            )
+        }
+    }
+
+    private companion object {
+
+        const val PASSWORD = "Str0ngP@ssw0rd!"
+
+        /**
+         * The value signed up for each standard OpenID claim, by claim id. Each value is valid for its
+         * claim's data type (see `ClaimValueValidator`): dates as `yyyy-MM-dd`, phone numbers as `+`
+         * followed by digits, `zoneinfo` an IANA zone id, `email` an `x@y` address, the rest plain strings.
+         * The keys also drive [passwordAndAllClaimsConfig] — enabling exactly the claims asserted here.
+         */
+        val EXPECTED: Map<String, String> = linkedMapOf(
+            "name" to "Ada Lovelace",
+            "given_name" to "Ada",
+            "family_name" to "Lovelace",
+            "middle_name" to "Augusta",
+            "nickname" to "Ada",
+            "preferred_username" to "ada.lovelace",
+            "profile" to "https://example.com/ada",
+            "picture" to "https://example.com/ada.png",
+            "website" to "https://ada.example.com",
+            "gender" to "female",
+            "birth_date" to "1815-12-10",
+            "zoneinfo" to "Europe/London",
+            "locale" to "en-GB",
+            "email" to "ada.lovelace@example.com",
+            "phone_number" to "+14155550100",
+            "street_address" to "12 Analytical Engine Way",
+            "locality" to "London",
+            "region" to "Greater London",
+            "postal_code" to "EC1A 1BB",
+            "country" to "GB",
+        )
+
+        /**
+         * Password auth with an email identifier, plus every standard OpenID claim enabled and required so
+         * the flow gathers them all. Claim keys mirror the underlying claim ids (see [EXPECTED]); the
+         * generated `sub` / `updated_at` claims are always on and need no configuration.
+         */
+        fun passwordAndAllClaimsConfig(): Map<String, Any> {
+            val enabledRequired = mapOf("enabled" to true, "required" to true)
+            return mapOf(
+                "auth" to mapOf(
+                    "by-password" to mapOf("enabled" to true),
+                    "identifier-claims" to listOf("email"),
+                ),
+                "claims" to EXPECTED.keys.associateWith { enabledRequired },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a feature integration test — `SignUpWithAllOpenIdClaimFeatureIT` — that exercises **sign-up while collecting every standard OpenID claim**, then verifies each stored value end-to-end on the running server, across **H2 and PostgreSQL**.

The flow:
1. Boot the container in the `admin` environment with all 20 standard OpenID claims enabled + required.
2. Sign up by redeeming the `first-admin` bootstrap invitation: identifier + password at the sign-up step, then a single collect-claims step gathers every remaining OpenID claim.
3. Exchange the code for tokens; the invitation's `is_sympauthy_admin=true` + the admin scope-granting rule put the admin scopes into the access token.
4. Read every collected claim back through `GET /api/v1/admin/users/{userId}/claims` and assert each value round-trips (plus generated `sub == userId` and `is_sympauthy_admin == "true"`).

The invitation + admin API are **only the means** to obtain an admin-scoped token for the read-back — sign-up with full claim collection is the subject of the test.

## Changes

- **`SignUpWithAllOpenIdClaimFeatureIT.kt`** (new) — the scenario above.
- **`AbstractSympauthyIT.kt`** — add `withCustomContainer(...)` so a scenario can build its own container (admin environment, admin client, custom claim set) while reusing the shared fixture/registry lifecycle and log-dump-on-failure; extract the shared start/teardown into a private `runStarted(...)`. `withContainer` delegates to it — existing scenarios are behaviorally unchanged.
- **`README.md`** — point the "Testing a specific image" section at a locally built **JVM** image (`:server:dockerBuild` → `server:latest`) instead of a native build, and add a callout explaining how JVM vs GraalVM-native runtime can diverge (closed-world native metadata: `reflect-config.json` / `resource-config.json`, MapStruct `*Impl`, etc.).

## Verification

`./gradlew :integration-tests:integrationTest --tests '*SignUpWithAllOpenIdClaimFeatureIT'` — **passes on H2 and PostgreSQL**, against both:
- the published nightly **native** image, and
- a locally built **JVM** image (`:server:dockerBuild`, `-Dsympauthy.image=server:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)