### PR TITLE
Admin API to generate an on-demand MFA-enrollment link for a user

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaController.kt
@@ -1,14 +1,24 @@
 package com.sympauthy.api.controller.admin
 
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
 import com.sympauthy.api.exception.httpExceptionOf
 import com.sympauthy.api.mapper.admin.AdminUserMfaMethodResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserMfaEnrollmentInputResource
+import com.sympauthy.api.resource.admin.AdminUserMfaEnrollmentResource
 import com.sympauthy.api.resource.admin.AdminUserMfaMethodListResource
 import com.sympauthy.api.resource.admin.AdminUserMfaRevokeResource
 import com.sympauthy.api.util.orNotFound
 import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.exception.recoverableBusinessExceptionOf
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.mfa.InteractiveFlowSessionMfaEnrollmentManager
 import com.sympauthy.business.manager.mfa.TotpManager
 import com.sympauthy.business.manager.user.UserManager
 import com.sympauthy.business.model.oauth2.AdminScopeId
+import com.sympauthy.config.model.EnabledMfaConfig
+import com.sympauthy.config.model.MfaConfig
 import com.sympauthy.security.SecurityRule.ADMIN_USERS_READ
 import com.sympauthy.security.SecurityRule.ADMIN_USERS_WRITE
 import io.micronaut.http.HttpStatus.NOT_FOUND
@@ -25,7 +35,13 @@ import java.util.*
 class AdminUserMfaController(
     @Inject private val userManager: UserManager,
     @Inject private val totpManager: TotpManager,
-    @Inject private val mfaMapper: AdminUserMfaMethodResourceMapper
+    @Inject private val mfaMapper: AdminUserMfaMethodResourceMapper,
+    @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
+    @Inject private val clientManager: ClientManager,
+    @Inject private val mfaEnrollmentManager: InteractiveFlowSessionMfaEnrollmentManager,
+    @Inject private val engine: InteractiveFlowEngine,
+    @Inject private val stepUriMapper: InteractiveFlowStepUriMapper,
+    @Inject private val uncheckedMfaConfig: MfaConfig,
 ) {
 
     @Operation(
@@ -95,6 +111,77 @@ class AdminUserMfaController(
             userId = userId,
             mfaId = mfaId,
             revoked = true
+        )
+    }
+
+    @Operation(
+        description = "Start an on-demand MFA enrollment for a given user, initiated by an administrator. " +
+                "Validates that the user and the named client exist and that the return (and optional cancel) " +
+                "URI are registered redirect URIs of that client, then creates an enrollment session gated by a " +
+                "confirmation the end-user must approve (shown as initiated by an administrator). Returns the " +
+                "redirect_url to hand or send to the user; once enrollment completes they are redirected to " +
+                "return_uri.",
+        tags = ["admin"],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The enrollment session was started.",
+                useReturnTypeSchema = true
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Invalid return or cancel URI, or MFA is not enabled on this server."
+            ),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:write."
+            ),
+            ApiResponse(responseCode = "404", description = "No user or client found with the given identifier.")
+        ]
+    )
+    @Post("/enrollment")
+    @Secured(ADMIN_USERS_WRITE)
+    @SecurityRequirement(name = "admin", scopes = [AdminScopeId.USERS_WRITE])
+    suspend fun startEnrollment(
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @Body resource: AdminUserMfaEnrollmentInputResource
+    ): AdminUserMfaEnrollmentResource {
+        // Fail fast (before creating any session) when MFA is not enabled on this server.
+        if ((uncheckedMfaConfig as? EnabledMfaConfig)?.enabled != true) {
+            throw recoverableBusinessExceptionOf(
+                "admin.users.mfa.enrollment.mfa_disabled",
+                "description.admin.users.mfa.enrollment.mfa_disabled"
+            )
+        }
+
+        // Both the target user and the named client must exist.
+        userManager.findByIdOrNull(userId).orNotFound()
+        val client = resource.clientId
+            ?.let { clientManager.findClientByIdOrNull(it) }
+            .orNotFound()
+
+        // Validate the return URI (and the optional cancel URI) against the named client's registered
+        // redirect URIs to avoid open redirects.
+        val returnUri = interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, resource.returnUri)
+        val cancelUri = resource.cancelUri
+            ?.let { interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, it) }
+
+        // Admin-initiated: pass a null client id so the confirmation shows "an administrator".
+        val flow = interactiveAuthFlowSessionManager.getDefaultInteractiveFlow()
+        val session = mfaEnrollmentManager.startMfaEnrollmentSession(
+            userId = userId,
+            returnUri = returnUri,
+            flow = flow,
+            initiatingClientId = null,
+            cancelUri = cancelUri
+        )
+
+        // The resulting redirect URI already carries the signed state as a query parameter.
+        val (steppedSession, step) = engine.advance(session)
+        val redirectUri = stepUriMapper.toRedirectUri(steppedSession, flow, step)
+        return AdminUserMfaEnrollmentResource(
+            redirectUrl = redirectUri.toString()
         )
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaEnrollmentInputResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaEnrollmentInputResource.kt
@@ -1,0 +1,38 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Request body for an administrator to start an on-demand MFA enrollment for a given user."
+)
+@Serdeable
+data class AdminUserMfaEnrollmentInputResource(
+    @get:Schema(
+        description = """
+Identifier of the client the end-user will be returned into once the enrollment completes.
+The ```return_uri``` (and optional ```cancel_uri```) are validated against this client's registered redirect
+URIs, and the user is redirected back to it on completion.
+        """
+    )
+    @get:JsonProperty("client_id")
+    val clientId: String?,
+    @get:Schema(
+        description = """
+URI the end-user is returned to once the MFA enrollment completes.
+Must be one of the named client's registered redirect URIs.
+        """
+    )
+    @get:JsonProperty("return_uri")
+    val returnUri: String?,
+    @get:Schema(
+        description = """
+Optional URI the end-user is returned to if they cancel the MFA enrollment.
+When provided, must be one of the named client's registered redirect URIs. When omitted, the enrollment
+offers no cancellation.
+        """
+    )
+    @get:JsonProperty("cancel_uri")
+    val cancelUri: String? = null
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaEnrollmentResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserMfaEnrollmentResource.kt
@@ -1,0 +1,20 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Response from starting an admin-initiated MFA enrollment: the link to hand to the user."
+)
+@Serdeable
+data class AdminUserMfaEnrollmentResource(
+    @get:Schema(
+        description = """
+URL to hand or send to the end-user so they can enroll their authenticator. The signed ```state```
+identifying the enrollment session is already included as a query parameter.
+        """
+    )
+    @get:JsonProperty("redirect_url")
+    val redirectUrl: String
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManager.kt
@@ -99,12 +99,13 @@ open class InteractiveFlowSessionMfaEnrollmentManager(
      * [InteractiveFlowRedirectType.PLAIN] redirect) and the optional [cancelUri] they are redirected back to if
      * they cancel, in a single transaction.
      *
-     * The enrollment is client-initiated, so the session is gated by an [InteractiveFlowPurpose.CONFIRM] step
+     * The enrollment is initiated on the end-user's behalf — by a client, or by an administrator when
+     * [initiatingClientId] is null — so the session is gated by an [InteractiveFlowPurpose.CONFIRM] step
      * prepended in front of [InteractiveFlowPurpose.MFA_ENROLLMENT]: the end-user must explicitly approve the
-     * enrollment [initiatingClientId] requested before it begins. The confirm parameter is stored on the
-     * session's confirm record in the same transaction.
+     * enrollment before it begins. The confirm parameter — including [initiatingClientId] (null for an
+     * administrator) — is stored on the session's confirm record in the same transaction.
      *
-     * The [returnUri] and [cancelUri] must have been validated (e.g. against the initiating client's registered
+     * The [returnUri] and [cancelUri] must have been validated (e.g. against the named client's registered
      * redirect URIs) by the caller before reaching here.
      */
     @Transactional
@@ -112,7 +113,7 @@ open class InteractiveFlowSessionMfaEnrollmentManager(
         userId: UUID,
         returnUri: URI,
         flow: AuthorizationFlow,
-        initiatingClientId: String,
+        initiatingClientId: String?,
         cancelUri: URI? = null,
     ): OnGoingInteractiveFlowSession {
         val session = sessionManager.newSession(

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/ConfirmActionType.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/ConfirmActionType.kt
@@ -9,8 +9,8 @@ package com.sympauthy.business.model.flow
  */
 enum class ConfirmActionType {
     /**
-     * The end-user is asked to approve enrolling a multi-factor authentication method, on behalf of a client
-     * that initiated the enrollment through the standalone MFA-enrollment endpoint.
+     * The end-user is asked to approve enrolling a multi-factor authentication method, initiated on their
+     * behalf through a standalone MFA-enrollment endpoint by a client or by an administrator.
      */
     ENROLL_MFA
 }

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -317,3 +317,5 @@ client.mfa.enrollment.mfa_disabled=Multi-factor authentication is not enabled on
 description.client.mfa.enrollment.mfa_disabled=This authorization server is not configured to support multi-factor authentication, so an enrollment cannot be started. Please contact the support of the application to report this issue.
 client.mfa.enrollment.invalid_access_token=The provided end-user access token is invalid.
 description.client.mfa.enrollment.invalid_access_token=The access token identifying the end-user is missing, expired, revoked, not associated with an end-user, or was not issued to your client. Obtain a fresh access token for the end-user and try again.
+admin.users.mfa.enrollment.mfa_disabled=Multi-factor authentication is not enabled on this authorization server.
+description.admin.users.mfa.enrollment.mfa_disabled=This authorization server is not configured to support multi-factor authentication, so an enrollment cannot be started.

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserMfaControllerTest.kt
@@ -1,17 +1,31 @@
 package com.sympauthy.api.controller.admin
 
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
 import com.sympauthy.api.exception.LocalizedHttpException
 import com.sympauthy.api.mapper.admin.AdminUserMfaMethodResourceMapper
+import com.sympauthy.api.resource.admin.AdminUserMfaEnrollmentInputResource
 import com.sympauthy.api.resource.admin.AdminUserMfaMethodResource
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.mfa.InteractiveFlowSessionMfaEnrollmentManager
 import com.sympauthy.business.manager.mfa.TotpManager
 import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.client.Client
+import com.sympauthy.business.model.flow.InteractiveFlow
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.InteractiveFlowStepResult
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.mfa.TotpEnrollment
 import com.sympauthy.business.model.user.User
+import com.sympauthy.config.model.DisabledMfaConfig
+import com.sympauthy.config.model.EnabledMfaConfig
+import com.sympauthy.config.model.MfaConfig
 import io.micronaut.http.HttpStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
@@ -21,6 +35,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
 import java.time.LocalDateTime
 import java.util.*
 
@@ -36,8 +51,34 @@ class AdminUserMfaControllerTest {
     @MockK
     lateinit var mfaMapper: AdminUserMfaMethodResourceMapper
 
-    @InjectMockKs
-    lateinit var controller: AdminUserMfaController
+    @MockK
+    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
+
+    @MockK
+    lateinit var clientManager: ClientManager
+
+    @MockK
+    lateinit var mfaEnrollmentManager: InteractiveFlowSessionMfaEnrollmentManager
+
+    @MockK
+    lateinit var engine: InteractiveFlowEngine
+
+    @MockK
+    lateinit var stepUriMapper: InteractiveFlowStepUriMapper
+
+    private fun controller(
+        mfaConfig: MfaConfig = EnabledMfaConfig(totp = true, required = false)
+    ) = AdminUserMfaController(
+        userManager = userManager,
+        totpManager = totpManager,
+        mfaMapper = mfaMapper,
+        interactiveAuthFlowSessionManager = interactiveAuthFlowSessionManager,
+        clientManager = clientManager,
+        mfaEnrollmentManager = mfaEnrollmentManager,
+        engine = engine,
+        stepUriMapper = stepUriMapper,
+        uncheckedMfaConfig = mfaConfig,
+    )
 
     private val userId: UUID = UUID.randomUUID()
     private val mfaId: UUID = UUID.randomUUID()
@@ -68,7 +109,7 @@ class AdminUserMfaControllerTest {
         coEvery { totpManager.findConfirmedEnrollments(userId) } returns listOf(enrollment)
         every { mfaMapper.toResource(enrollment) } returns resource
 
-        val result = controller.listMfaMethods(userId, null, null)
+        val result = controller().listMfaMethods(userId, null, null)
 
         assertEquals(1, result.mfaMethods.size)
         assertEquals(mfaId, result.mfaMethods[0].mfaId)
@@ -83,7 +124,7 @@ class AdminUserMfaControllerTest {
         coEvery { userManager.findByIdOrNull(userId) } returns null
 
         val exception = assertThrows<LocalizedHttpException> {
-            controller.listMfaMethods(userId, null, null)
+            controller().listMfaMethods(userId, null, null)
         }
 
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -94,7 +135,7 @@ class AdminUserMfaControllerTest {
         coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
         coEvery { totpManager.findConfirmedEnrollments(userId) } returns emptyList()
 
-        val result = controller.listMfaMethods(userId, null, null)
+        val result = controller().listMfaMethods(userId, null, null)
 
         assertTrue(result.mfaMethods.isEmpty())
         assertEquals(0, result.total)
@@ -108,7 +149,7 @@ class AdminUserMfaControllerTest {
         coEvery { totpManager.findConfirmedEnrollments(userId) } returns enrollments
         enrollments.forEachIndexed { i, e -> every { mfaMapper.toResource(e) } returns resources[i] }
 
-        val result = controller.listMfaMethods(userId, 1, 2)
+        val result = controller().listMfaMethods(userId, 1, 2)
 
         assertEquals(1, result.mfaMethods.size)
         assertEquals(1, result.page)
@@ -123,7 +164,7 @@ class AdminUserMfaControllerTest {
         coEvery { totpManager.findConfirmedEnrollmentOrNull(mfaId) } returns enrollment
         coEvery { totpManager.deleteEnrollment(enrollment) } returns Unit
 
-        val result = controller.revokeMfaMethod(userId, mfaId)
+        val result = controller().revokeMfaMethod(userId, mfaId)
 
         assertEquals(userId, result.userId)
         assertEquals(mfaId, result.mfaId)
@@ -136,7 +177,7 @@ class AdminUserMfaControllerTest {
         coEvery { userManager.findByIdOrNull(userId) } returns null
 
         val exception = assertThrows<LocalizedHttpException> {
-            controller.revokeMfaMethod(userId, mfaId)
+            controller().revokeMfaMethod(userId, mfaId)
         }
 
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -148,7 +189,7 @@ class AdminUserMfaControllerTest {
         coEvery { totpManager.findConfirmedEnrollmentOrNull(mfaId) } returns null
 
         val exception = assertThrows<LocalizedHttpException> {
-            controller.revokeMfaMethod(userId, mfaId)
+            controller().revokeMfaMethod(userId, mfaId)
         }
 
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -162,9 +203,147 @@ class AdminUserMfaControllerTest {
         coEvery { totpManager.findConfirmedEnrollmentOrNull(mfaId) } returns enrollment
 
         val exception = assertThrows<LocalizedHttpException> {
-            controller.revokeMfaMethod(userId, mfaId)
+            controller().revokeMfaMethod(userId, mfaId)
         }
 
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `startEnrollment - Validates user, client and return URI, starts an admin-initiated session and returns the link`() =
+        runTest {
+            val client = mockk<Client>()
+            val returnUri = URI.create("https://client.example.com/done")
+            val flow = mockk<InteractiveFlow>()
+            val session = mockk<OnGoingInteractiveFlowSession>()
+            val steppedSession = mockk<OnGoingInteractiveFlowSession>()
+            val redirectUri = URI.create("https://auth.example.com/flow/confirm?state=abc")
+
+            coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+            coEvery { clientManager.findClientByIdOrNull("client-id") } returns client
+            every {
+                interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, "https://client.example.com/done")
+            } returns returnUri
+            coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
+            // Admin-initiated: the initiating client id must be null (rendered as "an administrator"). Keying
+            // the stub on null means the test only reaches the assertion when the controller passes null.
+            coEvery {
+                mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow, null, null)
+            } returns session
+            coEvery { engine.advance(session) } returns
+                InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.Confirm)
+            coEvery {
+                stepUriMapper.toRedirectUri(steppedSession, flow, InteractiveFlowStep.Confirm)
+            } returns redirectUri
+
+            val result = controller().startEnrollment(
+                userId,
+                AdminUserMfaEnrollmentInputResource(
+                    clientId = "client-id",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+
+            assertEquals(redirectUri.toString(), result.redirectUrl)
+        }
+
+    @Test
+    fun `startEnrollment - Validates and forwards the optional cancel URI`() = runTest {
+        val client = mockk<Client>()
+        val returnUri = URI.create("https://client.example.com/done")
+        val cancelUri = URI.create("https://client.example.com/cancelled")
+        val flow = mockk<InteractiveFlow>()
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val steppedSession = mockk<OnGoingInteractiveFlowSession>()
+        val redirectUri = URI.create("https://auth.example.com/flow/confirm?state=abc")
+
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { clientManager.findClientByIdOrNull("client-id") } returns client
+        every {
+            interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, "https://client.example.com/done")
+        } returns returnUri
+        every {
+            interactiveAuthFlowSessionManager.parseRequestedRedirectUri(client, "https://client.example.com/cancelled")
+        } returns cancelUri
+        coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
+        // The stub only matches (and thus drives the redirect) when the validated cancel URI is threaded through.
+        coEvery {
+            mfaEnrollmentManager.startMfaEnrollmentSession(userId, returnUri, flow, null, cancelUri)
+        } returns session
+        coEvery { engine.advance(session) } returns
+            InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.Confirm)
+        coEvery {
+            stepUriMapper.toRedirectUri(steppedSession, flow, InteractiveFlowStep.Confirm)
+        } returns redirectUri
+
+        val result = controller().startEnrollment(
+            userId,
+            AdminUserMfaEnrollmentInputResource(
+                clientId = "client-id",
+                returnUri = "https://client.example.com/done",
+                cancelUri = "https://client.example.com/cancelled"
+            )
+        )
+
+        assertEquals(redirectUri.toString(), result.redirectUrl)
+    }
+
+    @Test
+    fun `startEnrollment - Fails with mfa_disabled and starts no session when MFA is disabled`() = runTest {
+        val exception = assertThrows<BusinessException> {
+            controller(mockk<DisabledMfaConfig>()).startEnrollment(
+                userId,
+                AdminUserMfaEnrollmentInputResource(
+                    clientId = "client-id",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+        }
+
+        assertEquals("admin.users.mfa.enrollment.mfa_disabled", exception.detailsId)
+        coVerify(exactly = 0) {
+            mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `startEnrollment - Returns 404 when user not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller().startEnrollment(
+                userId,
+                AdminUserMfaEnrollmentInputResource(
+                    clientId = "client-id",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+        coVerify(exactly = 0) {
+            mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `startEnrollment - Returns 404 when client not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { clientManager.findClientByIdOrNull("client-id") } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller().startEnrollment(
+                userId,
+                AdminUserMfaEnrollmentInputResource(
+                    clientId = "client-id",
+                    returnUri = "https://client.example.com/done"
+                )
+            )
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+        coVerify(exactly = 0) {
+            mfaEnrollmentManager.startMfaEnrollmentSession(any(), any(), any(), any(), any())
+        }
     }
 }

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManagerTest.kt
@@ -111,6 +111,34 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
         assertSame(withUser, result)
     }
 
+    @Test
+    fun `startMfaEnrollmentSession - Stores a null client id on the confirm record for an admin-initiated enrollment`() =
+        runTest {
+            val manager = managerWith(optionalMfa)
+            val returnUri = URI.create("https://client.example.com/enrolled")
+            val flow = mockk<AuthorizationFlow>()
+            val newSession = mockk<OnGoingInteractiveFlowSession>()
+            val withUser = mockk<OnGoingInteractiveFlowSession>()
+            coEvery {
+                sessionManager.newSession(
+                    purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+                    flow = flow,
+                    successRedirectUri = returnUri,
+                    redirectType = InteractiveFlowRedirectType.PLAIN,
+                    cancelRedirectUri = null,
+                )
+            } returns newSession
+            coEvery { sessionManager.setAuthenticatedUserId(newSession, userId) } returns withUser
+            // Admin-initiated: the confirm record must carry a null client id (rendered as "an administrator").
+            coEvery {
+                confirmManager.setConfirm(withUser, ConfirmActionType.ENROLL_MFA, null)
+            } returns mockk()
+
+            val result = manager.startMfaEnrollmentSession(userId, returnUri, flow, initiatingClientId = null)
+
+            assertSame(withUser, result)
+        }
+
     // --- getEnrollmentRoutingResult ---
 
     @Test


### PR DESCRIPTION
Closes #287.

## Summary

Adds `POST /api/v1/admin/users/{userId}/mfa/enrollment` on the existing `AdminUserMfaController` (`@Secured(ADMIN_USERS_WRITE)`). An administrator names a target **user** and a **client** and receives `{ redirect_url }` — a link to hand or send to the user that drives the standard interactive MFA enrollment and returns them to `return_uri` on completion.

This is the admin counterpart to the client endpoint #280, foreseen in #286 as "the admin variant (reuses `CONFIRM` with a null client id)".

## How it works

- **Request:** `client_id`, `return_uri`, optional `cancel_uri`. Both `return_uri` and `cancel_uri` are validated against the **named client's** registered redirect URIs via `parseRequestedRedirectUri` (open-redirect prevention, same as #280). Both the user and the client must exist (→ 404 otherwise). MFA-disabled is a fail-fast (→ 400).
- **CONFIRM gate:** the flow starts `[CONFIRM, MFA_ENROLLMENT]` (unconditional in the shared machinery). Because the action is **admin-initiated**, the confirm record carries a **null client id**, which `ConfirmFlowResource` already renders as "an administrator" — no UI change needed.
- **Response:** `{ redirect_url }` only. The link already embeds `?state=` (appended by `stepUriMapper.toRedirectUri`) and the admin does not drive the flow via API, so the standalone `state` field from #280 is intentionally omitted.

## Changes

- **Shared (only touch):** `InteractiveFlowSessionMfaEnrollmentManager.startMfaEnrollmentSession` — `initiatingClientId: String` → `String?`, so an admin enrollment can store a null client id. The existing client caller passes a non-null id, unchanged; the confirm `client_id` column and its only reader were already nullable.
- New endpoint on `AdminUserMfaController` + two admin resources (`AdminUserMfaEnrollmentInputResource`, `AdminUserMfaEnrollmentResource`).
- Admin-namespaced error keys `admin.users.mfa.enrollment.mfa_disabled`.
- `ConfirmActionType.ENROLL_MFA` KDoc generalized (client **or** administrator).

## Testing

- 5 new controller cases (happy path, optional cancel URI, MFA-disabled, user 404, client 404) + 1 manager case (admin-initiated null client id on the confirm record).
- Full `:server:test` suite green — 84 suites, 719 tests, 0 failures. OpenAPI spec generates cleanly.

## Notes

- No DB/migration changes — `interactive_flow_session_confirm.client_id` is already nullable (#286).
- Standalone admin enrollment is non-skippable for free (`initiatingPurpose == MFA_ENROLLMENT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)