### PR TITLE
Sign-up config: expose identifier claims via PasswordResource.identifier_claims

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ mock-webserver = "5.4.0"
 # Integration tests (integration-tests module). testcontainers, nimbus-jose-jwt and slf4j are
 # intentionally unversioned: the module imports the Micronaut Platform BOM so those stay in sync with
 # the server. Only testcontainers-sympauthy (absent from the BOM) is pinned here.
-testcontainers-sympauthy = "0.3.0"
+testcontainers-sympauthy = "0.4.0"
 
 [libraries]
 # Platform BOM — the Micronaut Gradle plugin resolves the platform version from this "micronaut-platform" alias.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -45,7 +45,7 @@ belongs in each class's KDoc, not the tree.
 ## Running
 
 ```bash
-export GITHUB_ACTOR=<your-github-username>
+export GITHUB_ACTOR=$(gh api user --jq .login)
 export GITHUB_TOKEN=$(gh auth token)
 
 # Runs feature + security scenarios against H2 and PostgreSQL.
@@ -70,7 +70,11 @@ GraalVM toolchain and builds in seconds:
 # 1. Build a JVM Docker image from the current code (Micronaut tags it `server:latest`).
 ./gradlew :server:dockerBuild
 
-# 2. Run the suite against it.
+# 2. Authenticate to GitHub Packages so the testcontainers-sympauthy library resolves.
+export GITHUB_ACTOR=$(gh api user --jq .login)
+export GITHUB_TOKEN=$(gh auth token)
+
+# 3. Run the suite against it.
 ./gradlew :integration-tests:integrationTest -Dsympauthy.image=server:latest
 ```
 

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignInController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignInController.kt
@@ -3,6 +3,7 @@ package com.sympauthy.api.controller.flow
 import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_AUTHORIZE_ENDPOINT
 import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_ENDPOINTS
 import com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil
+import com.sympauthy.api.mapper.flow.CollectableClaimResourceMapper
 import com.sympauthy.api.resource.flow.PasswordResource
 import com.sympauthy.api.resource.flow.ProviderResource
 import com.sympauthy.api.resource.flow.SignInFlowResource
@@ -23,6 +24,8 @@ import com.sympauthy.config.model.getUri
 import com.sympauthy.config.model.orThrow
 import com.sympauthy.security.SecurityRule.HAS_STATE
 import com.sympauthy.security.stateOrNull
+import com.sympauthy.util.orDefault
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -32,6 +35,7 @@ import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.inject.Inject
+import java.util.Locale
 
 @Controller("/api/v1/flow/sign-in")
 @Secured(HAS_STATE)
@@ -42,6 +46,7 @@ class SignInController(
     @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
     @Inject private val oauth2Manager: InteractiveFlowSessionOAuth2Manager,
     @Inject private val stepUriMapper: InteractiveFlowStepUriMapper,
+    @Inject private val collectableClaimResourceMapper: CollectableClaimResourceMapper,
     @Inject private val interactiveAuthFlowSessionControllerUtil: InteractiveAuthFlowSessionControllerUtil,
     @Inject private val uncheckedUrlsConfig: UrlsConfig
 ) {
@@ -59,19 +64,23 @@ on-going flow. All URLs it contains already include the state query param.
     )
     @Get
     suspend fun getSignInConfiguration(
-        authentication: Authentication
-    ): SignInFlowResource = interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect(
-        state = authentication.stateOrNull,
-        run = { session, flow ->
-            if (signInApplies(session, flow)) {
-                buildSignInConfiguration(session, flow)
-            } else {
-                null
-            }
-        },
-        mapResultToResource = { it },
-        mapRedirectUriToResource = { SignInFlowResource(redirectUrl = it.toString()) }
-    )
+        authentication: Authentication,
+        httpRequest: HttpRequest<*>
+    ): SignInFlowResource {
+        val locale = httpRequest.locale.orDefault()
+        return interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect(
+            state = authentication.stateOrNull,
+            run = { session, flow ->
+                if (signInApplies(session, flow)) {
+                    buildSignInConfiguration(session, flow, locale)
+                } else {
+                    null
+                }
+            },
+            mapResultToResource = { it },
+            mapRedirectUriToResource = { SignInFlowResource(redirectUrl = it.toString()) }
+        )
+    }
 
     /**
      * The sign-in step applies while no user is associated to the [session] yet, unless the flow is an
@@ -91,12 +100,15 @@ on-going flow. All URLs it contains already include the state query param.
 
     private suspend fun buildSignInConfiguration(
         session: OnGoingInteractiveFlowSession,
-        flow: InteractiveFlow
+        flow: InteractiveFlow,
+        locale: Locale
     ): SignInFlowResource {
         val urlsConfig = uncheckedUrlsConfig.orThrow()
         val password = if (passwordFlowManager.signInEnabled) {
             PasswordResource(
-                identifierClaims = claimManager.listIdentifierClaims().map { it.id }
+                identifierClaims = collectableClaimResourceMapper.toResources(
+                    claimManager.listIdentifierClaims(), locale
+                )
             )
         } else null
         val providers = providerManager.listEnabledProviders()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignUpController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignUpController.kt
@@ -93,11 +93,9 @@ on-going flow. All URLs it contains already include the state query param.
         locale: Locale
     ): SignUpFlowResource {
         val password = if (passwordFlowManager.signUpEnabled) {
-            PasswordResource(
-                identifierClaims = claimManager.listIdentifierClaims().map { it.id }
-            )
+            PasswordResource()
         } else null
-        val claims = claimManager.listCollectableClaims().map { claim ->
+        val claims = claimManager.listIdentifierClaims().map { claim ->
             CollectableClaimResource(
                 id = claim.id,
                 required = claim.required,
@@ -119,6 +117,8 @@ on-going flow. All URLs it contains already include the state query param.
     @Operation(
         description = """
 Initiate the creation of an account of a end-user with a password.
+
+Only identifier claims are saved on the created account. Any other claim present in the request is discarded.
         """,
         tags = ["flow"]
     )

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignUpController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/SignUpController.kt
@@ -2,7 +2,7 @@ package com.sympauthy.api.controller.flow
 
 import com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil
 import com.sympauthy.api.mapper.CollectedClaimUpdateMapper
-import com.sympauthy.api.resource.flow.CollectableClaimResource
+import com.sympauthy.api.mapper.flow.CollectableClaimResourceMapper
 import com.sympauthy.api.resource.flow.PasswordResource
 import com.sympauthy.api.resource.flow.SignUpFlowResource
 import com.sympauthy.api.resource.flow.SignUpInputResource
@@ -15,9 +15,7 @@ import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.flow.InteractiveFlow
 import com.sympauthy.security.SecurityRule.HAS_STATE
 import com.sympauthy.security.stateOrNull
-import com.sympauthy.server.DisplayMessages
 import com.sympauthy.util.orDefault
-import io.micronaut.context.MessageSource
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
@@ -38,8 +36,8 @@ class SignUpController(
     @Inject private val oauth2Manager: InteractiveFlowSessionOAuth2Manager,
     @Inject private val stepUriMapper: InteractiveFlowStepUriMapper,
     @Inject private val collectedClaimUpdateMapper: CollectedClaimUpdateMapper,
-    @Inject private val interactiveAuthFlowSessionControllerUtil: InteractiveAuthFlowSessionControllerUtil,
-    @Inject @param:DisplayMessages private val displayMessageSource: MessageSource
+    @Inject private val collectableClaimResourceMapper: CollectableClaimResourceMapper,
+    @Inject private val interactiveAuthFlowSessionControllerUtil: InteractiveAuthFlowSessionControllerUtil
 ) {
 
     @Operation(
@@ -93,23 +91,17 @@ on-going flow. All URLs it contains already include the state query param.
         locale: Locale
     ): SignUpFlowResource {
         val password = if (passwordFlowManager.signUpEnabled) {
-            PasswordResource()
-        } else null
-        val claims = claimManager.listIdentifierClaims().map { claim ->
-            CollectableClaimResource(
-                id = claim.id,
-                required = claim.required,
-                name = displayMessageSource.getMessage("claims.${claim.id}.name", claim.id, locale),
-                group = claim.group?.name?.lowercase(),
-                type = claim.dataType.name.lowercase()
+            PasswordResource(
+                identifierClaims = collectableClaimResourceMapper.toResources(
+                    claimManager.listIdentifierClaims(), locale
+                )
             )
-        }
+        } else null
         val signInRedirectUrl = if (oauth2Manager.fetchOAuth2(session).invitationId == null) {
             stepUriMapper.getSignInRedirectUri(session, flow).toString()
         } else null
         return SignUpFlowResource(
             password = password,
-            claims = claims,
             signInRedirectUrl = signInRedirectUrl
         )
     }

--- a/server/src/main/kotlin/com/sympauthy/api/mapper/flow/CollectableClaimResourceMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/mapper/flow/CollectableClaimResourceMapper.kt
@@ -1,0 +1,27 @@
+package com.sympauthy.api.mapper.flow
+
+import com.sympauthy.api.resource.flow.CollectableClaimResource
+import com.sympauthy.business.model.user.claim.Claim
+import com.sympauthy.server.DisplayMessages
+import io.micronaut.context.MessageSource
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.util.Locale
+
+@Singleton
+class CollectableClaimResourceMapper(
+    @Inject @param:DisplayMessages private val displayMessageSource: MessageSource
+) {
+
+    fun toResources(claims: List<Claim>, locale: Locale): List<CollectableClaimResource> =
+        claims.map { toResource(it, locale) }
+
+    fun toResource(claim: Claim, locale: Locale): CollectableClaimResource =
+        CollectableClaimResource(
+            id = claim.id,
+            required = claim.required,
+            name = displayMessageSource.getMessage("claims.${claim.id}.name", claim.id, locale),
+            group = claim.group?.name?.lowercase(),
+            type = claim.dataType.name.lowercase()
+        )
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/PasswordResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/PasswordResource.kt
@@ -14,10 +14,10 @@ data class PasswordResource(
     @get:Schema(
         name = "identifier_claims",
         description = """
-List of claims that uniquely identify a user, usable as login for sign-in.
-Only set for the sign-in step; during sign-up the identifier claims are exposed in the ```claims``` field instead.
+List of claims that uniquely identify a user. Used as login during sign-in and as the required claims collected
+during sign-up.
         """
     )
     @get:JsonProperty("identifier_claims")
-    val identifierClaims: List<String>? = null,
+    val identifierClaims: List<CollectableClaimResource>,
 )

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/PasswordResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/PasswordResource.kt
@@ -13,8 +13,11 @@ If null or not present, the associated password authentication method is disable
 data class PasswordResource(
     @get:Schema(
         name = "identifier_claims",
-        description = "List of claims that uniquely identify a user. Used as login for sign-in and as required claims for sign-up."
+        description = """
+List of claims that uniquely identify a user, usable as login for sign-in.
+Only set for the sign-in step; during sign-up the identifier claims are exposed in the ```claims``` field instead.
+        """
     )
     @get:JsonProperty("identifier_claims")
-    val identifierClaims: List<String>,
+    val identifierClaims: List<String>? = null,
 )

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/SignUpFlowResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/SignUpFlowResource.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 Everything the custom UI needs to render the sign-up step of the authorization flow.
 
 This resource returns either:
-- the configuration of the sign-up step (```password```, ```open_registration```, ```invitation```, ```claims```, ```sign_in_redirect_url```).
+- the configuration of the sign-up step (```password```, ```open_registration```, ```invitation```, ```sign_in_redirect_url```).
 - a ```redirect_url``` where the end-user must be redirected to continue the flow. When set, all other fields are null.
 
 Every URL contained in this resource already includes the ```state``` query param.
@@ -21,10 +21,6 @@ data class SignUpFlowResource(
         description = "Configuration of the password authentication. Null if sign-up by password is disabled."
     )
     val password: PasswordResource? = null,
-    @get:Schema(
-        description = "List of identifier claims collected by the authorization server during sign-up."
-    )
-    val claims: List<CollectableClaimResource>? = null,
     @get:Schema(
         name = "sign_in_redirect_url",
         description = """

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/SignUpFlowResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/SignUpFlowResource.kt
@@ -22,7 +22,7 @@ data class SignUpFlowResource(
     )
     val password: PasswordResource? = null,
     @get:Schema(
-        description = "List of claims collectable by the authorization server during sign-up."
+        description = "List of identifier claims collected by the authorization server during sign-up."
     )
     val claims: List<CollectableClaimResource>? = null,
     @get:Schema(

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/auth/InteractiveAuthFlowSessionPasswordManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/auth/InteractiveAuthFlowSessionPasswordManager.kt
@@ -131,6 +131,9 @@ open class InteractiveAuthFlowSessionPasswordManager(
 
     /**
      * Create a new user with the provided claims([unfilteredUpdates]) and [password].
+     *
+     * Only identifier claims are saved on the created account. Any other claim present in [unfilteredUpdates] is
+     * discarded.
      */
     @Transactional
     open suspend fun signUpWithClaimsAndPassword(


### PR DESCRIPTION
## Summary

The sign-up step only persists **identifier claims** — any other claim in the request is discarded. This aligns the sign-up/sign-in configuration and its docs with that behavior, and makes `PasswordResource.identifier_claims` the single, fully-described home for those claims.

## Changes

- **`PasswordResource.identifier_claims`** is now a non-nullable `List<CollectableClaimResource>` — each identifier claim carries its full declaration (`id`, `required`, `name`, `type`, `group`) instead of a bare `List<String>`. Both the sign-in and sign-up steps populate it.
- **Removed the top-level `SignUpFlowResource.claims` field.** The sign-up step reads its identifier claims from `password.identifier_claims`.
- **Added `CollectableClaimResourceMapper`** (`api/mapper/flow`) to build the resources with a localized `name` from `Claim` + `Locale`, shared by both flow controllers.
- **`SignInController`** now resolves the request locale (`HttpRequest.locale`) so it can localize the claim names it returns.
- **Docs.** `signUp` (`@Operation`) and `signUpWithClaimsAndPassword` (KDoc) note that only identifier claims are saved; any other claim is discarded. `@Schema` descriptions updated accordingly.
- **integration-tests README.** `GITHUB_ACTOR` is derived from `gh` (`$(gh api user --jq .login)`), and the "Testing a specific image" section gained the GitHub Packages auth exports so the `testcontainers-sympauthy` library resolves.

## Wire-format note

`password.identifier_claims` changes from `["email"]` to `[{ "id": "email", "required": true, "name": "…", "type": "string", "group": null }]`. The `testcontainers-sympauthy` flow library models this field as `List<String>` (`FlowConfiguration.passwordIdentifierClaims`), so it must be updated in lockstep before the integration tests are run against this image.

## Testing

- `./gradlew test` — unit tests pass.
- Integration tests deferred until `testcontainers-sympauthy` is updated for the new `identifier_claims` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)