### PR TITLE
Add a CONFIRM interactive-flow purpose to approve client-initiated actions

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentController.kt
@@ -114,6 +114,7 @@ end-user's browser to. Once enrollment completes, the end-user is redirected to 
             userId = userId,
             returnUri = returnUri,
             flow = flow,
+            initiatingClientId = client.id,
             cancelUri = cancelUri
         )
 

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/ConfirmController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/ConfirmController.kt
@@ -1,0 +1,85 @@
+package com.sympauthy.api.controller.flow
+
+import com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil
+import com.sympauthy.api.resource.flow.ConfirmFlowResource
+import com.sympauthy.api.resource.flow.SimpleFlowResource
+import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
+import com.sympauthy.security.SecurityRule.HAS_STATE
+import com.sympauthy.security.stateOrNull
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.inject.Inject
+
+/**
+ * Drives the confirmation step of an interactive flow: the signed-in end-user must explicitly approve an
+ * action a client (or an administrator) initiated on their behalf (an [com.sympauthy.business.model.flow.InteractiveFlowPurpose.CONFIRM] gate)
+ * before the rest of the flow runs. Denial is handled by cancelling the flow via `POST /api/v1/flow/cancel`.
+ */
+@Controller("/api/v1/flow/confirm")
+@Secured(HAS_STATE)
+class ConfirmController(
+    @Inject private val confirmManager: InteractiveFlowSessionConfirmManager,
+    @Inject private val interactiveAuthFlowSessionControllerUtil: InteractiveAuthFlowSessionControllerUtil
+) {
+
+    @Operation(
+        description = """
+Return everything the custom UI needs to render the confirmation step (the action the end-user is asked to
+approve and the client that initiated it), or a redirect URL if the end-user is not expected to be on the
+confirmation step (ex. the confirmation was already given, or the flow carries no confirmation step).
+
+This configuration only contains information associated to this authorization server, the client and the
+on-going flow. All URLs it contains already include the state query param.
+        """,
+        tags = ["flow"]
+    )
+    @Get
+    suspend fun getConfirmation(
+        authentication: Authentication
+    ): ConfirmFlowResource =
+        interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect(
+            state = authentication.stateOrNull,
+            run = { session, _ ->
+                val confirm = confirmManager.fetchConfirmOrNull(session)
+                if (confirm != null && !confirm.confirmed) {
+                    ConfirmFlowResource(
+                        action = confirm.action.name,
+                        initiatingClientId = confirm.clientId
+                    )
+                } else {
+                    null
+                }
+            },
+            mapResultToResource = { it },
+            mapRedirectUriToResource = { ConfirmFlowResource(redirectUrl = it.toString()) }
+        )
+
+    @Operation(
+        description = "Approve the action the end-user was asked to confirm. The flow then continues to the next step.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The action was approved. Contains the redirect URL to continue the flow.",
+                useReturnTypeSchema = true
+            )
+        ],
+        tags = ["flow"]
+    )
+    @Post
+    suspend fun confirm(
+        authentication: Authentication
+    ): SimpleFlowResource =
+        interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenUpdateAndRedirect(
+            state = authentication.stateOrNull,
+            update = { session, _ ->
+                confirmManager.markConfirmed(session)
+                session
+            },
+            mapRedirectUriToResource = { redirectUri -> SimpleFlowResource(redirectUri.toString()) }
+        )
+}

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/InteractiveFlowStepUriMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/InteractiveFlowStepUriMapper.kt
@@ -66,6 +66,10 @@ class InteractiveFlowStepUriMapper(
             session,
             flow.mfaTotpChallengeUri ?: throw internalBusinessExceptionOf("flow.mfa.totp.challenge_uri.missing")
         )
+        InteractiveFlowStep.Confirm -> appendState(
+            session,
+            flow.confirmUri ?: throw internalBusinessExceptionOf("flow.confirm.uri.missing")
+        )
         InteractiveFlowStep.CollectClaims -> appendState(session, flow.collectClaimsUri)
         is InteractiveFlowStep.ValidateClaims -> appendState(session, buildValidateClaimsUri(flow, step.media))
         InteractiveFlowStep.Error -> appendState(session, flow.errorUri)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/ConfirmFlowResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/ConfirmFlowResource.kt
@@ -1,0 +1,52 @@
+package com.sympauthy.api.resource.flow
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = """
+Everything the custom UI needs to render the confirmation step, where the signed-in end-user must explicitly
+approve an action a client (or an administrator) initiated on their behalf before the flow proceeds.
+
+This resource returns either:
+- the context of the confirmation step (```action```, ```initiating_client_id```), which the custom UI turns
+  into localized copy describing what is being approved and who requested it.
+- a ```redirect_url``` where the end-user must be redirected to continue the flow (e.g. once already
+  confirmed, or when the session carries no confirmation step). When set, all other fields are null.
+
+The end-user approves by calling ```POST /api/v1/flow/confirm``` or denies by cancelling the flow via
+```POST /api/v1/flow/cancel```.
+
+Every URL contained in this resource already includes the ```state``` query param.
+"""
+)
+@Serdeable
+data class ConfirmFlowResource(
+    @get:Schema(
+        description = """
+Machine-readable code of the action the end-user is asked to approve (e.g. ```ENROLL_MFA```). Null when this
+resource carries a ```redirect_url```.
+        """
+    )
+    val action: String? = null,
+    @get:Schema(
+        name = "initiating_client_id",
+        description = """
+Identifier of the client that initiated the action on the end-user's behalf. Null when the action was
+initiated by an administrator (the custom UI should then render a generic initiator such as
+"an administrator"), or when this resource carries a ```redirect_url```.
+        """
+    )
+    @get:JsonProperty("initiating_client_id")
+    val initiatingClientId: String? = null,
+    @get:Schema(
+        name = "redirect_url",
+        description = """
+URL where the end-user must be redirected to continue the flow instead of rendering the confirmation step.
+When set, all other fields are null.
+        """
+    )
+    @get:JsonProperty("redirect_url")
+    val redirectUrl: String? = null
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManager.kt
@@ -47,6 +47,7 @@ class AuthorizationFlowManager(
             collectClaimsUri = UriBuilder.of(rootUri).path("claims/edit").build(),
             validateClaimsUri = UriBuilder.of(rootUri).path("claims/validate").build(),
             errorUri = UriBuilder.of(rootUri).path("error").build(),
+            confirmUri = UriBuilder.of(rootUri).path("confirm").build(),
         )
     }
 

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionCleaner.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionCleaner.kt
@@ -2,6 +2,7 @@ package com.sympauthy.business.manager.flow
 
 import com.sympauthy.data.model.InteractiveFlowSessionEntity
 import com.sympauthy.data.repository.AuthorizationCodeRepository
+import com.sympauthy.data.repository.InteractiveFlowSessionConfirmRepository
 import com.sympauthy.data.repository.InteractiveFlowSessionOAuth2Repository
 import com.sympauthy.data.repository.InteractiveFlowSessionProviderRepository
 import com.sympauthy.data.repository.InteractiveFlowSessionRepository
@@ -21,6 +22,7 @@ open class InteractiveFlowSessionCleaner(
     @Inject private val sessionRepository: InteractiveFlowSessionRepository,
     @Inject private val oauth2Repository: InteractiveFlowSessionOAuth2Repository,
     @Inject private val providerRepository: InteractiveFlowSessionProviderRepository,
+    @Inject private val confirmRepository: InteractiveFlowSessionConfirmRepository,
     @Inject private val validationCodeRepository: ValidationCodeRepository,
     @Inject private val authorizationCodeRepository: AuthorizationCodeRepository,
 ) {
@@ -43,11 +45,15 @@ open class InteractiveFlowSessionCleaner(
         val deferredProviderCount = async {
             providerRepository.deleteBySessionIdIn(expiredSessionIds)
         }
+        val deferredConfirmCount = async {
+            confirmRepository.deleteBySessionIdIn(expiredSessionIds)
+        }
 
         val authorizationCodesCount = deferredAuthorizationCodesCount.await()
         val validationCodesCount = deferredValidationCodesCount.await()
         deferredOAuth2Count.await()
         deferredProviderCount.await()
+        deferredConfirmCount.await()
 
         val sessionsCount = sessionRepository.deleteByIds(expiredSessionIds)
 

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/confirm/ConfirmInteractiveFlowPurposeHandler.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/confirm/ConfirmInteractiveFlowPurposeHandler.kt
@@ -1,0 +1,33 @@
+package com.sympauthy.business.manager.flow.confirm
+
+import com.sympauthy.business.manager.flow.InteractiveFlowPurposeHandler
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * [InteractiveFlowPurposeHandler] for [InteractiveFlowPurpose.CONFIRM].
+ *
+ * Gates the rest of the session on the signed-in end-user explicitly approving the action a client (or an
+ * administrator) initiated on their behalf. While not approved, it presents the confirmation step
+ * ([InteractiveFlowStep.Confirm]); the purpose resolves once the session's confirm record is marked confirmed
+ * (the persisted [com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm.confirmed] marker).
+ *
+ * The purpose has no terminal effect: the approval is recorded during its step, so the engine simply marks it
+ * complete once resolved. Cancellation (denial) is an explicit flow-API action that marks the session
+ * cancelled, handled outside this handler.
+ */
+@Singleton
+class ConfirmInteractiveFlowPurposeHandler(
+    @Inject private val confirmManager: InteractiveFlowSessionConfirmManager,
+) : InteractiveFlowPurposeHandler {
+
+    override val purpose = InteractiveFlowPurpose.CONFIRM
+
+    override suspend fun nextStepOrNull(session: OnGoingInteractiveFlowSession): InteractiveFlowStep? {
+        val confirmed = confirmManager.fetchConfirmOrNull(session)?.confirmed ?: false
+        return if (confirmed) null else InteractiveFlowStep.Confirm
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/confirm/InteractiveFlowSessionConfirmManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/confirm/InteractiveFlowSessionConfirmManager.kt
@@ -1,0 +1,74 @@
+package com.sympauthy.business.manager.flow.confirm
+
+import com.sympauthy.business.exception.internalBusinessExceptionOf
+import com.sympauthy.business.mapper.InteractiveFlowSessionConfirmMapper
+import com.sympauthy.business.model.flow.ConfirmActionType
+import com.sympauthy.business.model.flow.InteractiveFlowSession
+import com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.data.model.InteractiveFlowSessionConfirmEntity
+import com.sympauthy.data.repository.InteractiveFlowSessionConfirmRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.LocalDateTime
+
+/**
+ * Manager in charge of the confirm parameter attached to an [InteractiveFlowSession] by an
+ * [com.sympauthy.business.model.flow.InteractiveFlowPurpose.CONFIRM] gate. It provides methods to:
+ * - store (upsert) what the end-user is asked to approve and who initiated it.
+ * - fetch the confirm record of a session.
+ * - mark the confirmation as approved (the resolved marker of the CONFIRM purpose).
+ */
+@Singleton
+class InteractiveFlowSessionConfirmManager(
+    @Inject private val confirmRepository: InteractiveFlowSessionConfirmRepository,
+    @Inject private val confirmMapper: InteractiveFlowSessionConfirmMapper,
+) {
+
+    /**
+     * Store what the end-user of [session] is asked to approve, upserting the session's confirm record with the
+     * [action] and the [clientId] that initiated it (null for an administrator-initiated action). The record
+     * starts unconfirmed.
+     */
+    suspend fun setConfirm(
+        session: OnGoingInteractiveFlowSession,
+        action: ConfirmActionType,
+        clientId: String? = null
+    ): InteractiveFlowSessionConfirm {
+        val entity = InteractiveFlowSessionConfirmEntity(
+            sessionId = session.id,
+            action = action.name,
+            clientId = clientId,
+            confirmedDate = null
+        )
+        if (confirmRepository.findBySessionId(session.id) != null) {
+            confirmRepository.update(entity)
+        } else {
+            confirmRepository.save(entity)
+        }
+        return confirmMapper.toInteractiveFlowSessionConfirm(entity)
+    }
+
+    /**
+     * Return the [InteractiveFlowSessionConfirm] record attached to the [session], or null if the session
+     * carries no confirm gate.
+     */
+    suspend fun fetchConfirmOrNull(session: InteractiveFlowSession): InteractiveFlowSessionConfirm? {
+        return confirmRepository.findBySessionId(session.id)
+            ?.let(confirmMapper::toInteractiveFlowSessionConfirm)
+    }
+
+    /**
+     * Mark the confirmation of [session] as approved by the end-user, resolving the CONFIRM purpose.
+     *
+     * Throws an unrecoverable [com.sympauthy.business.exception.BusinessException] if the session carries no
+     * confirm record (the CONFIRM purpose was never set up).
+     */
+    suspend fun markConfirmed(session: OnGoingInteractiveFlowSession): InteractiveFlowSessionConfirm {
+        val entity = confirmRepository.findBySessionId(session.id)
+            ?: throw internalBusinessExceptionOf("flow.confirm.missing_record")
+        val confirmed = entity.copy(confirmedDate = LocalDateTime.now())
+        confirmRepository.update(confirmed)
+        return confirmMapper.toInteractiveFlowSessionConfirm(confirmed)
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManager.kt
@@ -2,8 +2,10 @@ package com.sympauthy.business.manager.flow.mfa
 
 import com.sympauthy.business.exception.internalBusinessExceptionOf
 import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
 import com.sympauthy.business.manager.mfa.TotpManager
 import com.sympauthy.business.model.flow.AuthorizationFlow
+import com.sympauthy.business.model.flow.ConfirmActionType
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowRedirectType
 import com.sympauthy.business.model.flow.InteractiveFlowStep
@@ -30,6 +32,7 @@ open class InteractiveFlowSessionMfaEnrollmentManager(
     @Inject private val sessionManager: InteractiveFlowSessionManager,
     @Inject private val uncheckedMfaConfig: MfaConfig,
     @Inject private val totpManager: TotpManager,
+    @Inject private val confirmManager: InteractiveFlowSessionConfirmManager,
 ) {
 
     /**
@@ -96,6 +99,11 @@ open class InteractiveFlowSessionMfaEnrollmentManager(
      * [InteractiveFlowRedirectType.PLAIN] redirect) and the optional [cancelUri] they are redirected back to if
      * they cancel, in a single transaction.
      *
+     * The enrollment is client-initiated, so the session is gated by an [InteractiveFlowPurpose.CONFIRM] step
+     * prepended in front of [InteractiveFlowPurpose.MFA_ENROLLMENT]: the end-user must explicitly approve the
+     * enrollment [initiatingClientId] requested before it begins. The confirm parameter is stored on the
+     * session's confirm record in the same transaction.
+     *
      * The [returnUri] and [cancelUri] must have been validated (e.g. against the initiating client's registered
      * redirect URIs) by the caller before reaching here.
      */
@@ -104,16 +112,23 @@ open class InteractiveFlowSessionMfaEnrollmentManager(
         userId: UUID,
         returnUri: URI,
         flow: AuthorizationFlow,
+        initiatingClientId: String,
         cancelUri: URI? = null,
     ): OnGoingInteractiveFlowSession {
         val session = sessionManager.newSession(
-            purposes = listOf(InteractiveFlowPurpose.MFA_ENROLLMENT),
+            purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
             flow = flow,
             successRedirectUri = returnUri,
             redirectType = InteractiveFlowRedirectType.PLAIN,
             cancelRedirectUri = cancelUri,
         ) as? OnGoingInteractiveFlowSession
             ?: throw internalBusinessExceptionOf("flow.mfa.enrollment.start.not_ongoing")
-        return sessionManager.setAuthenticatedUserId(session, userId)
+        val sessionWithUser = sessionManager.setAuthenticatedUserId(session, userId)
+        confirmManager.setConfirm(
+            session = sessionWithUser,
+            action = ConfirmActionType.ENROLL_MFA,
+            clientId = initiatingClientId
+        )
+        return sessionWithUser
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/BusinessMapperFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/BusinessMapperFactory.kt
@@ -69,4 +69,7 @@ class BusinessMapperFactory {
 
     @Singleton
     fun interactiveFlowSessionProviderMapper() = Mappers.getMapper(InteractiveFlowSessionProviderMapper::class.java)
+
+    @Singleton
+    fun interactiveFlowSessionConfirmMapper() = Mappers.getMapper(InteractiveFlowSessionConfirmMapper::class.java)
 }

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionConfirmMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionConfirmMapper.kt
@@ -1,0 +1,28 @@
+package com.sympauthy.business.mapper
+
+import com.sympauthy.business.mapper.config.ToBusinessMapperConfig
+import com.sympauthy.business.model.flow.ConfirmActionType
+import com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm
+import com.sympauthy.data.model.InteractiveFlowSessionConfirmEntity
+import org.mapstruct.Mapper
+
+/**
+ * Handle the mapping from the [InteractiveFlowSessionConfirmEntity] to the
+ * [InteractiveFlowSessionConfirm] business model.
+ */
+@Mapper(
+    config = ToBusinessMapperConfig::class
+)
+abstract class InteractiveFlowSessionConfirmMapper {
+
+    fun toInteractiveFlowSessionConfirm(
+        entity: InteractiveFlowSessionConfirmEntity
+    ): InteractiveFlowSessionConfirm {
+        return InteractiveFlowSessionConfirm(
+            sessionId = entity.sessionId,
+            action = ConfirmActionType.valueOf(entity.action),
+            clientId = entity.clientId,
+            confirmedDate = entity.confirmedDate,
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/AuthorizationFlow.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/AuthorizationFlow.kt
@@ -59,6 +59,14 @@ class InteractiveFlow(
      */
     val errorUri: URI,
     /**
+     * [URI] of the page asking the end-user to confirm an action a client initiated on their behalf.
+     * The end-user is redirected here when the session carries a [InteractiveFlowPurpose.CONFIRM] gate. That
+     * page calls GET /api/v1/flow/confirm to describe the action and the initiating party, then confirms or
+     * cancels the flow.
+     * Null if no confirm-gated flow is configured for this flow.
+     */
+    val confirmUri: URI? = null,
+    /**
      * [URI] of the MFA enrollment method-selection page.
      * The end-user is redirected here when they must enroll an MFA method. That page calls
      * GET /api/v1/flow/mfa to choose the method to enroll (and skip when optional).

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/ConfirmActionType.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/ConfirmActionType.kt
@@ -1,0 +1,16 @@
+package com.sympauthy.business.model.flow
+
+/**
+ * The machine-readable action an [InteractiveFlowPurpose.CONFIRM] gate asks the end-user to approve.
+ *
+ * Exposed to the custom confirmation UI (via the confirm flow controller) so it can render the localized copy
+ * describing what the end-user is about to approve. Stored on the session's attached confirm record
+ * ([InteractiveFlowSessionConfirm]).
+ */
+enum class ConfirmActionType {
+    /**
+     * The end-user is asked to approve enrolling a multi-factor authentication method, on behalf of a client
+     * that initiated the enrollment through the standalone MFA-enrollment endpoint.
+     */
+    ENROLL_MFA
+}

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowPurpose.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowPurpose.kt
@@ -8,6 +8,15 @@ package com.sympauthy.business.model.flow
  */
 enum class InteractiveFlowPurpose {
     /**
+     * A gate the signed-in end-user must clear before the rest of the session runs: they must explicitly
+     * approve an action a client (or an administrator) initiated on their behalf. Prepended in front of the
+     * initiating purpose (e.g. [MFA_ENROLLMENT]) so it is driven first; it owns no terminal handoff and is
+     * never a session's [InteractiveFlowSession.initiatingPurpose]. What is being confirmed is described by
+     * the session's attached confirm record ([InteractiveFlowSessionConfirm]).
+     */
+    CONFIRM,
+
+    /**
      * The session backs the OAuth2 / OpenID Connect authorization flow initiated by a client at
      * `/api/oauth2/authorize`.
      */

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSession.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSession.kt
@@ -45,8 +45,12 @@ sealed class InteractiveFlowSession(
 
     /**
      * The purpose that initiated the session and owns its terminal handoff.
+     *
+     * [InteractiveFlowPurpose.CONFIRM] is a gate prepended in front of the initiating purpose, so it is
+     * skipped here: the initiating purpose is the first non-[InteractiveFlowPurpose.CONFIRM] purpose.
      */
-    val initiatingPurpose: InteractiveFlowPurpose get() = purposes.first()
+    val initiatingPurpose: InteractiveFlowPurpose
+        get() = purposes.first { it != InteractiveFlowPurpose.CONFIRM }
 }
 
 /**

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionConfirm.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionConfirm.kt
@@ -1,0 +1,41 @@
+package com.sympauthy.business.model.flow
+
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * The parameter of an [InteractiveFlowPurpose.CONFIRM] gate: what the signed-in end-user is being asked to
+ * approve and who initiated it, attached to an [InteractiveFlowSession].
+ *
+ * Keyed by [sessionId] and fetched via
+ * [com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager], never carried on the
+ * session itself. Stored when a client-initiated flow prepends the [InteractiveFlowPurpose.CONFIRM] gate.
+ */
+data class InteractiveFlowSessionConfirm(
+    /**
+     * Identifier of the [InteractiveFlowSession] this confirm parameter is attached to.
+     */
+    val sessionId: UUID,
+
+    /**
+     * The action the end-user is asked to approve.
+     */
+    val action: ConfirmActionType,
+
+    /**
+     * The identifier of the client that initiated the action on the end-user's behalf, or null when the action
+     * was initiated by an administrator.
+     */
+    val clientId: String? = null,
+
+    /**
+     * When the end-user approved the action, or null while the confirmation is still pending. Acts as the
+     * resolved marker for the [InteractiveFlowPurpose.CONFIRM] purpose.
+     */
+    val confirmedDate: LocalDateTime? = null,
+) {
+    /**
+     * Whether the end-user has approved the action.
+     */
+    val confirmed: Boolean get() = confirmedDate != null
+}

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowStep.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowStep.kt
@@ -21,6 +21,13 @@ sealed interface InteractiveFlowStep {
     data object SignUp : InteractiveFlowStep
 
     /**
+     * The end-user must explicitly approve (confirm) an action a client initiated on their behalf before the
+     * flow proceeds. The confirmation page describes the action and the initiating party from the session's
+     * attached confirm record.
+     */
+    data object Confirm : InteractiveFlowStep
+
+    /**
      * The end-user must choose which multi-factor authentication method to enroll (and may skip when the
      * enrollment is optional). The selection page auto-redirects to the method's enrollment step when there is
      * a single method to enroll and no skip is offered.

--- a/server/src/main/kotlin/com/sympauthy/config/parsing/AuthorizationFlowsConfigParser.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/parsing/AuthorizationFlowsConfigParser.kt
@@ -14,6 +14,7 @@ data class ParsedAuthorizationFlow(
     val rootUri: URI?,
     val signInUri: URI?,
     val signUpUri: URI?,
+    val confirmUri: URI?,
     val collectClaimsUri: URI?,
     val validateClaimsUri: URI?,
     val errorUri: URI?,
@@ -62,6 +63,14 @@ class AuthorizationFlowsConfigParser(
                 parser.getUriOrThrow(
                     properties, "$configKeyPrefix.sign-up",
                     AuthorizationFlowConfigurationProperties::signUp
+                )
+            }
+        }
+        val confirmUri = properties.confirm?.let {
+            ctx.parse {
+                parser.getUriOrThrow(
+                    properties, "$configKeyPrefix.confirm",
+                    AuthorizationFlowConfigurationProperties::confirm
                 )
             }
         }
@@ -118,6 +127,7 @@ class AuthorizationFlowsConfigParser(
             rootUri = rootUri,
             signInUri = signInUri,
             signUpUri = signUpUri,
+            confirmUri = confirmUri,
             collectClaimsUri = collectClaimsUri,
             validateClaimsUri = validateClaimsUri,
             errorUri = errorUri,

--- a/server/src/main/kotlin/com/sympauthy/config/properties/AuthorizationFlowConfigurationProperties.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/properties/AuthorizationFlowConfigurationProperties.kt
@@ -21,6 +21,9 @@ class AuthorizationFlowConfigurationProperties(
     // Properties for sign-up (optional; only required when sign-up or invitation is enabled)
     var signUp: String? = null
 
+    // Property for the confirm page (optional; only required when a confirm-gated flow is configured)
+    var confirm: String? = null
+
     // Properties for MFA steps (optional; only required when MFA is enabled)
     var mfaSelectionForEnrollment: String? = null
     var mfaSelectionForChallenge: String? = null

--- a/server/src/main/kotlin/com/sympauthy/config/validation/AuthorizationFlowsConfigValidator.kt
+++ b/server/src/main/kotlin/com/sympauthy/config/validation/AuthorizationFlowsConfigValidator.kt
@@ -47,6 +47,7 @@ class AuthorizationFlowsConfigValidator(
 
         val signInUri = resolveUri(rootUri, parsed.signInUri)
         val signUpUri = parsed.signUpUri?.let { resolveUri(rootUri, it) }
+        val confirmUri = parsed.confirmUri?.let { resolveUri(rootUri, it) }
         val collectClaimsUri = resolveUri(rootUri, parsed.collectClaimsUri)
         val validateClaimsUri = resolveUri(rootUri, parsed.validateClaimsUri)
         val errorUri = resolveUri(rootUri, parsed.errorUri)
@@ -96,6 +97,7 @@ class AuthorizationFlowsConfigValidator(
             id = parsed.id,
             signInUri = signInUri,
             signUpUri = signUpUri,
+            confirmUri = confirmUri,
             collectClaimsUri = collectClaimsUri,
             validateClaimsUri = validateClaimsUri,
             errorUri = errorUri,

--- a/server/src/main/kotlin/com/sympauthy/data/h2/repository/H2InteractiveFlowSessionConfirmRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/h2/repository/H2InteractiveFlowSessionConfirmRepository.kt
@@ -1,0 +1,12 @@
+package com.sympauthy.data.h2.repository
+
+import com.sympauthy.data.h2.DefaultDataSourceIsH2
+import com.sympauthy.data.repository.InteractiveFlowSessionConfirmRepository
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.model.query.builder.sql.Dialect.H2
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@Suppress("unused")
+@Requires(condition = DefaultDataSourceIsH2::class)
+@R2dbcRepository(dialect = H2)
+interface H2InteractiveFlowSessionConfirmRepository : InteractiveFlowSessionConfirmRepository

--- a/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionConfirmEntity.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionConfirmEntity.kt
@@ -1,0 +1,17 @@
+package com.sympauthy.data.model
+
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.serde.annotation.Serdeable
+import java.time.LocalDateTime
+import java.util.*
+
+@Serdeable
+@MappedEntity("interactive_flow_session_confirm")
+data class InteractiveFlowSessionConfirmEntity(
+    @get:Id
+    val sessionId: UUID,
+    val action: String,
+    val clientId: String? = null,
+    val confirmedDate: LocalDateTime? = null,
+)

--- a/server/src/main/kotlin/com/sympauthy/data/postgresql/repository/PostgreSQLInteractiveFlowSessionConfirmRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/postgresql/repository/PostgreSQLInteractiveFlowSessionConfirmRepository.kt
@@ -1,0 +1,12 @@
+package com.sympauthy.data.postgresql.repository
+
+import com.sympauthy.data.postgresql.DefaultDataSourceIsPostgreSQL
+import com.sympauthy.data.repository.InteractiveFlowSessionConfirmRepository
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@Suppress("unused")
+@Requires(condition = DefaultDataSourceIsPostgreSQL::class)
+@R2dbcRepository(dialect = POSTGRES)
+interface PostgreSQLInteractiveFlowSessionConfirmRepository : InteractiveFlowSessionConfirmRepository

--- a/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionConfirmRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionConfirmRepository.kt
@@ -1,0 +1,13 @@
+package com.sympauthy.data.repository
+
+import com.sympauthy.data.model.InteractiveFlowSessionConfirmEntity
+import io.micronaut.data.repository.kotlin.CoroutineCrudRepository
+import java.util.*
+
+interface InteractiveFlowSessionConfirmRepository :
+    CoroutineCrudRepository<InteractiveFlowSessionConfirmEntity, UUID> {
+
+    suspend fun findBySessionId(sessionId: UUID): InteractiveFlowSessionConfirmEntity?
+
+    suspend fun deleteBySessionIdIn(sessionIds: List<UUID>): Int
+}

--- a/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
@@ -143,6 +143,15 @@
     ]
   },
   {
+    "name": "com.sympauthy.business.mapper.InteractiveFlowSessionConfirmMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sympauthy.business.mapper.ConsentMapperImpl",
     "methods": [
       {

--- a/server/src/main/resources/databases/h2/V0_5_0_17__interactive_flow_session_confirm_new.sql
+++ b/server/src/main/resources/databases/h2/V0_5_0_17__interactive_flow_session_confirm_new.sql
@@ -1,0 +1,10 @@
+CREATE TABLE interactive_flow_session_confirm
+(
+    session_id     uuid NOT NULL,
+    action         text NOT NULL,
+    client_id      text,
+    confirmed_date timestamp,
+
+    PRIMARY KEY (session_id),
+    FOREIGN KEY (session_id) REFERENCES interactive_flow_sessions (id)
+);

--- a/server/src/main/resources/databases/postgresql/V0_5_0_17__interactive_flow_session_confirm_new.sql
+++ b/server/src/main/resources/databases/postgresql/V0_5_0_17__interactive_flow_session_confirm_new.sql
@@ -1,0 +1,10 @@
+CREATE TABLE interactive_flow_session_confirm
+(
+    session_id     uuid NOT NULL,
+    action         text NOT NULL,
+    client_id      text,
+    confirmed_date timestamp,
+
+    PRIMARY KEY (session_id),
+    FOREIGN KEY (session_id) REFERENCES interactive_flow_sessions (id)
+);

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -200,6 +200,7 @@ flow.mfa.totp.enroll.no_pending_enrollment=No pending TOTP enrollment found for 
 description.flow.mfa.totp.enroll.no_pending_enrollment=No TOTP enrollment is in progress. Please restart the enrollment process.
 flow.mfa.totp.enroll_uri.missing=The MFA TOTP enrollment URI is not configured for this authorization flow.
 flow.mfa.selection_for_enrollment_uri.missing=The MFA enrollment selection URI is not configured for this authorization flow.
+flow.confirm.uri.missing=The confirm page URI is not configured for this authorization flow.
 flow.purpose.unsupported=No flow purpose handler is registered for the session purpose {purpose}.
 flow.redirect.unhandled_status=The authorization flow reached an unexpected status with no matching redirect URI.
 flow.sign_up.disabled=Sign-up is disabled for this application.

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -201,6 +201,7 @@ description.flow.mfa.totp.enroll.no_pending_enrollment=No TOTP enrollment is in 
 flow.mfa.totp.enroll_uri.missing=The MFA TOTP enrollment URI is not configured for this authorization flow.
 flow.mfa.selection_for_enrollment_uri.missing=The MFA enrollment selection URI is not configured for this authorization flow.
 flow.confirm.uri.missing=The confirm page URI is not configured for this authorization flow.
+flow.confirm.missing_record=The confirmation could not be recorded: the session carries no confirm record.
 flow.purpose.unsupported=No flow purpose handler is registered for the session purpose {purpose}.
 flow.redirect.unhandled_status=The authorization flow reached an unexpected status with no matching redirect URI.
 flow.sign_up.disabled=Sign-up is disabled for this application.

--- a/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientMfaEnrollmentControllerTest.kt
@@ -91,12 +91,15 @@ class ClientMfaEnrollmentControllerTest {
             val enrollUri = URI.create("https://auth.example.com/flow/mfa/enrollment?state=abc")
 
             coEvery { clientManager.findClientById("client-id") } returns client
+            every { client.id } returns "client-id"
             coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
             every {
                 interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, "https://client.example.com/done")
             } returns returnUri
             coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
-            coEvery { mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow) } returns session
+            coEvery {
+                mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow, "client-id")
+            } returns session
             coEvery { engine.advance(session) } returns
                 InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.MfaSelectionForEnrollment)
             coEvery {
@@ -132,6 +135,7 @@ class ClientMfaEnrollmentControllerTest {
         val enrollUri = URI.create("https://auth.example.com/flow/mfa/enrollment?state=abc")
 
         coEvery { clientManager.findClientById("client-id") } returns client
+        every { client.id } returns "client-id"
         coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
         every {
             interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, "https://client.example.com/done")
@@ -141,7 +145,9 @@ class ClientMfaEnrollmentControllerTest {
         } returns cancelUri
         coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
         // The stub only matches (and thus drives the redirect) when the validated cancel URI is threaded through.
-        coEvery { mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow, cancelUri) } returns session
+        coEvery {
+            mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow, "client-id", cancelUri)
+        } returns session
         coEvery { engine.advance(session) } returns
             InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.MfaSelectionForEnrollment)
         coEvery {
@@ -176,7 +182,7 @@ class ClientMfaEnrollmentControllerTest {
         }
 
         assertEquals("client.mfa.enrollment.mfa_disabled", exception.detailsId)
-        coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any()) }
+        coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any(), any()) }
     }
 
     @Test
@@ -198,7 +204,7 @@ class ClientMfaEnrollmentControllerTest {
         }
 
         assertEquals("client.mfa.enrollment.invalid_access_token", exception.detailsId)
-        coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any()) }
+        coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any(), any()) }
     }
 
     @Test
@@ -224,6 +230,6 @@ class ClientMfaEnrollmentControllerTest {
             }
 
             assertEquals("client.mfa.enrollment.invalid_access_token", exception.detailsId)
-            coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any()) }
+            coVerify(exactly = 0) { mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any(), any()) }
         }
 }

--- a/server/src/test/kotlin/com/sympauthy/api/controller/flow/ConfirmControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/flow/ConfirmControllerTest.kt
@@ -1,0 +1,109 @@
+package com.sympauthy.api.controller.flow
+
+import com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil
+import com.sympauthy.api.resource.flow.ConfirmFlowResource
+import com.sympauthy.api.resource.flow.SimpleFlowResource
+import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
+import com.sympauthy.business.model.flow.ConfirmActionType
+import com.sympauthy.business.model.flow.InteractiveFlow
+import com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.security.StateAuthentication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+
+@ExtendWith(MockKExtension::class)
+class ConfirmControllerTest {
+
+    @MockK
+    lateinit var confirmManager: InteractiveFlowSessionConfirmManager
+
+    @MockK
+    lateinit var interactiveAuthFlowSessionControllerUtil: InteractiveAuthFlowSessionControllerUtil
+
+    private val controller by lazy {
+        ConfirmController(confirmManager, interactiveAuthFlowSessionControllerUtil)
+    }
+
+    private val session = mockk<OnGoingInteractiveFlowSession>()
+    private val flow = mockk<InteractiveFlow>()
+
+    @Test
+    fun `getConfirmation - Returns the action context while the confirmation is pending`() = runTest {
+        val confirm = mockk<InteractiveFlowSessionConfirm> {
+            every { confirmed } returns false
+            every { action } returns ConfirmActionType.ENROLL_MFA
+            every { clientId } returns "client-x"
+        }
+        coEvery { confirmManager.fetchConfirmOrNull(session) } returns confirm
+        coEvery {
+            interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect<ConfirmFlowResource, ConfirmFlowResource>(
+                eq("encoded-state"), any(), any(), any()
+            )
+        } coAnswers {
+            val run = arg<suspend (OnGoingInteractiveFlowSession, InteractiveFlow) -> ConfirmFlowResource?>(1)
+            val mapResultToResource = arg<suspend (ConfirmFlowResource) -> ConfirmFlowResource>(3)
+            mapResultToResource(run(session, flow)!!)
+        }
+
+        val result = controller.getConfirmation(StateAuthentication("encoded-state"))
+
+        assertEquals("ENROLL_MFA", result.action)
+        assertEquals("client-x", result.initiatingClientId)
+        assertNull(result.redirectUrl)
+    }
+
+    @Test
+    fun `getConfirmation - Redirects once the confirmation was already given`() = runTest {
+        val confirm = mockk<InteractiveFlowSessionConfirm> { every { confirmed } returns true }
+        val redirectUri = URI.create("https://auth.example.com/flow/mfa/enrollment?state=encoded-state")
+        coEvery { confirmManager.fetchConfirmOrNull(session) } returns confirm
+        coEvery {
+            interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect<ConfirmFlowResource, ConfirmFlowResource>(
+                eq("encoded-state"), any(), any(), any()
+            )
+        } coAnswers {
+            val run = arg<suspend (OnGoingInteractiveFlowSession, InteractiveFlow) -> ConfirmFlowResource?>(1)
+            val mapRedirectUriToResource = arg<suspend (URI) -> ConfirmFlowResource>(2)
+            assertNull(run(session, flow))
+            mapRedirectUriToResource(redirectUri)
+        }
+
+        val result = controller.getConfirmation(StateAuthentication("encoded-state"))
+
+        assertEquals(redirectUri.toString(), result.redirectUrl)
+        assertNull(result.action)
+    }
+
+    @Test
+    fun `confirm - Marks the confirmation and returns the next-step redirect URL`() = runTest {
+        val redirectUri = URI.create("https://auth.example.com/flow/mfa/enrollment?state=encoded-state")
+        coEvery { confirmManager.markConfirmed(session) } returns mockk()
+        coEvery {
+            interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenUpdateAndRedirect<SimpleFlowResource>(
+                eq("encoded-state"), any(), any()
+            )
+        } coAnswers {
+            val update = arg<suspend (OnGoingInteractiveFlowSession, InteractiveFlow) -> Any>(1)
+            val mapRedirectUriToResource = arg<suspend (URI) -> SimpleFlowResource>(2)
+            assertSame(session, update(session, flow))
+            mapRedirectUriToResource(redirectUri)
+        }
+
+        val result = controller.confirm(StateAuthentication("encoded-state"))
+
+        assertEquals(redirectUri.toString(), result.redirectUrl)
+        coVerify { confirmManager.markConfirmed(session) }
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/api/controller/flow/InteractiveFlowStepUriMapperTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/flow/InteractiveFlowStepUriMapperTest.kt
@@ -63,6 +63,29 @@ class InteractiveFlowStepUriMapperTest {
     }
 
     @Test
+    fun `toRedirectUri - Confirm maps to confirmUri with state appended`() = runTest {
+        val uri = URI.create("https://www.example.com/confirm")
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val flow = mockk<InteractiveFlow> { every { confirmUri } returns uri }
+        coEvery { mapper.appendState(session, uri) } returns uri
+
+        val result = mapper.toRedirectUri(session, flow, InteractiveFlowStep.Confirm)
+
+        assertEquals(uri, result)
+    }
+
+    @Test
+    fun `toRedirectUri - Confirm throws when the flow has no confirm page`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val flow = mockk<InteractiveFlow> { every { confirmUri } returns null }
+
+        val exception = assertThrows<BusinessException> {
+            mapper.toRedirectUri(session, flow, InteractiveFlowStep.Confirm)
+        }
+        assertEquals("flow.confirm.uri.missing", exception.detailsId)
+    }
+
+    @Test
     fun `toRedirectUri - SignUp falls back to signInUri when the flow has no sign-up page`() = runTest {
         val signInUri = URI.create("https://www.example.com/sign-in")
         val session = mockk<OnGoingInteractiveFlowSession>()

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/confirm/ConfirmInteractiveFlowPurposeHandlerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/confirm/ConfirmInteractiveFlowPurposeHandlerTest.kt
@@ -1,0 +1,50 @@
+package com.sympauthy.business.manager.flow.confirm
+
+import com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import io.mockk.coEvery
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class ConfirmInteractiveFlowPurposeHandlerTest {
+
+    @MockK
+    lateinit var confirmManager: InteractiveFlowSessionConfirmManager
+
+    @InjectMockKs
+    lateinit var handler: ConfirmInteractiveFlowPurposeHandler
+
+    private val session = mockk<OnGoingInteractiveFlowSession>()
+
+    @Test
+    fun `nextStepOrNull - Returns Confirm when the session carries no confirm record`() = runTest {
+        coEvery { confirmManager.fetchConfirmOrNull(session) } returns null
+
+        assertEquals(InteractiveFlowStep.Confirm, handler.nextStepOrNull(session))
+    }
+
+    @Test
+    fun `nextStepOrNull - Returns Confirm while the confirmation is still pending`() = runTest {
+        val confirm = mockk<InteractiveFlowSessionConfirm> { coEvery { confirmed } returns false }
+        coEvery { confirmManager.fetchConfirmOrNull(session) } returns confirm
+
+        assertEquals(InteractiveFlowStep.Confirm, handler.nextStepOrNull(session))
+    }
+
+    @Test
+    fun `nextStepOrNull - Returns null once the end-user has confirmed`() = runTest {
+        val confirm = mockk<InteractiveFlowSessionConfirm> { coEvery { confirmed } returns true }
+        coEvery { confirmManager.fetchConfirmOrNull(session) } returns confirm
+
+        assertNull(handler.nextStepOrNull(session))
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/confirm/InteractiveFlowSessionConfirmManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/confirm/InteractiveFlowSessionConfirmManagerTest.kt
@@ -1,0 +1,131 @@
+package com.sympauthy.business.manager.flow.confirm
+
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.mapper.InteractiveFlowSessionConfirmMapper
+import com.sympauthy.business.model.flow.ConfirmActionType
+import com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.data.model.InteractiveFlowSessionConfirmEntity
+import com.sympauthy.data.repository.InteractiveFlowSessionConfirmRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class InteractiveFlowSessionConfirmManagerTest {
+
+    @MockK
+    lateinit var confirmRepository: InteractiveFlowSessionConfirmRepository
+
+    @MockK
+    lateinit var confirmMapper: InteractiveFlowSessionConfirmMapper
+
+    @InjectMockKs
+    lateinit var manager: InteractiveFlowSessionConfirmManager
+
+    private val sessionId = UUID.randomUUID()
+    private val session = mockk<OnGoingInteractiveFlowSession> { every { id } returns sessionId }
+    private val model = mockk<InteractiveFlowSessionConfirm>()
+
+    @Test
+    fun `setConfirm - Saves a new unconfirmed record when none exists`() = runTest {
+        coEvery { confirmRepository.findBySessionId(sessionId) } returns null
+        coEvery { confirmRepository.save(any()) } returns mockk()
+        every { confirmMapper.toInteractiveFlowSessionConfirm(any()) } returns model
+
+        val result = manager.setConfirm(session, ConfirmActionType.ENROLL_MFA, "client-x")
+
+        assertSame(model, result)
+        coVerify {
+            confirmRepository.save(
+                match {
+                    it.sessionId == sessionId &&
+                        it.action == ConfirmActionType.ENROLL_MFA.name &&
+                        it.clientId == "client-x" &&
+                        it.confirmedDate == null
+                }
+            )
+        }
+        coVerify(exactly = 0) { confirmRepository.update(any()) }
+    }
+
+    @Test
+    fun `setConfirm - Updates the record when one already exists`() = runTest {
+        coEvery { confirmRepository.findBySessionId(sessionId) } returns mockk()
+        coEvery { confirmRepository.update(any()) } returns mockk()
+        every { confirmMapper.toInteractiveFlowSessionConfirm(any()) } returns model
+
+        val result = manager.setConfirm(session, ConfirmActionType.ENROLL_MFA, null)
+
+        assertSame(model, result)
+        coVerify {
+            confirmRepository.update(
+                match { it.sessionId == sessionId && it.clientId == null && it.confirmedDate == null }
+            )
+        }
+        coVerify(exactly = 0) { confirmRepository.save(any()) }
+    }
+
+    @Test
+    fun `fetchConfirmOrNull - Maps the entity when present`() = runTest {
+        val entity = mockk<InteractiveFlowSessionConfirmEntity>()
+        coEvery { confirmRepository.findBySessionId(sessionId) } returns entity
+        every { confirmMapper.toInteractiveFlowSessionConfirm(entity) } returns model
+
+        assertSame(model, manager.fetchConfirmOrNull(session))
+    }
+
+    @Test
+    fun `fetchConfirmOrNull - Returns null when absent`() = runTest {
+        coEvery { confirmRepository.findBySessionId(sessionId) } returns null
+
+        assertNull(manager.fetchConfirmOrNull(session))
+    }
+
+    @Test
+    fun `markConfirmed - Sets the confirmed date and updates the record`() = runTest {
+        val entity = InteractiveFlowSessionConfirmEntity(
+            sessionId = sessionId,
+            action = ConfirmActionType.ENROLL_MFA.name,
+            clientId = "client-x",
+            confirmedDate = null
+        )
+        coEvery { confirmRepository.findBySessionId(sessionId) } returns entity
+        coEvery { confirmRepository.update(any()) } returns mockk()
+        every { confirmMapper.toInteractiveFlowSessionConfirm(any()) } returns model
+
+        val result = manager.markConfirmed(session)
+
+        assertSame(model, result)
+        coVerify {
+            confirmRepository.update(
+                match<InteractiveFlowSessionConfirmEntity> { it.sessionId == sessionId && it.confirmedDate != null }
+            )
+        }
+    }
+
+    @Test
+    fun `markConfirmed - Throws when the session carries no confirm record`() = runTest {
+        coEvery { confirmRepository.findBySessionId(sessionId) } returns null
+
+        val exception = assertThrows<BusinessException> { manager.markConfirmed(session) }
+
+        assertEquals("flow.confirm.missing_record", exception.detailsId)
+        assertFalse(exception.recoverable)
+        coVerify(exactly = 0) { confirmRepository.update(any()) }
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManagerTest.kt
@@ -2,8 +2,10 @@ package com.sympauthy.business.manager.flow.mfa
 
 import com.sympauthy.business.exception.BusinessException
 import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
 import com.sympauthy.business.manager.mfa.TotpManager
 import com.sympauthy.business.model.flow.AuthorizationFlow
+import com.sympauthy.business.model.flow.ConfirmActionType
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowRedirectType
 import com.sympauthy.business.model.flow.InteractiveFlowStep
@@ -36,13 +38,18 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
     @MockK
     lateinit var totpManager: TotpManager
 
+    @MockK
+    lateinit var confirmManager: InteractiveFlowSessionConfirmManager
+
     private val userId = UUID.randomUUID()
+    private val clientId = "client-x"
     private val session = mockk<OnGoingInteractiveFlowSession>()
 
     private fun managerWith(mfaConfig: MfaConfig) = InteractiveFlowSessionMfaEnrollmentManager(
         sessionManager = sessionManager,
         uncheckedMfaConfig = mfaConfig,
-        totpManager = totpManager
+        totpManager = totpManager,
+        confirmManager = confirmManager
     )
 
     private val optionalMfa = EnabledMfaConfig(totp = true, required = false)
@@ -60,7 +67,7 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
         val withUser = mockk<OnGoingInteractiveFlowSession>()
         coEvery {
             sessionManager.newSession(
-                purposes = listOf(InteractiveFlowPurpose.MFA_ENROLLMENT),
+                purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
                 flow = flow,
                 successRedirectUri = returnUri,
                 redirectType = InteractiveFlowRedirectType.PLAIN,
@@ -68,10 +75,14 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
             )
         } returns newSession
         coEvery { sessionManager.setAuthenticatedUserId(newSession, userId) } returns withUser
+        coEvery {
+            confirmManager.setConfirm(withUser, ConfirmActionType.ENROLL_MFA, clientId)
+        } returns mockk()
 
-        val result = manager.startMfaEnrollmentSession(userId, returnUri, flow, cancelUri)
+        val result = manager.startMfaEnrollmentSession(userId, returnUri, flow, clientId, cancelUri)
 
         assertSame(withUser, result)
+        coVerify { confirmManager.setConfirm(withUser, ConfirmActionType.ENROLL_MFA, clientId) }
     }
 
     @Test
@@ -83,7 +94,7 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
         val withUser = mockk<OnGoingInteractiveFlowSession>()
         coEvery {
             sessionManager.newSession(
-                purposes = listOf(InteractiveFlowPurpose.MFA_ENROLLMENT),
+                purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
                 flow = flow,
                 successRedirectUri = returnUri,
                 redirectType = InteractiveFlowRedirectType.PLAIN,
@@ -91,8 +102,11 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
             )
         } returns newSession
         coEvery { sessionManager.setAuthenticatedUserId(newSession, userId) } returns withUser
+        coEvery {
+            confirmManager.setConfirm(withUser, ConfirmActionType.ENROLL_MFA, clientId)
+        } returns mockk()
 
-        val result = manager.startMfaEnrollmentSession(userId, returnUri, flow)
+        val result = manager.startMfaEnrollmentSession(userId, returnUri, flow, clientId)
 
         assertSame(withUser, result)
     }

--- a/server/src/test/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionTest.kt
@@ -1,0 +1,32 @@
+package com.sympauthy.business.model.flow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class InteractiveFlowSessionTest {
+
+    private fun ongoing(purposes: List<InteractiveFlowPurpose>) = OnGoingInteractiveFlowSession(
+        id = UUID.randomUUID(),
+        purposes = purposes,
+        flowId = null,
+        expirationDate = LocalDateTime.now().plusMinutes(5),
+        sessionDate = LocalDateTime.now(),
+        userId = null,
+    )
+
+    @Test
+    fun `initiatingPurpose - Skips the CONFIRM gate to the first real purpose`() {
+        val session = ongoing(listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT))
+
+        assertEquals(InteractiveFlowPurpose.MFA_ENROLLMENT, session.initiatingPurpose)
+    }
+
+    @Test
+    fun `initiatingPurpose - Is the first purpose when there is no CONFIRM gate`() {
+        val session = ongoing(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE))
+
+        assertEquals(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, session.initiatingPurpose)
+    }
+}


### PR DESCRIPTION
Closes #286.

Adds a generic **`CONFIRM` interactive-flow purpose**: a gate the signed-in end-user must clear before a client-initiated action runs. First consumer: the standalone MFA enrollment started via `POST /api/v1/client/mfa/enrollment` (#280), which previously began immediately with no chance to confirm intent.

## Behaviour
- A client-initiated flow starts as `[CONFIRM, MFA_ENROLLMENT]`. The engine drives `CONFIRM` first: `GET /api/v1/flow/confirm` returns the action context (machine-readable `action` code + initiating `client_id`) for the custom UI to render localized copy.
- **Confirm** (`POST /api/v1/flow/confirm`) → the flow proceeds to the next purpose. **Deny** → the existing `POST /api/v1/flow/cancel` marks the session cancelled and hands the user back to the caller. Confirmation is not skippable.
- OAuth2-login MFA is user-initiated and does **not** prepend `CONFIRM`, so it is unaffected.

## Design notes (settled on the issue)
The issue predates the typed-redirect/cancel work now in `main`, so a few things are simpler than originally described:

1. **Cancel reuses the existing `Cancelled` state** — the confirm page's deny button calls the existing cancel endpoint; no new cancel code.
2. **The confirm parameter is an attached record** (`interactive_flow_session_confirm`, migration `V0_5_0_17`), mirroring the OAuth2/Provider record stack — the `interactive_flow_session_mfa_enrollment` table the issue referenced had been removed.
3. **`initiatingPurpose` is redefined to skip `CONFIRM`** (first non-`CONFIRM` purpose). Without this, prepending the gate would silently make standalone enrollment skippable — a real bug this prevents.

## Changes
- **Engine/model:** `InteractiveFlowPurpose.CONFIRM`, `InteractiveFlowStep.Confirm`, redefined `initiatingPurpose`, `ConfirmInteractiveFlowPurposeHandler`.
- **Record:** migration (pg + h2), entity, repository (+ pg/h2 impls), `InteractiveFlowSessionConfirm` model + `ConfirmActionType` enum, MapStruct mapper (reflect-config + `BusinessMapperFactory` registration), `InteractiveFlowSessionConfirmManager`, GC in the session cleaner.
- **URI wiring:** `confirmUri` on `InteractiveFlow`, mapper branch, hardcoded default `.../flow/confirm`, optional `confirm` config key.
- **API:** `ConfirmController` + `ConfirmFlowResource`.
- **First consumer:** `startMfaEnrollmentSession` prepends `CONFIRM` and stores the confirm record (`action = ENROLL_MFA`, initiating client id).

## Testing
- All 713+ server tests pass (unit + in-process integration).
- The `integration-tests` OpenAPI client regenerates and compiles with the new endpoint.
- Not run here (needs Docker + a published image): the testcontainers `integrationTest` task.

## Out of scope (per the issue)
- The custom confirm-page **UI**.
- The **admin variant** (will reuse `CONFIRM` with a null client id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
