### PR TITLE
Share the HTTP contract with integration-tests via a generated client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,14 @@ Multi-module Gradle project (root + `server`). All source code is in `server/src
   2.1 [forbids 307 redirects](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-http-307-redirect)
   because they cause the browser to resubmit the POST body (including credentials) to the redirect target. Always use *
   *303 See Other** (`HttpResponse.seeOther()`) which forces a GET on the redirect target.
+- **Document endpoint parameters inline, never in `@Operation(parameters = [...])`** — put a
+  `@Parameter(description = "…")` directly on each `@QueryValue`/`@PathVariable`/`@Header` method argument and let
+  Micronaut derive the schema from the Kotlin type. Do **not** list parameters in a method-level
+  `@Operation(parameters = [Parameter(name = "…", schema = Schema(...))])` block: when an `@Operation`-level
+  `@Parameter` name matches a bound method argument, micronaut-openapi keeps the description but **drops the schema**,
+  emitting a typeless parameter in the generated OpenAPI spec (which then fails the OpenAPI client generation in
+  `integration-tests`). Type, `required` (from nullability) and `format` (e.g. `uuid` from `UUID`) are all inferred
+  from the argument, so the inline `@Parameter` only needs the human-readable `description`.
 
 #### Config (com.sympauthy.config)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.kotlin.allopen) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.micronaut.application) apply false
+    alias(libs.plugins.micronaut.minimal.library) apply false
+    alias(libs.plugins.micronaut.openapi) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,3 +56,5 @@ kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 micronaut-application = { id = "io.micronaut.application", version.ref = "micronaut-plugin" }
+micronaut-minimal-library = { id = "io.micronaut.minimal.library", version.ref = "micronaut-plugin" }
+micronaut-openapi = { id = "io.micronaut.openapi", version.ref = "micronaut-plugin" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -6,9 +6,17 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 // (H2 and PostgreSQL). These tests require Docker and a published/built SympAuthy image, so they live
 // in a dedicated `integrationTest` source set and run only via `./gradlew :integration-tests:integrationTest`
 // — never as part of the default `build`/`check`/`test` lifecycle.
-
+//
+// The tests call the server through a typed HTTP client generated from the server's OpenAPI contract:
+// the Micronaut OpenAPI plugin turns `server`'s published spec into declarative Micronaut @Client
+// interfaces + Serde models (see the `micronaut { openapi { client(...) } }` block). This is why the
+// module applies the Micronaut plugins and pulls in an HTTP-client runtime — unlike a plain black-box
+// tester, it hosts a Micronaut ApplicationContext to drive the generated client against the container.
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.micronaut.minimal.library)
+    alias(libs.plugins.micronaut.openapi)
 }
 
 repositories {
@@ -33,6 +41,12 @@ val integrationTest: SourceSet = sourceSets.create("integrationTest")
 configurations["integrationTestImplementation"].extendsFrom(configurations["testImplementation"])
 configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
 
+// The Micronaut OpenAPI plugin emits the generated client into the (otherwise empty) `main` source set.
+// Expose main's compiled output — the @Client beans and models — to the integrationTest source set so the
+// scenarios can call the generated client.
+integrationTest.compileClasspath += sourceSets["main"].output
+integrationTest.runtimeClasspath += sourceSets["main"].output
+
 dependencies {
     // Micronaut Platform BOM governs testcontainers, nimbus-jose-jwt and slf4j so they match the server.
     testImplementation(platform(libs.micronaut.platform))
@@ -47,6 +61,82 @@ dependencies {
 
     testRuntimeOnly(libs.junit.platform.launcher)
     testRuntimeOnly(libs.slf4j.simple)
+
+    // Runtime for the generated OpenAPI client (compiled into `main`): a declarative Micronaut @Client with
+    // plain Jackson models (see serializationFramework=JACKSON above). The tests instantiate a Micronaut
+    // ApplicationContext to obtain and drive these beans. micronaut-serde is deliberately not used — its
+    // Kotlin KSP introspection generator mis-generates the models' BeanIntrospection (ClassFormatError).
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-jackson-databind")
+}
+
+micronaut {
+    openapi {
+        // Generate a typed Kotlin client from the server's published OpenAPI contract — one source of
+        // truth for the request/response models and the endpoint paths. Live-wired below so the client is
+        // regenerated whenever the server's contract changes.
+        client(file("${rootProject.projectDir}/server/build/openapi/openapi.yml")) {
+            apiPackageName = "com.sympauthy.api.client.api"
+            modelPackageName = "com.sympauthy.api.client.model"
+            lang.set("kotlin")
+            clientId = "sympauthy"
+            // Generate plain Jackson models instead of @Serdeable ones. The Micronaut Serde Kotlin (KSP)
+            // introspection generator mis-generates these data classes' BeanIntrospection — a duplicate
+            // "$property$keys$metadata" method that fails to load (ClassFormatError) when the client's
+            // ApplicationContext starts. Jackson-databind (de)serialization needs no compile-time
+            // introspection, so it sidesteps that generator bug while keeping a real Micronaut @Client.
+            serializationFramework.set("JACKSON")
+            // The models are deserialization targets only — no bean validation needed (also keeps
+            // jakarta.validation off the classpath).
+            useBeanValidation = false
+        }
+    }
+}
+
+// Live-wire the generated client to the server's contract: regeneration depends on the server
+// republishing its spec, so a wire-format change forces the client to regenerate and fails compilation
+// on drift instead of silently going stale.
+tasks.matching { it.name.startsWith("generateClientOpenApi") }.configureEach {
+    dependsOn(":server:syncOpenApiSpec")
+}
+
+// Post-process the generated model sources for two things the generator's own configuration does not
+// cover, both needed to (de)serialize the server's responses on the JVM via Jackson-databind. This runs as
+// a doLast on the generator task itself, so the rewritten files become that task's recorded output — which
+// keeps Gradle's incremental tracking correct (downstream compilation recompiles when they change) without
+// touching the source-set wiring.
+//
+//  1. Remove @Introspected. The models (de)serialize through Jackson-databind (serializationFramework =
+//     JACKSON above), which needs no Micronaut BeanIntrospection — but the generator stamps @Introspected
+//     on every model regardless. One model, SignUpInputResource, extends HashMap because its schema
+//     declares additionalProperties: true (the server's @JsonAnySetter claims map), and Micronaut's Kotlin
+//     KSP introspection generator mis-generates the BeanIntrospection for that @Introspected Map subclass —
+//     a duplicate "$property$keys$metadata" method that fails to load (ClassFormatError) the moment the
+//     client's ApplicationContext starts. Dropping the unused annotation stops any introspection being
+//     generated for the models, sidestepping the bug while leaving Jackson (de)serialization intact.
+//
+//  2. Retype ZonedDateTime -> LocalDateTime. The generator hardcodes the date-time format to ZonedDateTime
+//     (no configuration hook), but the server serializes its LocalDateTime timestamps without a zone or
+//     offset (e.g. "2026-07-31T13:16:29.061704"), which Jackson cannot parse into a ZonedDateTime. The
+//     server uses LocalDateTime throughout, so retyping the generated fields matches the wire format.
+//
+// Both rewrites are idempotent, so re-running on an already-processed tree is a no-op.
+tasks.matching { it.name == "generateClientOpenApiModels" }.configureEach {
+    val modelsDir = layout.buildDirectory.dir("generated/openapi/generateClientOpenApiModels/src/main/kotlin")
+    doLast {
+        modelsDir.get().asFile.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
+            val original = file.readText()
+            val rewritten = original
+                .lineSequence()
+                .filterNot {
+                    it.trim() == "@Introspected" ||
+                        it.trim() == "import io.micronaut.core.annotation.Introspected"
+                }
+                .joinToString("\n")
+                .replace("ZonedDateTime", "LocalDateTime")
+            if (rewritten != original) file.writeText(rewritten.trimEnd('\n') + "\n")
+        }
+    }
 }
 
 java {
@@ -54,6 +144,9 @@ java {
 }
 
 tasks {
+    compileKotlin {
+        compilerOptions { jvmTarget.set(JvmTarget.JVM_25) }
+    }
     compileTestKotlin {
         compilerOptions { jvmTarget.set(JvmTarget.JVM_25) }
     }

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
@@ -13,9 +13,11 @@ import com.nimbusds.jose.util.JSONObjectUtils
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import com.sympauthy.it.client.BearerTokenHolder
 import com.sympauthy.testcontainers.Client
 import com.sympauthy.testcontainers.SympauthyContainer
 import com.sympauthy.testcontainers.flow.InteractiveFlowRegistry
+import io.micronaut.context.ApplicationContext
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -163,6 +165,28 @@ abstract class AbstractSympauthyIT {
             System.err.println(runCatching { sympauthy.logs }.getOrElse { "(logs unavailable: $it)" })
             throw failure
         }
+    }
+
+    // --- Generated OpenAPI client -------------------------------------------------------------------
+
+    /**
+     * Runs [block] with a Micronaut [ApplicationContext] hosting the OpenAPI client generated from the
+     * server's contract, wired to the running [sympauthy] container (the `@Client("sympauthy")` service
+     * URL is bound to the container's mapped address). When [token] is non-null it is attached as a bearer
+     * token to every client request (see `BearerTokenClientFilter`). The context is closed on exit.
+     *
+     * Obtain the typed API beans inside the block, e.g. `ctx.getBean(AdminApi::class.java)`; their methods
+     * return `reactor.core.publisher.Mono`, so call `.block()` to get the deserialized resource.
+     */
+    protected fun <T> withApiClient(
+        sympauthy: SympauthyContainer,
+        token: String? = null,
+        block: (ApplicationContext) -> T,
+    ): T = ApplicationContext.run(
+        mapOf("micronaut.http.services.sympauthy.url" to sympauthy.baseUrl),
+    ).use { ctx ->
+        ctx.getBean(BearerTokenHolder::class.java).token = token
+        block(ctx)
     }
 
     // --- HTTP / JWT helpers -------------------------------------------------------------------------

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
@@ -9,10 +9,11 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.jwk.source.JWKSourceBuilder
 import com.nimbusds.jose.proc.JWSVerificationKeySelector
 import com.nimbusds.jose.proc.SecurityContext
-import com.nimbusds.jose.util.JSONObjectUtils
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import com.sympauthy.api.client.api.OpeniddiscoveryApi
+import com.sympauthy.api.client.model.OpenIdConfigurationResource
 import com.sympauthy.it.client.BearerTokenHolder
 import com.sympauthy.testcontainers.Client
 import com.sympauthy.testcontainers.SympauthyContainer
@@ -191,21 +192,18 @@ abstract class AbstractSympauthyIT {
 
     // --- HTTP / JWT helpers -------------------------------------------------------------------------
 
-    /** The parsed OpenID Connect discovery document served by [sympauthy]. */
-    protected fun discovery(sympauthy: SympauthyContainer): Map<String, Any?> {
-        val response = httpGet(sympauthy.openIdConfigurationUrl, followRedirects = true)
-        check(response.statusCode() == 200) {
-            "discovery returned HTTP ${response.statusCode()}: ${response.body()}"
-        }
-        return JSONObjectUtils.parse(response.body())
-    }
+    /** The OpenID Connect discovery document served by [sympauthy], read through the generated client. */
+    protected fun discovery(sympauthy: SympauthyContainer): OpenIdConfigurationResource =
+        withApiClient(sympauthy) { ctx ->
+            ctx.getBean(OpeniddiscoveryApi::class.java).getConfiguration().block()
+        } ?: error("discovery endpoint returned an empty body")
 
     /**
      * Verifies [idToken] is genuinely signed by the key set [sympauthy] advertises at its `jwks_uri`,
      * returning the validated claims. Throws if the signature does not verify against the JWKS.
      */
     protected fun verifyIdTokenSignature(sympauthy: SympauthyContainer, idToken: String): JWTClaimsSet {
-        val jwksUri = URI.create(discovery(sympauthy)["jwks_uri"] as String).toURL()
+        val jwksUri = URI.create(discovery(sympauthy).jwksUri).toURL()
         val signedJwt = SignedJWT.parse(idToken)
         val jwkSource = JWKSourceBuilder.create<SecurityContext>(jwksUri).build()
         val processor = DefaultJWTProcessor<SecurityContext>().apply {
@@ -236,7 +234,7 @@ abstract class AbstractSympauthyIT {
         )
         overrides.forEach { (key, value) -> if (value == null) params.remove(key) else params[key] = value }
         val query = params.entries.joinToString("&") { (key, value) -> "${encode(key)}=${encode(value)}" }
-        return "${discovery(sympauthy)["authorization_endpoint"]}?$query"
+        return "${discovery(sympauthy).authorizationEndpoint}?$query"
     }
 
     protected fun httpGet(

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/SignUpWithAllOpenIdClaimFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/SignUpWithAllOpenIdClaimFeatureIT.kt
@@ -1,6 +1,6 @@
 package com.sympauthy.it.feature
 
-import com.nimbusds.jose.util.JSONObjectUtils
+import com.sympauthy.api.client.api.AdminApi
 import com.sympauthy.it.AbstractSympauthyIT
 import com.sympauthy.it.Database
 import com.sympauthy.it.SympauthyImage
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.util.UUID
 
 /**
  * Feature scenario — **sign up while collecting every standard OpenID claim, then verify each stored value.**
@@ -78,18 +79,18 @@ class SignUpWithAllOpenIdClaimFeatureIT : AbstractSympauthyIT() {
             val userId = verifyIdTokenSignature(sympauthy, idToken).subject
 
             // Read every collected claim back through the admin API using the token the flow just issued.
-            val response = httpGet(
-                "${sympauthy.baseUrl}/api/v1/admin/users/$userId/claims?size=100",
-                headers = mapOf("Authorization" to "Bearer ${tokens.accessToken()}"),
-            )
-            assertEquals(
-                200, response.statusCode(),
-                "admin claims API should authorize the granted token: ${response.body()}",
-            )
+            // This call goes through the typed client generated from the server's OpenAPI contract: the
+            // endpoint path (`/api/v1/admin/users/{userId}/claims`) and the request/response models are the
+            // ones the server declares, not hand-copied here — a non-2xx response throws instead of needing
+            // an explicit status assertion.
+            val claimList = withApiClient(sympauthy, token = tokens.accessToken()) { ctx ->
+                ctx.getBean(AdminApi::class.java)
+                    .listUserClaims(UUID.fromString(userId), size = 100)
+                    .block()
+            }
+            requireNotNull(claimList) { "admin claims API returned an empty body" }
 
-            val values = (JSONObjectUtils.parse(response.body())["claims"] as List<*>)
-                .filterIsInstance<Map<String, Any?>>()
-                .associate { it["claim_id"] as String to it["value"] }
+            val values = claimList.claims.associate { it.claimId to it.value }
 
             EXPECTED.forEach { (id, value) ->
                 assertEquals(value, values[id], "claim '$id' read back through the admin user API")

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/AuthorizationCodeBoundToClientIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/AuthorizationCodeBoundToClientIT.kt
@@ -49,7 +49,7 @@ class AuthorizationCodeBoundToClientIT : AbstractSympauthyIT() {
 
             // Redeem the code as a *different* registered client than the one it was issued to.
             val response = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to code,

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/AuthorizationCodeReplayIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/AuthorizationCodeReplayIT.kt
@@ -42,7 +42,7 @@ class AuthorizationCodeReplayIT : AbstractSympauthyIT() {
 
             // Replaying the very same code must now be denied.
             val replay = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to code,

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/DpopProofValidationIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/DpopProofValidationIT.kt
@@ -31,7 +31,7 @@ class DpopProofValidationIT : AbstractSympauthyIT() {
     @EnumSource(Database::class)
     fun tokenEndpointRejectsInvalidDpopProofs(database: Database) {
         withContainer(database) { sympauthy, registry ->
-            val tokenEndpoint = discovery(sympauthy)["token_endpoint"] as String
+            val tokenEndpoint = discovery(sympauthy).tokenEndpoint
             // The DPoP proof is validated before the grant, so the rest of the request is immaterial.
             val baseForm = mapOf(
                 "grant_type" to "authorization_code",

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/IntrospectionActiveFalseForOtherClientsTokenIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/IntrospectionActiveFalseForOtherClientsTokenIT.kt
@@ -50,7 +50,7 @@ class IntrospectionActiveFalseForOtherClientsTokenIT : AbstractSympauthyIT() {
 
             // Introspect it while authenticated as a *different* client.
             val response = httpPostForm(
-                discovery(sympauthy)["introspection_endpoint"] as String,
+                discovery(sympauthy).introspectionEndpoint!!,
                 mapOf("token" to foreignAccessToken),
                 headers = mapOf("Authorization" to basicAuth(OTHER_CLIENT_ID, OTHER_CLIENT_SECRET)),
             )

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/IntrospectionRequiresClientAuthIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/IntrospectionRequiresClientAuthIT.kt
@@ -30,7 +30,7 @@ class IntrospectionRequiresClientAuthIT : AbstractSympauthyIT() {
     fun introspectionRequiresClientAuthentication(database: Database) {
         withContainer(database) { sympauthy, _ ->
             val response = httpPostForm(
-                discovery(sympauthy)["introspection_endpoint"] as String,
+                discovery(sympauthy).introspectionEndpoint!!,
                 mapOf("token" to "any-token-value"),
                 // Deliberately no Authorization header and no client_id/client_secret in the body.
             )

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/PkceDowngradeMissingVerifierIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/PkceDowngradeMissingVerifierIT.kt
@@ -36,7 +36,7 @@ class PkceDowngradeMissingVerifierIT : AbstractSympauthyIT() {
             val code = checkNotNull(result.code()) { "expected an authorization code from sign-up" }
 
             val response = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to code,

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/PkceVerifierMismatchIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/PkceVerifierMismatchIT.kt
@@ -37,7 +37,7 @@ class PkceVerifierMismatchIT : AbstractSympauthyIT() {
             val code = checkNotNull(result.code()) { "expected an authorization code from sign-up" }
 
             val response = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to code,

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/RefreshTokenRevocationCascadesIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/RefreshTokenRevocationCascadesIT.kt
@@ -42,7 +42,7 @@ class RefreshTokenRevocationCascadesIT : AbstractSympauthyIT() {
             val refreshToken = checkNotNull(tokens.refreshToken()) { "refresh-enabled should yield a refresh token" }
 
             val discovery = discovery(sympauthy)
-            val introspectionEndpoint = discovery["introspection_endpoint"] as String
+            val introspectionEndpoint = discovery.introspectionEndpoint!!
             val auth = mapOf("Authorization" to basicAuth(registry.clientId(), checkNotNull(registry.clientSecret())))
 
             // The access token is active before revocation.
@@ -54,7 +54,7 @@ class RefreshTokenRevocationCascadesIT : AbstractSympauthyIT() {
 
             // Revoke the *refresh* token.
             val revoke = httpPostForm(
-                discovery["revocation_endpoint"] as String,
+                discovery.revocationEndpoint!!,
                 mapOf("token" to refreshToken, "token_type_hint" to "refresh_token"),
                 auth,
             )

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/RevokeAlwaysReturns200IT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/RevokeAlwaysReturns200IT.kt
@@ -39,7 +39,7 @@ class RevokeAlwaysReturns200IT : AbstractSympauthyIT() {
 
         withContainer(database, confidentialClient) { sympauthy, _ ->
             val response = httpPostForm(
-                discovery(sympauthy)["revocation_endpoint"] as String,
+                discovery(sympauthy).revocationEndpoint!!,
                 mapOf("token" to "this-token-does-not-exist"),
                 headers = mapOf("Authorization" to basicAuth(CLIENT_ID, CLIENT_SECRET)),
             )

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/RevokedTokenBecomesInactiveIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/RevokedTokenBecomesInactiveIT.kt
@@ -42,9 +42,9 @@ class RevokedTokenBecomesInactiveIT : AbstractSympauthyIT() {
 
         withContainer(database, confidentialClient) { sympauthy, _ ->
             val discovery = discovery(sympauthy)
-            val tokenEndpoint = discovery["token_endpoint"] as String
-            val introspectionEndpoint = discovery["introspection_endpoint"] as String
-            val revocationEndpoint = discovery["revocation_endpoint"] as String
+            val tokenEndpoint = discovery.tokenEndpoint
+            val introspectionEndpoint = discovery.introspectionEndpoint!!
+            val revocationEndpoint = discovery.revocationEndpoint!!
             val auth = mapOf("Authorization" to basicAuth(CLIENT_ID, CLIENT_SECRET))
 
             // Issue a token via client_credentials.

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenEndpointRejectsUnknownCodeIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenEndpointRejectsUnknownCodeIT.kt
@@ -31,7 +31,7 @@ class TokenEndpointRejectsUnknownCodeIT : AbstractSympauthyIT() {
     fun tokenEndpointRejectsUnknownCodeWithInvalidGrant(database: Database) {
         withContainer(database) { sympauthy, registry ->
             val response = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to "this-code-was-never-issued",

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenEndpointRequiresDpopWhenConfiguredIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenEndpointRequiresDpopWhenConfiguredIT.kt
@@ -38,7 +38,7 @@ class TokenEndpointRequiresDpopWhenConfiguredIT : AbstractSympauthyIT() {
             val code = checkNotNull(result.code()) { "expected an authorization code from sign-up" }
 
             val response = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to code,

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenRedirectUriMismatchIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/TokenRedirectUriMismatchIT.kt
@@ -36,7 +36,7 @@ class TokenRedirectUriMismatchIT : AbstractSympauthyIT() {
             val code = checkNotNull(result.code()) { "expected an authorization code from sign-up" }
 
             val response = httpPostForm(
-                discovery(sympauthy)["token_endpoint"] as String,
+                discovery(sympauthy).tokenEndpoint,
                 mapOf(
                     "grant_type" to "authorization_code",
                     "code" to code,

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/UserInfoRejectsInvalidBearerIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/UserInfoRejectsInvalidBearerIT.kt
@@ -28,7 +28,7 @@ class UserInfoRejectsInvalidBearerIT : AbstractSympauthyIT() {
     @EnumSource(Database::class)
     fun userInfoRejectsMissingOrInvalidBearer(database: Database) {
         withContainer(database) { sympauthy, _ ->
-            val userInfoEndpoint = discovery(sympauthy)["userinfo_endpoint"] as String
+            val userInfoEndpoint = discovery(sympauthy).userinfoEndpoint!!
 
             val noToken = httpGet(userInfoEndpoint)
             assertEquals(401, noToken.statusCode(), "userinfo must require a bearer token, body=${noToken.body()}")

--- a/integration-tests/src/main/kotlin/com/sympauthy/it/client/BearerTokenClientFilter.kt
+++ b/integration-tests/src/main/kotlin/com/sympauthy/it/client/BearerTokenClientFilter.kt
@@ -1,0 +1,35 @@
+package com.sympauthy.it.client
+
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.annotation.ClientFilter
+import io.micronaut.http.annotation.RequestFilter
+import jakarta.inject.Singleton
+
+/**
+ * Holds the bearer token to attach to generated-client requests for the current scenario.
+ *
+ * The token is obtained during the interactive flow — after the [io.micronaut.context.ApplicationContext]
+ * that hosts the generated client is created — so it is set on this mutable holder just before an
+ * authenticated call rather than baked into static client configuration.
+ */
+@Singleton
+class BearerTokenHolder {
+    @Volatile
+    var token: String? = null
+}
+
+/**
+ * Attaches `Authorization: Bearer <token>` to every request the generated `@Client("sympauthy")` makes,
+ * reading the current token from [BearerTokenHolder].
+ *
+ * The generated client exposes no auth parameter — OAuth2 is declared in the contract via securitySchemes,
+ * not per-operation — so the header is injected here instead of being passed at each call site.
+ */
+@ClientFilter(serviceId = ["sympauthy"])
+class BearerTokenClientFilter(private val holder: BearerTokenHolder) {
+
+    @RequestFilter
+    fun addBearerToken(request: MutableHttpRequest<*>) {
+        holder.token?.let(request::bearerAuth)
+    }
+}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -200,3 +200,35 @@ tasks {
         }
     }
 }
+
+// --- OpenAPI contract sharing -------------------------------------------------------------------
+// micronaut-openapi generates the HTTP contract as part of `kspKotlin`, writing it under
+// build/generated/ksp/main/resources/META-INF/swagger/sympauthy-<info.version>.yml (the file name
+// tracks the OpenAPI `info.version`, not the project version). Republish it at a stable, versionless
+// path (build/openapi/openapi.yml) and expose it as a consumable Gradle artifact so a downstream module
+// — the integration-tests OpenAPI client generator — consumes a single source of truth and regenerates
+// whenever the contract changes.
+val syncOpenApiSpec by tasks.registering(Sync::class) {
+    description = "Publishes the generated OpenAPI spec to build/openapi/openapi.yml for downstream consumers."
+    group = "openapi"
+    dependsOn(tasks.named("kspKotlin"))
+    from(layout.buildDirectory.dir("generated/ksp/main/resources/META-INF/swagger")) {
+        include("*.yml")
+        rename(".+\\.yml", "openapi.yml")
+    }
+    into(layout.buildDirectory.dir("openapi"))
+}
+
+// A consumable-only configuration carrying the published spec, wired to build via syncOpenApiSpec. The
+// integration-tests module depends on `project(":server", configuration = "openApiSpec")` to obtain the
+// contract with a proper task dependency (no reaching into another project's build directory by path).
+val openApiSpec: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
+artifacts {
+    add(openApiSpec.name, layout.buildDirectory.file("openapi/openapi.yml")) {
+        builtBy(syncOpenApiSpec)
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminAudienceController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminAudienceController.kt
@@ -16,7 +16,6 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -33,18 +32,6 @@ class AdminAudienceController(
     @Operation(
         description = "Retrieve all configured audiences. Since audiences are defined in configuration files, this endpoint exposes them as read-only resources.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of audiences."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -56,8 +43,8 @@ class AdminAudienceController(
     )
     @Get
     suspend fun listAudiences(
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): AdminAudienceListResource {
         val (page, size) = resolvePageParams(page, size)
         val audiences = audienceManager.listAudiences()
@@ -77,13 +64,6 @@ class AdminAudienceController(
     @Operation(
         description = "Retrieve details for a specific audience by its identifier.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "audienceId",
-                description = "Unique identifier of the audience.",
-                schema = Schema(type = "string")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Audience details."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -96,7 +76,7 @@ class AdminAudienceController(
     )
     @Get("/{audienceId}")
     suspend fun getAudience(
-        @PathVariable audienceId: String
+        @PathVariable @Parameter(description = "Unique identifier of the audience.") audienceId: String
     ): AdminAudienceResource {
         val audience = audienceManager.findAudienceByIdOrNull(audienceId).orNotFound()
         val clientsCount = clientManager.countClientsByAudienceId()[audience.id] ?: 0

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClaimController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClaimController.kt
@@ -13,7 +13,6 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -29,33 +28,6 @@ class AdminClaimController(
     @Operation(
         description = "Retrieve all configured claims (standard and custom). Since claims are defined in configuration files, this endpoint exposes them as read-only resources.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            ),
-            Parameter(
-                name = "enabled",
-                description = "Filter by enabled status.",
-                schema = Schema(type = "boolean")
-            ),
-            Parameter(
-                name = "required",
-                description = "Filter by required status.",
-                schema = Schema(type = "boolean")
-            ),
-            Parameter(
-                name = "origin",
-                description = "Filter by claim origin.",
-                schema = Schema(type = "string", allowableValues = ["openid", "custom"])
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of claims."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -67,11 +39,11 @@ class AdminClaimController(
     )
     @Get
     fun listClaims(
-        @QueryValue page: Int?,
-        @QueryValue size: Int?,
-        @QueryValue enabled: Boolean?,
-        @QueryValue required: Boolean?,
-        @QueryValue origin: String?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?,
+        @QueryValue @Parameter(description = "Filter by enabled status.") enabled: Boolean?,
+        @QueryValue @Parameter(description = "Filter by required status.") required: Boolean?,
+        @QueryValue @Parameter(description = "Filter by claim origin.") origin: String?
     ): AdminClaimListResource {
         val (page, size) = resolvePageParams(page, size)
         val claims = claimManager.listAllClaims()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClientController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminClientController.kt
@@ -15,7 +15,6 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -31,18 +30,6 @@ class AdminClientController(
     @Operation(
         description = "Retrieve all configured clients. Since clients are defined in configuration files, this endpoint exposes them as read-only resources. Client secrets are never included.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of clients."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -54,8 +41,8 @@ class AdminClientController(
     )
     @Get
     suspend fun listClients(
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): AdminClientListResource {
         val (page, size) = resolvePageParams(page, size)
         val clients = clientManager.listClients()
@@ -74,13 +61,6 @@ class AdminClientController(
     @Operation(
         description = "Retrieve details for a specific client by its identifier.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "clientId",
-                description = "Unique identifier of the client.",
-                schema = Schema(type = "string")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Client details."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -93,7 +73,7 @@ class AdminClientController(
     )
     @Get("/{clientId}")
     suspend fun getClient(
-        @PathVariable clientId: String
+        @PathVariable @Parameter(description = "Unique identifier of the client.") clientId: String
     ): AdminClientResource {
         val client = clientManager.findClientByIdOrNull(clientId).orNotFound()
         return clientMapper.toResource(client)

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminConsentController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminConsentController.kt
@@ -17,7 +17,6 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -33,23 +32,6 @@ class AdminConsentController(
     @Operation(
         description = "Retrieve a paginated list of active consents for a given user.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of consents."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -64,9 +46,9 @@ class AdminConsentController(
     @Secured(ADMIN_CONSENT_READ)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.CONSENT_READ])
     suspend fun listConsents(
-        @PathVariable userId: UUID,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): AdminConsentListResource {
         userManager.findByIdOrNull(userId).orNotFound()
         val (page, size) = resolvePageParams(page, size)
@@ -87,18 +69,6 @@ class AdminConsentController(
         description = "Revoke the active consent for a given user and audience. " +
                 "This also revokes all refresh tokens issued for this user+audience pair.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "audienceId",
-                description = "Identifier of the audience.",
-                schema = Schema(type = "string")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "204", description = "Consent revoked successfully."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -114,8 +84,8 @@ class AdminConsentController(
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.CONSENT_WRITE])
     @Status(HttpStatus.NO_CONTENT)
     suspend fun revokeConsent(
-        @PathVariable userId: UUID,
-        @PathVariable audienceId: String,
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @PathVariable @Parameter(description = "Identifier of the audience.") audienceId: String,
         authentication: Authentication
     ) {
         val consent = consentManager.findActiveConsentByAudienceOrNull(userId, audienceId).orNotFound()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminInvitationController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminInvitationController.kt
@@ -17,7 +17,6 @@ import io.micronaut.http.annotation.*
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -63,28 +62,6 @@ class AdminInvitationController(
     @Operation(
         description = "Retrieve a paginated list of invitations, optionally filtered by audience.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "audience_id",
-                description = "Filter by audience identifier.",
-                schema = Schema(type = "string")
-            ),
-            Parameter(
-                name = "status",
-                description = "Filter by invitation status.",
-                schema = Schema(type = "string", allowableValues = ["pending", "consumed", "revoked", "expired"])
-            ),
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of invitations."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -98,10 +75,10 @@ class AdminInvitationController(
     @Secured(ADMIN_INVITATIONS_READ)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.INVITATIONS_READ])
     suspend fun listInvitations(
-        @QueryValue("audience_id") audienceId: String?,
-        @QueryValue status: String?,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @QueryValue("audience_id") @Parameter(description = "Filter by audience identifier.") audienceId: String?,
+        @QueryValue @Parameter(description = "Filter by invitation status.") status: String?,
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): AdminInvitationListResource {
         val (resolvedPage, resolvedSize) = resolvePageParams(page, size)
         val allInvitations = if (audienceId != null) {
@@ -129,13 +106,6 @@ class AdminInvitationController(
     @Operation(
         description = "Retrieve a single invitation by its identifier.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "invitationId",
-                description = "Unique identifier of the invitation.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Invitation details."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -150,7 +120,7 @@ class AdminInvitationController(
     @Secured(ADMIN_INVITATIONS_READ)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.INVITATIONS_READ])
     suspend fun getInvitation(
-        @PathVariable invitationId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the invitation.") invitationId: UUID
     ): AdminInvitationResource {
         val invitation = invitationManager.findByIdOrNull(invitationId).orNotFound()
         return invitationMapper.toResource(invitation)
@@ -159,13 +129,6 @@ class AdminInvitationController(
     @Operation(
         description = "Revoke a pending invitation.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "invitationId",
-                description = "Unique identifier of the invitation to revoke.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Invitation revoked."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -180,7 +143,7 @@ class AdminInvitationController(
     @Secured(ADMIN_INVITATIONS_WRITE)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.INVITATIONS_WRITE])
     suspend fun revokeInvitation(
-        @PathVariable invitationId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the invitation to revoke.") invitationId: UUID
     ): AdminInvitationResource {
         val invitation = invitationManager.revokeInvitation(invitationId)
         return invitationMapper.toResource(invitation)

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminScopeController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminScopeController.kt
@@ -12,7 +12,6 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -28,28 +27,6 @@ class AdminScopeController(
     @Operation(
         description = "Retrieve all configured scopes (consentable, grantable, client). Since scopes are defined in configuration, this endpoint exposes them as read-only resources.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            ),
-            Parameter(
-                name = "type",
-                description = "Filter by scope type.",
-                schema = Schema(type = "string", allowableValues = ["consentable", "grantable", "client"])
-            ),
-            Parameter(
-                name = "enabled",
-                description = "Filter by enabled status.",
-                schema = Schema(type = "boolean")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of scopes."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -61,10 +38,10 @@ class AdminScopeController(
     )
     @Get
     suspend fun listScopes(
-        @QueryValue page: Int?,
-        @QueryValue size: Int?,
-        @QueryValue type: String?,
-        @QueryValue enabled: Boolean?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?,
+        @QueryValue @Parameter(description = "Filter by scope type.") type: String?,
+        @QueryValue @Parameter(description = "Filter by enabled status.") enabled: Boolean?
     ): AdminScopeListResource {
         val (page, size) = resolvePageParams(page, size)
         val scopes = scopeManager.listScopes()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserClaimController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserClaimController.kt
@@ -39,53 +39,6 @@ class AdminUserClaimController(
     @Operation(
         description = "Retrieve a paginated list of claims for a given user, with metadata and filtering.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            ),
-            Parameter(
-                name = "claim_id",
-                description = "Filter by specific claim identifier.",
-                schema = Schema(type = "string")
-            ),
-            Parameter(
-                name = "identifier",
-                description = "Filter by whether the claim is an identifier claim.",
-                schema = Schema(type = "boolean")
-            ),
-            Parameter(
-                name = "required",
-                description = "Filter by whether the claim is required.",
-                schema = Schema(type = "boolean")
-            ),
-            Parameter(
-                name = "collected",
-                description = "Filter by whether the claim has been collected.",
-                schema = Schema(type = "boolean")
-            ),
-            Parameter(
-                name = "verified",
-                description = "Filter by whether the claim has been verified.",
-                schema = Schema(type = "boolean")
-            ),
-            Parameter(
-                name = "origin",
-                description = "Filter by claim origin.",
-                schema = Schema(type = "string", allowableValues = ["openid", "custom"])
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of user claims."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -99,15 +52,15 @@ class AdminUserClaimController(
     @Get
     @Secured(ADMIN_USERS_READ)
     suspend fun listUserClaims(
-        @PathVariable userId: UUID,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?,
-        @QueryValue("claim_id") claimId: String?,
-        @QueryValue identifier: Boolean?,
-        @QueryValue required: Boolean?,
-        @QueryValue collected: Boolean?,
-        @QueryValue verified: Boolean?,
-        @QueryValue origin: String?
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?,
+        @QueryValue("claim_id") @Parameter(description = "Filter by specific claim identifier.") claimId: String?,
+        @QueryValue @Parameter(description = "Filter by whether the claim is an identifier claim.") identifier: Boolean?,
+        @QueryValue @Parameter(description = "Filter by whether the claim is required.") required: Boolean?,
+        @QueryValue @Parameter(description = "Filter by whether the claim has been collected.") collected: Boolean?,
+        @QueryValue @Parameter(description = "Filter by whether the claim has been verified.") verified: Boolean?,
+        @QueryValue @Parameter(description = "Filter by claim origin.") origin: String?
     ): AdminUserClaimListResource {
         userManager.findByIdOrNull(userId).orNotFound()
         val (resolvedPage, resolvedSize) = resolvePageParams(page, size)

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserController.kt
@@ -21,7 +21,6 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -49,44 +48,6 @@ class AdminUserController(
                 "Claim values can be included in the response by specifying the 'claims' parameter. " +
                 "Dynamic query parameters matching claim identifiers are treated as exact-match filters.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            ),
-            Parameter(
-                name = "status",
-                description = "Filter by user status (e.g. enabled, disabled).",
-                schema = Schema(type = "string")
-            ),
-            Parameter(
-                name = "claims",
-                description = "Comma-separated list of claim IDs to include in the response. " +
-                        "Absent: all enabled claims. Empty string: no claims. Example: email,name.",
-                schema = Schema(type = "string")
-            ),
-            Parameter(
-                name = "q",
-                description = "Partial case-insensitive text search across all enabled claim values.",
-                schema = Schema(type = "string")
-            ),
-            Parameter(
-                name = "sort",
-                description = "Property to sort by: created_at, status, or a claim identifier.",
-                schema = Schema(type = "string", defaultValue = "created_at")
-            ),
-            Parameter(
-                name = "order",
-                description = "Sort direction: asc or desc.",
-                schema = Schema(type = "string", defaultValue = "asc")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of users."),
             ApiResponse(responseCode = "400", description = "Invalid claim ID, status, or sort property."),
@@ -100,13 +61,18 @@ class AdminUserController(
     @Get
     suspend fun listUsers(
         request: HttpRequest<*>,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?,
-        @QueryValue status: String?,
-        @QueryValue claims: String?,
-        @QueryValue q: String?,
-        @QueryValue sort: String?,
-        @QueryValue order: String?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?,
+        @QueryValue @Parameter(description = "Filter by user status (e.g. enabled, disabled).") status: String?,
+        @QueryValue @Parameter(
+            description = "Comma-separated list of claim IDs to include in the response. " +
+                    "Absent: all enabled claims. Empty string: no claims. Example: email,name."
+        ) claims: String?,
+        @QueryValue @Parameter(
+            description = "Partial case-insensitive text search across all enabled claim values."
+        ) q: String?,
+        @QueryValue @Parameter(description = "Property to sort by: created_at, status, or a claim identifier.") sort: String?,
+        @QueryValue @Parameter(description = "Sort direction: asc or desc.") order: String?
     ): AdminUserListResource {
         val (page, size) = resolvePageParams(page, size)
 
@@ -149,13 +115,6 @@ class AdminUserController(
     @Operation(
         description = "Retrieve details for a specific user by their identifier.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "id",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "User details."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -168,7 +127,7 @@ class AdminUserController(
     )
     @Get("/{id}")
     suspend fun getUser(
-        @PathVariable id: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the user.") id: UUID
     ): AdminUserDetailResource {
         val user = userManager.findByIdOrNull(id).orNotFound()
         val identifierClaims = collectedClaimManager.findIdentifierByUserId(user.id)

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserLogoutController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserLogoutController.kt
@@ -16,7 +16,6 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -33,13 +32,6 @@ class AdminUserLogoutController(
     @Operation(
         description = "Force logout a user by revoking all their tokens across all clients.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Tokens revoked successfully."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -53,7 +45,7 @@ class AdminUserLogoutController(
     @Post
     @Secured(ADMIN_CONSENT_WRITE)
     suspend fun forceLogout(
-        @PathVariable userId: UUID,
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
         authentication: Authentication
     ): AdminForceLogoutResource {
         userManager.findByIdOrNull(userId).orNotFound()
@@ -72,18 +64,6 @@ class AdminUserLogoutController(
     @Operation(
         description = "Force logout a user from a specific client by revoking their tokens for that client.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "clientId",
-                description = "Identifier of the client.",
-                schema = Schema(type = "string")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Tokens revoked successfully."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -97,8 +77,8 @@ class AdminUserLogoutController(
     @Post("/{clientId}")
     @Secured(ADMIN_CONSENT_WRITE)
     suspend fun forceClientLogout(
-        @PathVariable userId: UUID,
-        @PathVariable clientId: String,
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @PathVariable @Parameter(description = "Identifier of the client.") clientId: String,
         authentication: Authentication
     ): AdminForceLogoutResource {
         userManager.findByIdOrNull(userId).orNotFound()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaController.kt
@@ -16,7 +16,6 @@ import io.micronaut.http.annotation.*
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -32,23 +31,6 @@ class AdminUserMfaController(
     @Operation(
         description = "Retrieve a paginated list of registered MFA methods for a given user.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of MFA methods."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -63,9 +45,9 @@ class AdminUserMfaController(
     @Secured(ADMIN_USERS_READ)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.USERS_READ])
     suspend fun listMfaMethods(
-        @PathVariable userId: UUID,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): AdminUserMfaMethodListResource {
         userManager.findByIdOrNull(userId).orNotFound()
         val (page, size) = resolvePageParams(page, size)
@@ -86,18 +68,6 @@ class AdminUserMfaController(
         description = "Revoke a specific MFA method registered by a user. " +
                 "The user will need to re-enroll on their next sign-in if MFA is required.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "mfaId",
-                description = "Unique identifier of the MFA registration to revoke.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "MFA method revoked successfully."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -112,8 +82,8 @@ class AdminUserMfaController(
     @Secured(ADMIN_USERS_WRITE)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.USERS_WRITE])
     suspend fun revokeMfaMethod(
-        @PathVariable userId: UUID,
-        @PathVariable mfaId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @PathVariable @Parameter(description = "Unique identifier of the MFA registration to revoke.") mfaId: UUID
     ): AdminUserMfaRevokeResource {
         userManager.findByIdOrNull(userId).orNotFound()
         val enrollment = totpManager.findConfirmedEnrollmentOrNull(mfaId).orNotFound()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
@@ -14,7 +14,6 @@ import io.micronaut.http.annotation.*
 import io.micronaut.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -29,23 +28,6 @@ class AdminUserProviderController(
     @Operation(
         description = "Retrieve a paginated list of external identity providers linked to a user.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of linked providers."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -60,9 +42,9 @@ class AdminUserProviderController(
     @Secured(ADMIN_USERS_READ)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.USERS_READ])
     suspend fun listProviders(
-        @PathVariable userId: UUID,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): AdminUserProviderListResource {
         userManager.findByIdOrNull(userId).orNotFound()
         val (page, size) = resolvePageParams(page, size)
@@ -88,18 +70,6 @@ class AdminUserProviderController(
     @Operation(
         description = "Remove the link between a user and an external identity provider.",
         tags = ["admin"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            ),
-            Parameter(
-                name = "providerId",
-                description = "Identifier of the provider to unlink.",
-                schema = Schema(type = "string")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Provider unlinked successfully."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -117,8 +87,8 @@ class AdminUserProviderController(
     @Secured(ADMIN_USERS_WRITE)
     @SecurityRequirement(name = "admin", scopes = [AdminScopeId.USERS_WRITE])
     suspend fun unlinkProvider(
-        @PathVariable userId: UUID,
-        @PathVariable providerId: String
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @PathVariable @Parameter(description = "Identifier of the provider to unlink.") providerId: String
     ): AdminUserProviderUnlinkResource {
         userManager.findByIdOrNull(userId).orNotFound()
         providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, providerId).orNotFound()

--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientInvitationController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientInvitationController.kt
@@ -20,7 +20,6 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -73,18 +72,6 @@ class ClientInvitationController(
     @Operation(
         description = "Retrieve a paginated list of invitations created by this client.",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of invitations."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -99,8 +86,8 @@ class ClientInvitationController(
     @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.INVITATIONS_READ])
     suspend fun listInvitations(
         authentication: Authentication,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?
     ): ClientInvitationListResource {
         val clientAuth = authentication.clientAuthentication
         val (resolvedPage, resolvedSize) = resolvePageParams(page, size)
@@ -120,13 +107,6 @@ class ClientInvitationController(
     @Operation(
         description = "Retrieve a single invitation created by this client.",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "invitationId",
-                description = "Unique identifier of the invitation.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Invitation details."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -142,7 +122,7 @@ class ClientInvitationController(
     @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.INVITATIONS_READ])
     suspend fun getInvitation(
         authentication: Authentication,
-        @PathVariable invitationId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the invitation.") invitationId: UUID
     ): ClientInvitationResource {
         val clientAuth = authentication.clientAuthentication
         val invitation = invitationManager.findByIdOrNull(invitationId)
@@ -154,13 +134,6 @@ class ClientInvitationController(
     @Operation(
         description = "Revoke a pending invitation created by this client.",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "invitationId",
-                description = "Unique identifier of the invitation to revoke.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Invitation revoked."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -176,7 +149,7 @@ class ClientInvitationController(
     @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.INVITATIONS_WRITE])
     suspend fun revokeInvitation(
         authentication: Authentication,
-        @PathVariable invitationId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the invitation to revoke.") invitationId: UUID
     ): ClientInvitationResource {
         val clientAuth = authentication.clientAuthentication
         invitationManager.findByIdOrNull(invitationId)

--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientUserClaimController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientUserClaimController.kt
@@ -20,7 +20,6 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -41,13 +40,6 @@ class ClientUserClaimController(
     @Operation(
         description = "Retrieve claims for a user (only those the user has consented to share, plus custom claims).",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "User claims."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -63,7 +55,7 @@ class ClientUserClaimController(
     @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.USERS_CLAIMS_READ])
     suspend fun getUserClaims(
         authentication: Authentication,
-        @PathVariable userId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID
     ): ClientUserClaimResource {
         val clientAuth = authentication.clientAuthentication
         val client = clientManager.findClientById(clientAuth.clientId)
@@ -81,13 +73,6 @@ class ClientUserClaimController(
     @Operation(
         description = "Update custom claims for a user. Only claims prefixed with 'custom_' can be modified.",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Updated user claims."),
             ApiResponse(
@@ -107,7 +92,7 @@ class ClientUserClaimController(
     @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.USERS_CLAIMS_WRITE])
     suspend fun updateUserClaims(
         authentication: Authentication,
-        @PathVariable userId: UUID,
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
         @Body body: Map<String, Any?>
     ): ClientUserClaimResource {
         val clientAuth = authentication.clientAuthentication

--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientUserController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientUserController.kt
@@ -19,7 +19,6 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.inject.Inject
@@ -37,28 +36,6 @@ class ClientUserController(
     @Operation(
         description = "Retrieve a paginated list of end-users who have granted scopes to the requesting client.",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "page",
-                description = "Zero-indexed page number.",
-                schema = Schema(type = "integer", defaultValue = "0")
-            ),
-            Parameter(
-                name = "size",
-                description = "Number of results per page.",
-                schema = Schema(type = "integer", defaultValue = "20")
-            ),
-            Parameter(
-                name = "provider_id",
-                description = "Filter users linked to a specific provider.",
-                schema = Schema(type = "string")
-            ),
-            Parameter(
-                name = "subject",
-                description = "Filter by provider subject ID. Must be used together with provider_id.",
-                schema = Schema(type = "string")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "Paginated list of users."),
             ApiResponse(responseCode = "400", description = "Invalid query parameters."),
@@ -72,10 +49,10 @@ class ClientUserController(
     @Get
     suspend fun listUsers(
         authentication: Authentication,
-        @QueryValue page: Int?,
-        @QueryValue size: Int?,
-        @QueryValue("provider_id") providerId: String?,
-        @QueryValue subject: String?
+        @QueryValue @Parameter(description = "Zero-indexed page number.") page: Int?,
+        @QueryValue @Parameter(description = "Number of results per page.") size: Int?,
+        @QueryValue("provider_id") @Parameter(description = "Filter users linked to a specific provider.") providerId: String?,
+        @QueryValue @Parameter(description = "Filter by provider subject ID. Must be used together with provider_id.") subject: String?
     ): ClientUserListResource {
         if (subject != null && providerId == null) {
             throw businessExceptionOf("client.subject_without_provider")
@@ -103,13 +80,6 @@ class ClientUserController(
     @Operation(
         description = "Retrieve basic information about a specific user's authorization status.",
         tags = ["client"],
-        parameters = [
-            Parameter(
-                name = "userId",
-                description = "Unique identifier of the user.",
-                schema = Schema(type = "string", format = "uuid")
-            )
-        ],
         responses = [
             ApiResponse(responseCode = "200", description = "User information."),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
@@ -123,7 +93,7 @@ class ClientUserController(
     @Get("/{userId}")
     suspend fun getUser(
         authentication: Authentication,
-        @PathVariable userId: UUID
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID
     ): ClientUserResource {
         val clientAuth = authentication.clientAuthentication
         val client = clientManager.findClientById(clientAuth.clientId)


### PR DESCRIPTION
## What & why

`integration-tests` now calls the server through a **typed Micronaut `@Client` generated from the server's OpenAPI spec**, so the request/response models and endpoint paths are declared once (by the server) and consumed — no hand-copied wire models on the test side.

```
server (micronaut-openapi KSP) ── syncOpenApiSpec ──► build/openapi/openapi.yml
        └► integration-tests: io.micronaut.openapi generates a Kotlin @Client("sympauthy")
           (models + API interfaces) ──► compiled into main ──► driven from the tests
```

- **Live-wired**: `generateClientOpenApi*` depends on `:server:syncOpenApiSpec`, so a wire-format change regenerates the client and **fails compilation on drift**.
- **Driving it**: `withApiClient(...)` (in `AbstractSympauthyIT`) starts an `ApplicationContext` bound to the container URL; `BearerTokenClientFilter` injects the flow's access token (the generated client has no auth parameter). `SignUpWithAllOpenIdClaimFeatureIT` reads claims via `AdminApi.listUserClaims(...)` + typed models instead of `JSONObjectUtils` map-fishing.

## Server-side spec fix (14 controllers)

The admin/client controllers documented parameters via a method-level `@Operation(parameters=[…])` block. When an `@Operation` parameter name matches a bound method argument, micronaut-openapi keeps the description but **drops the schema**, so those params were emitted **typeless** in the published spec (a real bug for every spec consumer, and it broke client generation). Fixed by moving the docs to inline `@Parameter(description=…)` and letting Micronaut infer the type from the Kotlin signature. Convention documented in `CLAUDE.md`.

## Generator workarounds (in `integration-tests/build.gradle.kts`)

The Micronaut OpenAPI generator needed a few nudges to produce a runnable client for this spec — each documented inline:

1. **Plain Jackson models** (`serializationFramework=JACKSON`) — the Serde KSP introspection generator mis-generates a `BeanIntrospection` for the models (duplicate `$property$keys$metadata` → `ClassFormatError` at startup).
2. **Strip `@Introspected`** from generated models (via a `doLast` on the generator) — `SignUpInputResource` extends `HashMap` (from the server's `@JsonAnySetter` claims map), and `@Introspected` on a Map subclass reproduces the same crash; Jackson-databind needs no introspection anyway.
3. **Retype `ZonedDateTime → LocalDateTime`** — the generator hardcodes `date-time → ZonedDateTime`, but the server serializes zoneless `LocalDateTime`.

## Test plan

- [x] `./gradlew :server:test` — green
- [x] `./gradlew :integration-tests:integrationTest --tests "*SignUpWithAllOpenIdClaimFeatureIT"` — passes on **H2** and **PostgreSQL** through the generated client
- [x] Incremental re-run (no clean) — up-to-date, no stale bytecode

🤖 Generated with [Claude Code](https://claude.com/claude-code)