### PR TITLE
Client API to trigger MFA enrollment on demand (#280)

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/OpenAPI.kt
+++ b/server/src/main/kotlin/com/sympauthy/OpenAPI.kt
@@ -93,7 +93,9 @@ import jakarta.inject.Singleton
                     scopes = [
                         OAuthScope(name = BuiltInClientScopeId.USERS_READ),
                         OAuthScope(name = BuiltInClientScopeId.USERS_CLAIMS_READ),
-                        OAuthScope(name = BuiltInClientScopeId.USERS_CLAIMS_WRITE)
+                        OAuthScope(name = BuiltInClientScopeId.USERS_CLAIMS_WRITE),
+                        OAuthScope(name = BuiltInClientScopeId.USERS_MFA_READ),
+                        OAuthScope(name = BuiltInClientScopeId.USERS_MFA_WRITE)
                     ]
                 )
             )

--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentController.kt
@@ -1,0 +1,127 @@
+package com.sympauthy.api.controller.client
+
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.api.resource.client.ClientMfaEnrollmentInputResource
+import com.sympauthy.api.resource.client.ClientMfaEnrollmentResource
+import com.sympauthy.business.exception.recoverableBusinessExceptionOf
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.auth.oauth2.TokenManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.mfa.InteractiveFlowSessionMfaEnrollmentManager
+import com.sympauthy.business.model.oauth2.BuiltInClientScopeId
+import com.sympauthy.config.model.EnabledMfaConfig
+import com.sympauthy.config.model.MfaConfig
+import com.sympauthy.security.SecurityRule.CLIENT_USERS_MFA_WRITE
+import com.sympauthy.security.clientAuthentication
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import jakarta.inject.Inject
+
+/**
+ * Client-API entry point for a client to start enrolling a multi-factor authentication method on behalf of one
+ * of its signed-in end-users, outside of an OAuth2 authorization (e.g. from an account-settings screen).
+ *
+ * Dual authentication:
+ * - the **calling client** authenticates with a client-credentials token holding the `users:mfa:write` scope.
+ * - the **end-user** is identified by their access token, passed in the request body and validated to have been
+ *   issued to the calling client.
+ *
+ * It starts an [com.sympauthy.business.model.flow.InteractiveFlowPurpose.MFA_ENROLLMENT] session for that
+ * end-user and hands the caller the initial signed `state` + the enrollment page URL to drive the browser to.
+ * Once the enrollment completes, the end-user is redirected back to the caller-provided `return_uri`. The
+ * subsequent enrollment steps are driven through the state-secured flow API.
+ */
+@Secured(CLIENT_USERS_MFA_WRITE)
+@Controller(ClientMfaEnrollmentController.CLIENT_MFA_ENROLLMENT_ENDPOINT)
+class ClientMfaEnrollmentController(
+    @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
+    @Inject private val clientManager: ClientManager,
+    @Inject private val tokenManager: TokenManager,
+    @Inject private val mfaEnrollmentManager: InteractiveFlowSessionMfaEnrollmentManager,
+    @Inject private val engine: InteractiveFlowEngine,
+    @Inject private val stepUriMapper: InteractiveFlowStepUriMapper,
+    @Inject private val sessionManager: InteractiveFlowSessionManager,
+    @Inject private val uncheckedMfaConfig: MfaConfig,
+) {
+
+    @Operation(
+        description = """
+Starts a standalone MFA enrollment for one of the calling client's signed-in end-users.
+
+Validates the end-user `access_token` (must be a valid, unexpired user access token issued to the calling
+client) and the `return_uri` (must be one of the calling client's registered redirect URIs), creates an
+enrollment session, and returns the signed `state` and the `redirect_url` the caller must navigate the
+end-user's browser to. Once enrollment completes, the end-user is redirected to `return_uri`.
+        """,
+        tags = ["client"],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The enrollment session was started.",
+                useReturnTypeSchema = true
+            ),
+            ApiResponse(responseCode = "400", description = "Invalid access token or return URI, or MFA is not enabled."),
+            ApiResponse(responseCode = "401", description = "Missing or invalid client access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: users:mfa:write."
+            )
+        ]
+    )
+    @Post
+    @Secured(CLIENT_USERS_MFA_WRITE)
+    @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.USERS_MFA_WRITE])
+    suspend fun startEnrollment(
+        authentication: Authentication,
+        @Body resource: ClientMfaEnrollmentInputResource
+    ): ClientMfaEnrollmentResource {
+        // Fail fast (before creating any session) when MFA is not enabled on this server.
+        if ((uncheckedMfaConfig as? EnabledMfaConfig)?.enabled != true) {
+            throw recoverableBusinessExceptionOf(
+                "client.mfa.enrollment.mfa_disabled",
+                "description.client.mfa.enrollment.mfa_disabled"
+            )
+        }
+
+        val client = clientManager.findClientById(authentication.clientAuthentication.clientId)
+
+        // Validate the end-user access token: signature, expiry, not revoked, issued to the calling client
+        // (enforced by introspectToken), and associated with an end-user (not a client-credentials token).
+        val userToken = resource.accessToken
+            ?.let { tokenManager.introspectToken(client, it, "access_token") }
+        val userId = userToken?.userId
+            ?: throw recoverableBusinessExceptionOf(
+                "client.mfa.enrollment.invalid_access_token",
+                "description.client.mfa.enrollment.invalid_access_token"
+            )
+
+        // Validate the return URI against the calling client's registered redirect URIs to avoid open redirects.
+        val returnUri = interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, resource.returnUri)
+
+        val flow = interactiveAuthFlowSessionManager.getDefaultInteractiveFlow()
+        val session = mfaEnrollmentManager.startMfaEnrollmentSession(
+            userId = userId,
+            returnUri = returnUri,
+            flow = flow
+        )
+
+        val (steppedSession, step) = engine.advance(session)
+        val redirectUri = stepUriMapper.toRedirectUri(steppedSession, flow, step)
+        return ClientMfaEnrollmentResource(
+            state = sessionManager.encodeState(steppedSession),
+            redirectUrl = redirectUri.toString()
+        )
+    }
+
+    companion object {
+        const val CLIENT_MFA_ENROLLMENT_ENDPOINT = "/api/v1/client/mfa/enrollment"
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientMfaEnrollmentInputResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientMfaEnrollmentInputResource.kt
@@ -1,0 +1,26 @@
+package com.sympauthy.api.resource.client
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request body to start a standalone MFA enrollment on behalf of a signed-in end-user.")
+@Serdeable
+data class ClientMfaEnrollmentInputResource(
+    @get:Schema(
+        description = """
+Access token identifying the end-user who initiated the enrollment.
+Must be a valid, unexpired user access token issued by this authorization server to the calling client.
+        """
+    )
+    @get:JsonProperty("access_token")
+    val accessToken: String?,
+    @get:Schema(
+        description = """
+URI the end-user is returned to once the MFA enrollment completes.
+Must be one of the calling client's registered redirect URIs.
+        """
+    )
+    @get:JsonProperty("return_uri")
+    val returnUri: String?
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientMfaEnrollmentResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientMfaEnrollmentResource.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.api.resource.client
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Response from starting a standalone MFA enrollment: where to drive the end-user next."
+)
+@Serdeable
+data class ClientMfaEnrollmentResource(
+    @get:Schema(
+        description = "Signed state identifying the enrollment session, echoed by the flow endpoints."
+    )
+    val state: String,
+    @get:Schema(
+        description = "URL to navigate the end-user to in order to enroll their authenticator (state included)."
+    )
+    @get:JsonProperty("redirect_url")
+    val redirectUrl: String
+)

--- a/server/src/main/kotlin/com/sympauthy/business/model/oauth2/BuiltInClientScope.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/oauth2/BuiltInClientScope.kt
@@ -14,6 +14,8 @@ enum class BuiltInClientScope(
     USERS_READ(BuiltInClientScopeId.USERS_READ),
     USERS_CLAIMS_READ(BuiltInClientScopeId.USERS_CLAIMS_READ),
     USERS_CLAIMS_WRITE(BuiltInClientScopeId.USERS_CLAIMS_WRITE),
+    USERS_MFA_READ(BuiltInClientScopeId.USERS_MFA_READ),
+    USERS_MFA_WRITE(BuiltInClientScopeId.USERS_MFA_WRITE),
     INVITATIONS_READ(BuiltInClientScopeId.INVITATIONS_READ),
     INVITATIONS_WRITE(BuiltInClientScopeId.INVITATIONS_WRITE);
 }
@@ -27,6 +29,8 @@ object BuiltInClientScopeId {
     const val USERS_READ = "users:read"
     const val USERS_CLAIMS_READ = "users:claims:read"
     const val USERS_CLAIMS_WRITE = "users:claims:write"
+    const val USERS_MFA_READ = "users:mfa:read"
+    const val USERS_MFA_WRITE = "users:mfa:write"
     const val INVITATIONS_READ = "invitations:read"
     const val INVITATIONS_WRITE = "invitations:write"
 }

--- a/server/src/main/kotlin/com/sympauthy/security/SecurityRule.kt
+++ b/server/src/main/kotlin/com/sympauthy/security/SecurityRule.kt
@@ -25,6 +25,8 @@ object SecurityRule {
     const val CLIENT_USERS_READ = "SCOPE_${BuiltInClientScopeId.USERS_READ}"
     const val CLIENT_USERS_CLAIMS_READ = "SCOPE_${BuiltInClientScopeId.USERS_CLAIMS_READ}"
     const val CLIENT_USERS_CLAIMS_WRITE = "SCOPE_${BuiltInClientScopeId.USERS_CLAIMS_WRITE}"
+    const val CLIENT_USERS_MFA_READ = "SCOPE_${BuiltInClientScopeId.USERS_MFA_READ}"
+    const val CLIENT_USERS_MFA_WRITE = "SCOPE_${BuiltInClientScopeId.USERS_MFA_WRITE}"
     const val CLIENT_INVITATIONS_READ = "SCOPE_${BuiltInClientScopeId.INVITATIONS_READ}"
     const val CLIENT_INVITATIONS_WRITE = "SCOPE_${BuiltInClientScopeId.INVITATIONS_WRITE}"
 }

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -309,3 +309,7 @@ client.invalid_claim=The claim cannot be modified by the client with the current
 description.client.invalid_claim=The claim {claim} cannot be modified by the client. Either the claim does not exist or the client does not hold the required scopes.
 client.subject_without_provider=The subject query parameter must be used together with provider_id.
 description.client.subject_without_provider=The subject query parameter requires a provider_id to be specified.
+client.mfa.enrollment.mfa_disabled=Multi-factor authentication is not enabled on this authorization server.
+description.client.mfa.enrollment.mfa_disabled=This authorization server is not configured to support multi-factor authentication, so an enrollment cannot be started. Please contact the support of the application to report this issue.
+client.mfa.enrollment.invalid_access_token=The provided end-user access token is invalid.
+description.client.mfa.enrollment.invalid_access_token=The access token identifying the end-user is missing, expired, revoked, not associated with an end-user, or was not issued to your client. Obtain a fresh access token for the end-user and try again.

--- a/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentControllerTest.kt
@@ -1,0 +1,184 @@
+package com.sympauthy.api.controller.client
+
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.api.resource.client.ClientMfaEnrollmentInputResource
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.auth.oauth2.TokenManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.mfa.InteractiveFlowSessionMfaEnrollmentManager
+import com.sympauthy.business.model.client.Client
+import com.sympauthy.business.model.flow.InteractiveFlow
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.InteractiveFlowStepResult
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.oauth2.AuthenticationToken
+import com.sympauthy.config.model.DisabledMfaConfig
+import com.sympauthy.config.model.EnabledMfaConfig
+import com.sympauthy.config.model.MfaConfig
+import com.sympauthy.security.ClientAuthentication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class ClientMfaEnrollmentControllerTest {
+
+    @MockK
+    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
+
+    @MockK
+    lateinit var clientManager: ClientManager
+
+    @MockK
+    lateinit var tokenManager: TokenManager
+
+    @MockK
+    lateinit var mfaEnrollmentManager: InteractiveFlowSessionMfaEnrollmentManager
+
+    @MockK
+    lateinit var engine: InteractiveFlowEngine
+
+    @MockK
+    lateinit var stepUriMapper: InteractiveFlowStepUriMapper
+
+    @MockK
+    lateinit var sessionManager: InteractiveFlowSessionManager
+
+    private fun controller(mfaConfig: MfaConfig) = ClientMfaEnrollmentController(
+        interactiveAuthFlowSessionManager = interactiveAuthFlowSessionManager,
+        clientManager = clientManager,
+        tokenManager = tokenManager,
+        mfaEnrollmentManager = mfaEnrollmentManager,
+        engine = engine,
+        stepUriMapper = stepUriMapper,
+        sessionManager = sessionManager,
+        uncheckedMfaConfig = mfaConfig,
+    )
+
+    private fun clientAuthentication(clientId: String): ClientAuthentication {
+        val authenticationToken = mockk<AuthenticationToken> {
+            every { this@mockk.clientId } returns clientId
+        }
+        return ClientAuthentication(authenticationToken, emptyList())
+    }
+
+    @Test
+    fun `startEnrollment - Validates the token and return URI, starts the session, and returns state and redirect URL`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val authentication = clientAuthentication("client-id")
+            val client = mockk<Client>()
+            val userToken = mockk<AuthenticationToken> {
+                every { this@mockk.userId } returns userId
+            }
+            val returnUri = URI.create("https://client.example.com/done")
+            val flow = mockk<InteractiveFlow>()
+            val session = mockk<OnGoingInteractiveFlowSession>()
+            val steppedSession = mockk<OnGoingInteractiveFlowSession>()
+            val enrollUri = URI.create("https://auth.example.com/flow/mfa/enrollment?state=abc")
+
+            coEvery { clientManager.findClientById("client-id") } returns client
+            coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
+            every {
+                interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, "https://client.example.com/done")
+            } returns returnUri
+            coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
+            coEvery { mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow) } returns session
+            coEvery { engine.advance(session) } returns
+                InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.MfaSelectionForEnrollment)
+            coEvery {
+                stepUriMapper.toRedirectUri(steppedSession, flow, InteractiveFlowStep.MfaSelectionForEnrollment)
+            } returns enrollUri
+            coEvery { sessionManager.encodeState(steppedSession) } returns "encoded-state"
+
+            val result = controller(EnabledMfaConfig(totp = true, required = false)).startEnrollment(
+                authentication,
+                ClientMfaEnrollmentInputResource(
+                    accessToken = "user-access-token",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+
+            assertEquals("encoded-state", result.state)
+            assertEquals(enrollUri.toString(), result.redirectUrl)
+        }
+
+    @Test
+    fun `startEnrollment - Fails with mfa_disabled and starts no session when MFA is disabled`() = runTest {
+        val authentication = clientAuthentication("client-id")
+
+        val exception = assertThrows<BusinessException> {
+            controller(mockk<DisabledMfaConfig>()).startEnrollment(
+                authentication,
+                ClientMfaEnrollmentInputResource(
+                    accessToken = "user-access-token",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+        }
+
+        assertEquals("client.mfa.enrollment.mfa_disabled", exception.detailsId)
+        coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any()) }
+    }
+
+    @Test
+    fun `startEnrollment - Fails with invalid_access_token when the token cannot be introspected`() = runTest {
+        val authentication = clientAuthentication("client-id")
+        val client = mockk<Client>()
+
+        coEvery { clientManager.findClientById("client-id") } returns client
+        coEvery { tokenManager.introspectToken(client, "bad-token", "access_token") } returns null
+
+        val exception = assertThrows<BusinessException> {
+            controller(EnabledMfaConfig(totp = true, required = false)).startEnrollment(
+                authentication,
+                ClientMfaEnrollmentInputResource(
+                    accessToken = "bad-token",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+        }
+
+        assertEquals("client.mfa.enrollment.invalid_access_token", exception.detailsId)
+        coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any()) }
+    }
+
+    @Test
+    fun `startEnrollment - Fails with invalid_access_token when the token is not associated with an end-user`() =
+        runTest {
+            val authentication = clientAuthentication("client-id")
+            val client = mockk<Client>()
+            val clientOnlyToken = mockk<AuthenticationToken> {
+                every { userId } returns null
+            }
+
+            coEvery { clientManager.findClientById("client-id") } returns client
+            coEvery { tokenManager.introspectToken(client, "client-token", "access_token") } returns clientOnlyToken
+
+            val exception = assertThrows<BusinessException> {
+                controller(EnabledMfaConfig(totp = true, required = false)).startEnrollment(
+                    authentication,
+                    ClientMfaEnrollmentInputResource(
+                        accessToken = "client-token",
+                        returnUri = "https://client.example.com/done"
+                    )
+                )
+            }
+
+            assertEquals("client.mfa.enrollment.invalid_access_token", exception.detailsId)
+            coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any()) }
+        }
+}


### PR DESCRIPTION
## Summary

Re-exposes the client-facing API to trigger MFA enrollment on demand for a signed-in end-user (deferred from #278 / #279 pending the API-design decision). The internal `MFA_ENROLLMENT` machinery was already merged — this PR adds only the entry point and its scopes/DTOs.

**Endpoint:** `POST /api/v1/client/mfa/enrollment`

### Design (settled on the issue)

- **Dual authentication.** The **caller** is a client authenticating with a **client-credentials** bearer token holding the new `users:mfa:write` scope. The **end-user** is identified by their **access token, passed in the request body**.
- **Token validation.** The end-user access token is validated with `TokenManager.introspectToken` — signature, expiry, not revoked, **and issued to the calling client** (`token.clientId == caller.clientId`) — plus an *is-a-user-token* check (`userId != null`), rejecting client-credentials tokens. A client can therefore only start enrollment for a user whose token was issued to that same client.
- **Return-URI check.** `return_uri` is validated against the **calling client's registered redirect URIs** via the existing `parseRequestedRedirectUri` (open-redirect prevention). No new config.
- **Response.** JSON `{ state, redirect_url }` — the caller drives the end-user's browser to `redirect_url`; on completion the user is returned to `return_uri`.
- **MFA-disabled guard.** If MFA/TOTP is not enabled in config, the request is rejected up front with a user-readable 400 **before** any session is created (avoids an orphan session + opaque 500).

Full decision record: sympauthy/sympauthy#280 (comment).

### Changes

- **Scopes:** `users:mfa:read` + `users:mfa:write` added to `BuiltInClientScope` / `BuiltInClientScopeId`, `SecurityRule`, and the OpenAPI `client` security scheme. `users:mfa:read` is reserved for a future read endpoint. `ScopeManager` derives grant/resolution from the enum automatically.
- **DTOs:** `ClientMfaEnrollmentInputResource` (`access_token`, `return_uri`) and `ClientMfaEnrollmentResource` (`state`, `redirect_url`).
- **Controller:** `ClientMfaEnrollmentController`.
- **Errors:** `client.mfa.enrollment.mfa_disabled` and `client.mfa.enrollment.invalid_access_token`, each with a user-facing `description.*`.
- **Reuses (unchanged, already merged):** `startMfaEnrollmentSession`, the `interactive_flow_session_mfa_enrollment` return-URI record, and `InteractiveFlowStepUriMapper` terminal routing. No schema/migration changes.

### Commits (one per step)

1. Add `users:mfa:read` / `users:mfa:write` client scopes.
2. Add the client API endpoint (controller + DTOs + errors).
3. Add `ClientMfaEnrollmentControllerTest`.

## Testing

- `ClientMfaEnrollmentControllerTest` — happy path + MFA-disabled + un-introspectable token + non-user token (each failure asserts no session is started).
- Full server suite: **690 passed, 0 failed**.
- Unit-tested only; the testcontainers end-to-end suite (H2 + PostgreSQL) is left to CI, consistent with how #278/#279 deferred it.

Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
