### PR TITLE
Mark interactive-flow purposes complete as they resolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,40 @@ MICRONAUT_CONFIG_FILES=$(pwd)/config/application.yml MICRONAUT_ENVIRONMENTS=defa
 MICRONAUT_CONFIG_FILES=$(pwd)/config/application.yml MICRONAUT_ENVIRONMENTS=default,admin ./server/build/native/nativeCompile/server
 ```
 
+### Integration tests (`:integration-tests`)
+
+The `:integration-tests` module boots the SympAuthy image as a Docker container and drives it over real
+HTTP, against both databases (H2 + PostgreSQL). It runs **only** via the `integrationTest` task (never in
+`build` / `check` / `test`). To validate the **current working tree**, build a JVM image and point the
+tests at it (the default nightly image is stale and lacks your changes):
+
+```bash
+# 1. Build a JVM Docker image from the working tree (Micronaut tags it `server:latest`).
+#    Seconds, no GraalVM toolchain needed — always rebuild after code changes.
+./gradlew :server:dockerBuild
+
+# 2. Authenticate to GitHub Packages (testcontainers-sympauthy lives there; needs a read:packages token).
+#    The gh CLI token works.
+export GITHUB_ACTOR=$(gh api user --jq .login)
+export GITHUB_TOKEN=$(gh auth token)
+
+# 3. Run the full suite (feature + security, H2 + PostgreSQL) against the freshly built image.
+./gradlew :integration-tests:integrationTest -Dsympauthy.image=server:latest
+
+# Run a single scenario
+./gradlew :integration-tests:integrationTest -Dsympauthy.image=server:latest --tests '*AuthorizationCodeFeatureIT'
+```
+
+- **Requires** Docker (host-reachable daemon) and JDK 25.
+- **JVM image ≠ CI native image.** `server:latest` runs the code on the JVM; CI (and the nightly image)
+  use a GraalVM **native** image, whose closed-world reflection only works when declared in the native
+  metadata (`reflect-config.json` / `resource-config.json` — e.g. every MapStruct `*Impl`). A green JVM
+  run is **necessary but not sufficient** — the native run in CI is the source of truth.
+- Changing the shape of any flow-config response resource (`SignInFlowResource`, `SignUpFlowResource`,
+  `PasswordResource`, `CollectableClaimResource`, `ProviderResource`) is a **wire-format break** that
+  requires bumping `testcontainers-sympauthy` (`gradle/libs.versions.toml`) in lockstep. See
+  `integration-tests/README.md`.
+
 ## Architecture
 
 Multi-module Gradle project (root + `server`). All source code is in `server/src/main/kotlin/com/sympauthy/`.

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngine.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngine.kt
@@ -1,6 +1,5 @@
 package com.sympauthy.business.manager.flow
 
-import com.sympauthy.business.exception.internalBusinessExceptionOf
 import com.sympauthy.business.model.flow.CancelledInteractiveFlowSession
 import com.sympauthy.business.model.flow.CompletedInteractiveFlowSession
 import com.sympauthy.business.model.flow.FailedInteractiveFlowSession
@@ -18,10 +17,11 @@ import jakarta.inject.Singleton
  *
  * The engine drives the purposes in order: it asks each [InteractiveFlowPurposeHandler], in turn, for the next
  * step of its purpose; the first purpose that still needs a step yields the step to present. As a purpose
- * resolves, the engine appends the follow-up purposes it declares. Once every purpose has resolved, the engine
- * runs each purpose's terminal effect and marks it complete, transitioning the session to completed (or
- * failed). The engine is the sole owner of every session mutation — appending, completing, failing — while the
- * handlers only read the session and describe what their purpose needs.
+ * resolves, the engine marks it complete and appends the follow-up purposes it declares — so completion is
+ * recorded one purpose at a time as the engine hands off, even while later purposes still need steps. Once
+ * every purpose has resolved, the engine runs each purpose's terminal effect and transitions the session to
+ * completed (or failed). The engine is the sole owner of every session mutation — appending, completing,
+ * failing — while the handlers only read the session and describe what their purpose needs.
  */
 @Singleton
 class InteractiveFlowEngine(
@@ -61,10 +61,15 @@ class InteractiveFlowEngine(
         var current = session
         var index = 0
         while (index < current.purposes.size) {
-            val handler = purposeRegistry.getForPurpose(current.purposes[index])
+            val purpose = current.purposes[index]
+            val handler = purposeRegistry.getForPurpose(purpose)
             handler.nextStepOrNull(current)?.let { step ->
                 return InteractiveFlowStepResult(current, step)
             }
+            // The purpose has resolved: mark it complete as the engine hands off, then append the follow-up
+            // purposes it declares. Completion is recorded one purpose at a time, even when a later purpose
+            // still yields a step and the session as a whole is not yet complete.
+            current = sessionManager.markPurposeAsCompleted(current, purpose)
             current = appendFollowUps(current, handler)
             index++
         }
@@ -89,28 +94,26 @@ class InteractiveFlowEngine(
     }
 
     /**
-     * Every purpose has resolved: run each purpose's terminal effect and mark it complete, in order. The
-     * session becomes completed once the last outstanding purpose is completed; a failing effect fails it.
+     * Every purpose has resolved and been marked complete: run each purpose's terminal effect in order, then
+     * transition the session to completed. A failing terminal effect fails the session instead.
+     *
+     * Terminal effects run only here — once every purpose (e.g. the final MFA gate) has resolved — so a
+     * purpose's concern-specific completion work (e.g. the OAuth2 purpose granting scopes and recording
+     * consent) is committed only when the whole flow is about to succeed.
      */
     private suspend fun complete(session: OnGoingInteractiveFlowSession): InteractiveFlowStepResult {
-        var current = session
         for (purpose in session.purposes) {
-            when (val effect = purposeRegistry.getForPurpose(purpose).applyTerminalEffect(current)) {
-                is TerminalEffectResult.Fail -> return InteractiveFlowStepResult(
-                    sessionManager.markAsFailedIfNotRecoverable(current, effect.error),
+            val effect = purposeRegistry.getForPurpose(purpose).applyTerminalEffect(session)
+            if (effect is TerminalEffectResult.Fail) {
+                return InteractiveFlowStepResult(
+                    sessionManager.markAsFailedIfNotRecoverable(session, effect.error),
                     InteractiveFlowStep.Error
                 )
-
-                TerminalEffectResult.Proceed -> when (val next = sessionManager.makePurposeAsComplete(current, purpose)) {
-                    is CompletedInteractiveFlowSession -> return InteractiveFlowStepResult(next, InteractiveFlowStep.Complete)
-                    is OnGoingInteractiveFlowSession -> current = next
-                    is FailedInteractiveFlowSession -> return InteractiveFlowStepResult(next, InteractiveFlowStep.Error)
-                    // makePurposeAsComplete only ever completes or leaves the session ongoing.
-                    is CancelledInteractiveFlowSession -> throw internalBusinessExceptionOf("flow.redirect.unhandled_status")
-                }
             }
         }
-        // Completing the last purpose must have produced a completed (or failed) session.
-        throw internalBusinessExceptionOf("flow.redirect.unhandled_status")
+        return InteractiveFlowStepResult(
+            sessionManager.markAsCompleted(session),
+            InteractiveFlowStep.Complete
+        )
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
@@ -254,34 +254,40 @@ class InteractiveFlowSessionManager(
     }
 
     /**
-     * Record [purpose] as completed on the [session], persist the updated completed-purpose list, and return
-     * the resulting session.
+     * Record [purpose] as completed on the ongoing [session] as the engine hands off to the next purpose,
+     * persist the updated completed-purpose list, and return the still-[OnGoingInteractiveFlowSession].
      *
-     * The whole session completes — its completion date is persisted and a [CompletedInteractiveFlowSession]
-     * is returned — only once every purpose the session carries has been completed. Until then the still
-     * [OnGoingInteractiveFlowSession] is returned with [purpose] added to its completed purposes.
-     *
-     * Marking an already-completed [purpose] is a no-op on the list. The presence of the concern-specific
-     * completion invariants (e.g. consent / grant for an OAuth2 session) is enforced by the matching manager
-     * when the attached record is read.
+     * This is pure progress bookkeeping: it never transitions the session to completed — that is
+     * [markAsCompleted], run by the engine once every purpose has resolved and its terminal effect applied.
+     * Marking an already-completed [purpose] is a no-op on the list.
      */
-    suspend fun makePurposeAsComplete(
+    suspend fun markPurposeAsCompleted(
         session: OnGoingInteractiveFlowSession,
         purpose: InteractiveFlowPurpose
-    ): InteractiveFlowSession {
-        val userId = session.userId ?: throw businessExceptionOf(
-            "auth.interactive_flow_session.complete.missing_user"
-        )
+    ): OnGoingInteractiveFlowSession {
         val completedPurposes = (session.completedPurposes + purpose).distinct()
         sessionRepository.updateCompletedPurposes(
             id = session.id,
             completedPurposes = completedPurposes.map(InteractiveFlowPurpose::name)
         )
+        return session.copy(completedPurposes = completedPurposes)
+    }
 
-        if (!session.purposes.all { it in completedPurposes }) {
-            return session.copy(completedPurposes = completedPurposes)
-        }
-
+    /**
+     * Transition the ongoing [session] to completed: persist the completion date and return the resulting
+     * [CompletedInteractiveFlowSession].
+     *
+     * Called by the engine once every purpose the session carries has resolved (and been marked complete via
+     * [markPurposeAsCompleted]) and its terminal effect applied. The concern-specific completion invariants
+     * (e.g. consent / grant for an OAuth2 session) are enforced by the matching purpose's terminal effect,
+     * run before this transition.
+     */
+    suspend fun markAsCompleted(
+        session: OnGoingInteractiveFlowSession
+    ): CompletedInteractiveFlowSession {
+        val userId = session.userId ?: throw businessExceptionOf(
+            "auth.interactive_flow_session.complete.missing_user"
+        )
         val completeDate = LocalDateTime.now()
         sessionRepository.updateCompleteDate(
             id = session.id,
@@ -295,7 +301,7 @@ class InteractiveFlowSessionManager(
             sessionDate = session.sessionDate,
             userId = userId,
             signedUp = session.signedUp,
-            completedPurposes = completedPurposes,
+            completedPurposes = session.completedPurposes,
             mfaPassedDate = session.mfaPassedDate,
             completeDate = completeDate,
             successRedirectUri = session.successRedirectUri

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
@@ -11,6 +11,7 @@ import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.flow.TerminalEffectResult
 import java.net.URI
 import io.mockk.coEvery
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -72,13 +73,17 @@ class InteractiveFlowEngineTest {
     @Test
     fun `advance - All purposes resolved runs the terminal effect and completes the session`() = runTest {
         val session = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
+        val marked = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
         val completed = completedSession()
         val handler = mockk<InteractiveFlowPurposeHandler>()
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns handler
         coEvery { handler.nextStepOrNull(session) } returns null
-        coEvery { handler.followUpPurposes(session) } returns emptyList()
-        coEvery { handler.applyTerminalEffect(session) } returns TerminalEffectResult.Proceed
-        coEvery { sessionManager.makePurposeAsComplete(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns completed
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        } returns marked
+        coEvery { handler.followUpPurposes(marked) } returns emptyList()
+        coEvery { handler.applyTerminalEffect(marked) } returns TerminalEffectResult.Proceed
+        coEvery { sessionManager.markAsCompleted(marked) } returns completed
 
         val result = engine.advance(session)
 
@@ -89,14 +94,18 @@ class InteractiveFlowEngineTest {
     @Test
     fun `advance - A failing terminal effect fails the session and maps to Error`() = runTest {
         val session = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
+        val marked = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
         val error = mockk<BusinessException>()
         val failed = failedSession()
         val handler = mockk<InteractiveFlowPurposeHandler>()
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns handler
         coEvery { handler.nextStepOrNull(session) } returns null
-        coEvery { handler.followUpPurposes(session) } returns emptyList()
-        coEvery { handler.applyTerminalEffect(session) } returns TerminalEffectResult.Fail(error)
-        coEvery { sessionManager.markAsFailedIfNotRecoverable(session, error) } returns failed
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        } returns marked
+        coEvery { handler.followUpPurposes(marked) } returns emptyList()
+        coEvery { handler.applyTerminalEffect(marked) } returns TerminalEffectResult.Fail(error)
+        coEvery { sessionManager.markAsFailedIfNotRecoverable(marked, error) } returns failed
 
         val result = engine.advance(session)
 
@@ -105,9 +114,39 @@ class InteractiveFlowEngineTest {
     }
 
     @Test
+    fun `advance - Marks a resolved purpose complete even when a later purpose still needs a step`() = runTest {
+        // Regression: the CONFIRM gate resolves and must be recorded as completed even though the following
+        // MFA purpose still yields a step (so the whole session is not yet complete and complete() is never
+        // reached). `markPurposeAsCompleted` returning `afterConfirm` is what surfaces as the result session,
+        // so reaching the assertion proves CONFIRM was marked complete as the engine handed off.
+        val session = onGoingSession(
+            listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT)
+        )
+        val afterConfirm = onGoingSession(
+            listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT)
+        )
+        val confirmHandler = mockk<InteractiveFlowPurposeHandler>()
+        val mfaHandler = mockk<InteractiveFlowPurposeHandler>()
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.CONFIRM) } returns confirmHandler
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.MFA_ENROLLMENT) } returns mfaHandler
+        coEvery { confirmHandler.nextStepOrNull(session) } returns null
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.CONFIRM)
+        } returns afterConfirm
+        coEvery { confirmHandler.followUpPurposes(afterConfirm) } returns emptyList()
+        coEvery { mfaHandler.nextStepOrNull(afterConfirm) } returns InteractiveFlowStep.MfaSelectionForEnrollment
+
+        val result = engine.advance(session)
+
+        assertSame(afterConfirm, result.session)
+        assertEquals(InteractiveFlowStep.MfaSelectionForEnrollment, result.step)
+    }
+
+    @Test
     fun `advance - Appends a follow-up purpose then visits it`() = runTest {
         // The first purpose resolves and declares a follow-up; the engine appends it and the walk visits it.
         val session = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
+        val marked = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
         val grown = onGoingSession(
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
         )
@@ -116,9 +155,12 @@ class InteractiveFlowEngineTest {
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns oauth2Handler
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.MFA_CHALLENGE) } returns mfaHandler
         coEvery { oauth2Handler.nextStepOrNull(session) } returns null
-        coEvery { oauth2Handler.followUpPurposes(session) } returns listOf(InteractiveFlowPurpose.MFA_CHALLENGE)
         coEvery {
-            sessionManager.appendPurpose(session, InteractiveFlowPurpose.MFA_CHALLENGE)
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        } returns marked
+        coEvery { oauth2Handler.followUpPurposes(marked) } returns listOf(InteractiveFlowPurpose.MFA_CHALLENGE)
+        coEvery {
+            sessionManager.appendPurpose(marked, InteractiveFlowPurpose.MFA_CHALLENGE)
         } returns grown
         coEvery { mfaHandler.nextStepOrNull(grown) } returns InteractiveFlowStep.MfaSelectionForChallenge
 
@@ -134,13 +176,19 @@ class InteractiveFlowEngineTest {
         val session = onGoingSession(
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
         )
+        val marked = onGoingSession(
+            listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
+        )
         val oauth2Handler = mockk<InteractiveFlowPurposeHandler>()
         val mfaHandler = mockk<InteractiveFlowPurposeHandler>()
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns oauth2Handler
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.MFA_CHALLENGE) } returns mfaHandler
         coEvery { oauth2Handler.nextStepOrNull(session) } returns null
-        coEvery { oauth2Handler.followUpPurposes(session) } returns listOf(InteractiveFlowPurpose.MFA_CHALLENGE)
-        coEvery { mfaHandler.nextStepOrNull(session) } returns InteractiveFlowStep.MfaSelectionForChallenge
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        } returns marked
+        coEvery { oauth2Handler.followUpPurposes(marked) } returns listOf(InteractiveFlowPurpose.MFA_CHALLENGE)
+        coEvery { mfaHandler.nextStepOrNull(marked) } returns InteractiveFlowStep.MfaSelectionForChallenge
 
         val result = engine.advance(session)
 
@@ -148,13 +196,16 @@ class InteractiveFlowEngineTest {
     }
 
     @Test
-    fun `advance - Completes each purpose in order until the last yields a completed session`() = runTest {
-        // Both purposes are resolved: each terminal effect runs in order, the first hands off a still-ongoing
-        // session, the second completes it.
+    fun `advance - Runs every terminal effect in order then completes the session once`() = runTest {
+        // Both purposes are resolved: each is marked complete as the engine hands off, then every terminal
+        // effect runs in order on the fully-marked session before the single completion transition.
         val session = onGoingSession(
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
         )
         val afterFirst = onGoingSession(
+            listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
+        )
+        val afterSecond = onGoingSession(
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
         )
         val completed = completedSession()
@@ -163,34 +214,44 @@ class InteractiveFlowEngineTest {
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns oauth2Handler
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.MFA_CHALLENGE) } returns mfaHandler
         coEvery { oauth2Handler.nextStepOrNull(session) } returns null
-        coEvery { oauth2Handler.followUpPurposes(session) } returns emptyList()
-        coEvery { mfaHandler.nextStepOrNull(session) } returns null
-        coEvery { mfaHandler.followUpPurposes(session) } returns emptyList()
-        coEvery { oauth2Handler.applyTerminalEffect(session) } returns TerminalEffectResult.Proceed
         coEvery {
-            sessionManager.makePurposeAsComplete(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
         } returns afterFirst
-        coEvery { mfaHandler.applyTerminalEffect(afterFirst) } returns TerminalEffectResult.Proceed
+        coEvery { oauth2Handler.followUpPurposes(afterFirst) } returns emptyList()
+        coEvery { mfaHandler.nextStepOrNull(afterFirst) } returns null
         coEvery {
-            sessionManager.makePurposeAsComplete(afterFirst, InteractiveFlowPurpose.MFA_CHALLENGE)
-        } returns completed
+            sessionManager.markPurposeAsCompleted(afterFirst, InteractiveFlowPurpose.MFA_CHALLENGE)
+        } returns afterSecond
+        coEvery { mfaHandler.followUpPurposes(afterSecond) } returns emptyList()
+        coEvery { oauth2Handler.applyTerminalEffect(afterSecond) } returns TerminalEffectResult.Proceed
+        coEvery { mfaHandler.applyTerminalEffect(afterSecond) } returns TerminalEffectResult.Proceed
+        coEvery { sessionManager.markAsCompleted(afterSecond) } returns completed
 
         val result = engine.advance(session)
 
         assertSame(completed, result.session)
         assertEquals(InteractiveFlowStep.Complete, result.step)
+        // Terminal effects run on the fully-marked session, in purpose order, before completion.
+        coVerifyOrder {
+            oauth2Handler.applyTerminalEffect(afterSecond)
+            mfaHandler.applyTerminalEffect(afterSecond)
+        }
     }
 
     @Test
     fun `completeIfNecessary - Returns the session advanced by advance`() = runTest {
         val session = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
+        val marked = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
         val completed = completedSession()
         val handler = mockk<InteractiveFlowPurposeHandler>()
         every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns handler
         coEvery { handler.nextStepOrNull(session) } returns null
-        coEvery { handler.followUpPurposes(session) } returns emptyList()
-        coEvery { handler.applyTerminalEffect(session) } returns TerminalEffectResult.Proceed
-        coEvery { sessionManager.makePurposeAsComplete(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns completed
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        } returns marked
+        coEvery { handler.followUpPurposes(marked) } returns emptyList()
+        coEvery { handler.applyTerminalEffect(marked) } returns TerminalEffectResult.Proceed
+        coEvery { sessionManager.markAsCompleted(marked) } returns completed
 
         assertSame(completed, engine.completeIfNecessary(session))
     }

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
@@ -3,7 +3,6 @@ package com.sympauthy.business.manager.flow
 import com.sympauthy.business.manager.jwt.JwtManager
 import com.sympauthy.business.manager.user.UserManager
 import com.sympauthy.business.mapper.InteractiveFlowSessionMapper
-import com.sympauthy.business.model.flow.CompletedInteractiveFlowSession
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowRedirectType
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
@@ -162,11 +161,11 @@ class InteractiveFlowSessionManagerTest {
     }
 
     @Test
-    fun `makePurposeAsComplete - Records the purpose and stays ongoing while purposes remain`() = runTest {
+    fun `markPurposeAsCompleted - Records the purpose and stays ongoing without completing the session`() = runTest {
         val sessionId = UUID.randomUUID()
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
-            purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
+            purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
@@ -174,28 +173,50 @@ class InteractiveFlowSessionManagerTest {
         )
         // Stub with the exact expected persisted names so reaching the assertion proves the right list was saved.
         coEvery {
-            sessionRepository.updateCompletedPurposes(sessionId, listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE.name))
+            sessionRepository.updateCompletedPurposes(sessionId, listOf(InteractiveFlowPurpose.CONFIRM.name))
         } returns Unit
 
-        val result = interactiveFlowSessionManager.makePurposeAsComplete(
-            session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE
+        val result = interactiveFlowSessionManager.markPurposeAsCompleted(
+            session, InteractiveFlowPurpose.CONFIRM
         )
 
-        assertTrue(result is OnGoingInteractiveFlowSession)
-        result as OnGoingInteractiveFlowSession
-        assertEquals(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE), result.completedPurposes)
+        assertEquals(listOf(InteractiveFlowPurpose.CONFIRM), result.completedPurposes)
+        // Bookkeeping only: the session must not be completed even though a purpose was recorded.
         coVerify(exactly = 0) { sessionRepository.updateCompleteDate(any(), any()) }
     }
 
     @Test
-    fun `makePurposeAsComplete - Completes the session once every purpose is complete`() = runTest {
+    fun `markPurposeAsCompleted - Recording an already-completed purpose is a no-op on the list`() = runTest {
+        val sessionId = UUID.randomUUID()
+        val session = OnGoingInteractiveFlowSession(
+            id = sessionId,
+            purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+            completedPurposes = listOf(InteractiveFlowPurpose.CONFIRM),
+            flowId = "flow-id",
+            expirationDate = LocalDateTime.now().plusHours(1),
+            sessionDate = LocalDateTime.now(),
+            userId = UUID.randomUUID(),
+        )
+        coEvery {
+            sessionRepository.updateCompletedPurposes(sessionId, listOf(InteractiveFlowPurpose.CONFIRM.name))
+        } returns Unit
+
+        val result = interactiveFlowSessionManager.markPurposeAsCompleted(
+            session, InteractiveFlowPurpose.CONFIRM
+        )
+
+        assertEquals(listOf(InteractiveFlowPurpose.CONFIRM), result.completedPurposes)
+    }
+
+    @Test
+    fun `markAsCompleted - Persists the complete date and returns a completed session`() = runTest {
         val sessionId = UUID.randomUUID()
         val userId = UUID.randomUUID()
         val redirectUri = URI.create("https://client.example.com/callback")
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
-            completedPurposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            completedPurposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
@@ -204,20 +225,10 @@ class InteractiveFlowSessionManagerTest {
             redirectType = InteractiveFlowRedirectType.AUTHORIZATION_CODE,
             cancelRedirectUri = redirectUri,
         )
-        coEvery {
-            sessionRepository.updateCompletedPurposes(
-                sessionId,
-                listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE.name, InteractiveFlowPurpose.MFA_CHALLENGE.name)
-            )
-        } returns Unit
         coEvery { sessionRepository.updateCompleteDate(sessionId, any()) } returns Unit
 
-        val result = interactiveFlowSessionManager.makePurposeAsComplete(
-            session, InteractiveFlowPurpose.MFA_CHALLENGE
-        )
+        val result = interactiveFlowSessionManager.markAsCompleted(session)
 
-        assertTrue(result is CompletedInteractiveFlowSession)
-        result as CompletedInteractiveFlowSession
         assertEquals(userId, result.userId)
         assertEquals(
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),


### PR DESCRIPTION
## Problem

The `CONFIRM` purpose was not written to `completed_purposes` when the end-user clicked the confirm button.

The `InteractiveFlowEngine` deferred **all** purpose completion into `complete()`, which only runs once *every* purpose has resolved. A prepended `CONFIRM` gate (used by the standalone MFA-enrollment flow, purposes `[CONFIRM, MFA_ENROLLMENT]`) resolves before its sibling, so the engine walked past it and returned the next step — never marking `CONFIRM` complete at hand-off. This contradicted the documented intent on `OnGoingInteractiveFlowSession.completedPurposes` ("completed one at a time (each purpose's handler completes its own purpose as the engine hands off)").

## Fix

- **`InteractiveFlowSessionManager`** — split `makePurposeAsComplete` (which did bookkeeping *and* the terminal transition) into:
  - `markPurposeAsCompleted` — bookkeeping only; appends to `completed_purposes`, always stays ongoing.
  - `markAsCompleted` — the terminal transition to a `CompletedInteractiveFlowSession` (matches the `markAs…` naming of `markAsFailedIfNotRecoverable` / `markAsCancelled`).
- **`InteractiveFlowEngine`** — `advanceOnGoing` now marks each purpose complete the moment it resolves (as it hands off), and `complete()` runs every purpose's terminal effect then performs a single completion transition.

### Invariant preserved
Terminal effects still run **only** at final completion, once every purpose (including the final MFA gate) has resolved. The OAuth2 purpose's scope grant + consent recording remain deferred until the flow is about to succeed — only the progress bookkeeping became incremental.

## Verification

- Full `:server:test` suite green (updated engine/manager unit tests for the split; added regression test `advance - Marks a resolved purpose complete even when a later purpose still needs a step`).
- Integration tests against the JVM image (`server:latest`): **42 tests, 0 failures** on **H2 + PostgreSQL** (feature + security), including `AuthorizationCodeFeatureIT` — confirming the OAuth2 authorization-code completion path is not regressed.

> Note: the ITs cover the OAuth2 path (no regression); the CONFIRM/MFA-enrollment path itself is covered by unit tests. JVM image is necessary-but-not-sufficient vs. CI's native image.

Also documents the JVM-image + integration-test recipe in `CLAUDE.md`.

Related: #286 (introduced the `CONFIRM` purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)