### PR TITLE
Add integration tests for OAuth2 authorization cancellation

### DIFF
--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/AbstractSympauthyIT.kt
@@ -15,6 +15,7 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import com.sympauthy.api.client.api.OpeniddiscoveryApi
 import com.sympauthy.api.client.model.OpenIdConfigurationResource
 import com.sympauthy.it.client.BearerTokenHolder
+import com.sympauthy.it.client.FlowHttpClient
 import com.sympauthy.testcontainers.Client
 import com.sympauthy.testcontainers.SympauthyContainer
 import com.sympauthy.testcontainers.flow.InteractiveFlowRegistry
@@ -190,6 +191,21 @@ abstract class AbstractSympauthyIT {
         block(ctx)
     }
 
+    /**
+     * Runs [block] with a [FlowHttpClient] bound to [sympauthy] that does **not** follow redirects, so a
+     * scenario can read the `/authorize` `303` `Location` (which carries the signed internal state) and
+     * drive the state-secured flow endpoints (`/api/v1/flow/cancel`). The hosting context is closed on exit.
+     */
+    protected fun <T> withFlowClient(
+        sympauthy: SympauthyContainer,
+        block: (FlowHttpClient) -> T,
+    ): T = ApplicationContext.run(
+        mapOf(
+            "micronaut.http.services.sympauthy.url" to sympauthy.baseUrl,
+            "micronaut.http.services.sympauthy.follow-redirects" to false,
+        ),
+    ).use { ctx -> block(ctx.getBean(FlowHttpClient::class.java)) }
+
     // --- HTTP / JWT helpers -------------------------------------------------------------------------
 
     /** The OpenID Connect discovery document served by [sympauthy], read through the generated client. */
@@ -306,6 +322,21 @@ abstract class AbstractSympauthyIT {
 
     protected fun encode(value: String): String =
         java.net.URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    /** The value of query parameter [name] in [url] (decoded), or null if absent. */
+    protected fun queryParam(url: String, name: String): String? = queryParams(url)[name]
+
+    /** The decoded query parameters of [url], in order. */
+    protected fun queryParams(url: String): Map<String, String> {
+        val query = URI.create(url).rawQuery ?: return emptyMap()
+        return query.split("&").filter { it.isNotEmpty() }.associate { pair ->
+            val separator = pair.indexOf('=')
+            val key = if (separator < 0) pair else pair.substring(0, separator)
+            val value = if (separator < 0) "" else pair.substring(separator + 1)
+            java.net.URLDecoder.decode(key, StandardCharsets.UTF_8) to
+                java.net.URLDecoder.decode(value, StandardCharsets.UTF_8)
+        }
+    }
 
     /** A PKCE verifier/challenge pair (S256), matching what a public client must send. */
     protected fun generatePkce(): Pkce {

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/CancelledFlowStateNotReplayableIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/CancelledFlowStateNotReplayableIT.kt
@@ -1,0 +1,58 @@
+package com.sympauthy.it.security
+
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Security scenario — **once a flow is cancelled its signed state is spent: it can no longer be replayed
+ * to drive the flow.**
+ *
+ * Risk: the signed internal state travels in URLs and the `Authorization: State` header, so it can leak
+ * (browser history, logs, a shared link). Cancellation must make the session terminal, so a captured
+ * state cannot be replayed afterwards to resurrect the flow and reach a code-minting step. If a cancelled
+ * session could still be advanced, an attacker holding the state could complete an authorization the user
+ * had explicitly declined.
+ *
+ * This starts an authorization, cancels it, then replays the same state against a state-secured step that
+ * requires an ongoing session (`GET /api/v1/flow/mfa/challenge`) and asserts it is rejected with
+ * `400 ctrl.flow.not_ongoing`, on each supported database.
+ *
+ * Source: [OAuth 2.1 §7.1 (Access Token / credential handling)](
+ * https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#section-7.1) — cancellation is a terminal
+ * state; the flow's own single-use / terminal-session model enforces it.
+ */
+@Tag("security")
+class CancelledFlowStateNotReplayableIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "a cancelled flow's state cannot be replayed on {0}")
+    @EnumSource(Database::class)
+    fun cancelledStateCannotBeReplayed(database: Database) {
+        withContainer(database) { sympauthy, registry ->
+            withFlowClient(sympauthy) { flow ->
+                val authorize = flow.get(authorizeUrl(sympauthy, registry))
+                val internalState = queryParam(authorize.location ?: error("authorize 303 had no Location"), "state")
+                    ?: error("authorize redirect did not carry a state: ${authorize.location}")
+
+                // Cancel the flow: the session becomes terminal.
+                val cancel = flow.cancel(internalState)
+                assertEquals(200, cancel.status, "the first cancel should succeed, body=${cancel.body}")
+
+                // Replaying the now-spent state against an ongoing-required step must be rejected.
+                val replay = flow.get("/api/v1/flow/mfa/challenge?state=${encode(internalState)}")
+                assertEquals(
+                    400, replay.status,
+                    "replaying a cancelled flow's state must be rejected, body=${replay.body}",
+                )
+                assertTrue(
+                    replay.body.contains("ctrl.flow.not_ongoing"),
+                    "the rejection should report the session is no longer ongoing, was: ${replay.body}",
+                )
+            }
+        }
+    }
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/OAuth2AuthorizeCancelIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/security/OAuth2AuthorizeCancelIT.kt
@@ -1,0 +1,70 @@
+package com.sympauthy.it.security
+
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Security scenario — **cancelling an OAuth2 authorization returns the `access_denied` error to the
+ * client, and never mints an authorization code.**
+ *
+ * Risk: when the end-user declines an authorization request, OAuth2 requires the server to hand the
+ * user-agent back to the client's `redirect_uri` with `error=access_denied` and the client's `state`
+ * echoed — and, crucially, to *not* issue an authorization code. A server that dropped the user on an
+ * error page (or, worse, still minted a code) would both break clients that rely on the standard error
+ * channel and risk handing out a credential for a flow the user rejected.
+ *
+ * This starts a real authorization request, captures the signed internal state from the `303` to the
+ * sign-in page, cancels the flow via `POST /api/v1/flow/cancel`, and asserts the returned redirect is
+ * the client `redirect_uri` carrying `error=access_denied` with the client `state` echoed and **no
+ * `code`**, on each supported database.
+ *
+ * Source: [RFC 6749 §4.1.2.1 (Authorization Code Grant — Error Response)](
+ * https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1).
+ */
+@Tag("security")
+class OAuth2AuthorizeCancelIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "cancelling an authorization returns access_denied with no code on {0}")
+    @EnumSource(Database::class)
+    fun cancellingAuthorizationReturnsAccessDenied(database: Database) {
+        withContainer(database) { sympauthy, registry ->
+            withFlowClient(sympauthy) { flow ->
+                // Start the authorization: the server redirects (303) to the sign-in page, carrying the
+                // signed internal state that authenticates the flow endpoints.
+                val authorize = flow.get(authorizeUrl(sympauthy, registry))
+                assertEquals(303, authorize.status, "authorize should redirect to the first flow step")
+                val internalState = queryParam(authorize.location ?: error("authorize 303 had no Location"), "state")
+                    ?: error("authorize redirect did not carry a state: ${authorize.location}")
+
+                // The user declines: cancel the ongoing flow.
+                val cancel = flow.cancel(internalState)
+                assertEquals(200, cancel.status, "cancel should succeed, body=${cancel.body}")
+                val redirect = cancel.fields["redirect_url"]
+                    ?: error("cancel response had no redirect_url: ${cancel.body}")
+
+                assertTrue(
+                    redirect.startsWith(registry.redirectUri()),
+                    "cancel should redirect to the client redirect_uri, was: $redirect",
+                )
+                assertEquals(
+                    "access_denied", queryParam(redirect, "error"),
+                    "a cancelled authorization must return error=access_denied, was: $redirect",
+                )
+                assertEquals(
+                    "integration-test-state", queryParam(redirect, "state"),
+                    "the client state must be echoed back, was: $redirect",
+                )
+                assertNull(
+                    queryParam(redirect, "code"),
+                    "a cancelled authorization must not mint an authorization code, was: $redirect",
+                )
+            }
+        }
+    }
+}

--- a/integration-tests/src/main/kotlin/com/sympauthy/it/client/FlowHttpClient.kt
+++ b/integration-tests/src/main/kotlin/com/sympauthy/it/client/FlowHttpClient.kt
@@ -38,11 +38,6 @@ class FlowHttpClient(
             .header("Authorization", "State $state"),
     )
 
-    /** POSTs [body] as JSON to [path], authenticated as the bearer-token [accessToken] (e.g. a client token). */
-    fun postJson(path: String, accessToken: String, body: Any): FlowCall = exchange(
-        HttpRequest.POST(path, body).bearerAuth(accessToken),
-    )
-
     private fun exchange(request: HttpRequest<*>): FlowCall {
         val (status, location, body) = try {
             val response = http.toBlocking().exchange(request, String::class.java)

--- a/integration-tests/src/main/kotlin/com/sympauthy/it/client/FlowHttpClient.kt
+++ b/integration-tests/src/main/kotlin/com/sympauthy/it/client/FlowHttpClient.kt
@@ -1,0 +1,92 @@
+package com.sympauthy.it.client
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.json.JsonMapper
+import jakarta.inject.Singleton
+import java.net.URI
+
+/**
+ * A non-redirect-following Micronaut HTTP client for the flow endpoints the generated typed client
+ * cannot express directly:
+ * - the `/authorize` GET, whose `303` `Location` carries the signed internal state as `?state=<jwt>`;
+ * - the state-secured `POST /api/v1/flow/cancel`, whose `Authorization: State <jwt>` is not a generated
+ *   parameter (state is a security scheme, not an operation argument).
+ *
+ * It returns a plain [FlowCall] (status + `Location` + body) rather than throwing on non-2xx, so a
+ * scenario can assert on a `303` redirect or a recoverable `4xx` the same way.
+ *
+ * Bound to the `sympauthy` service ([Client]); the hosting context must set
+ * `micronaut.http.services.sympauthy.follow-redirects=false` so the `/authorize` `303` is observable.
+ */
+@Singleton
+class FlowHttpClient(
+    @param:Client("sympauthy") private val http: HttpClient,
+    private val jsonMapper: JsonMapper,
+) {
+
+    /** GETs [url] (absolute or relative) without following redirects. */
+    fun get(url: String): FlowCall = exchange(HttpRequest.GET<Any>(relativize(url)))
+
+    /** POSTs the bodyless `/api/v1/flow/cancel`, authenticated by the signed [state]. */
+    fun cancel(state: String): FlowCall = exchange(
+        HttpRequest.create<Any>(HttpMethod.POST, "/api/v1/flow/cancel")
+            .header("Authorization", "State $state"),
+    )
+
+    /** POSTs [body] as JSON to [path], authenticated as the bearer-token [accessToken] (e.g. a client token). */
+    fun postJson(path: String, accessToken: String, body: Any): FlowCall = exchange(
+        HttpRequest.POST(path, body).bearerAuth(accessToken),
+    )
+
+    private fun exchange(request: HttpRequest<*>): FlowCall {
+        val (status, location, body) = try {
+            val response = http.toBlocking().exchange(request, String::class.java)
+            Triple(response.status.code, response.header("Location"), response.body() ?: "")
+        } catch (e: HttpClientResponseException) {
+            val response = e.response
+            Triple(
+                response.status.code,
+                response.headers.get("Location"),
+                response.getBody(String::class.java).orElse(""),
+            )
+        }
+        return FlowCall(status, location, body, parseFields(body))
+    }
+
+    /** The top-level scalar JSON fields of [body] (e.g. `redirect_url`, `state`); empty if not a JSON object. */
+    private fun parseFields(body: String): Map<String, String> {
+        if (body.isBlank()) return emptyMap()
+        return try {
+            val map = jsonMapper.readValue(body, Argument.mapOf(String::class.java, Any::class.java))
+                ?: return emptyMap()
+            map.entries
+                .filter { (_, value) -> value !is Map<*, *> && value !is Collection<*> }
+                .associate { (key, value) -> key to value.toString() }
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    /** A relative path (+query) for a same-host URL, so the service-bound client resolves it against its base. */
+    private fun relativize(url: String): String {
+        val uri = URI.create(url)
+        if (uri.host == null) return url
+        return if (uri.rawQuery != null) "${uri.rawPath}?${uri.rawQuery}" else uri.rawPath
+    }
+}
+
+/**
+ * The outcome of a flow HTTP call: the response [status], any `Location` header, the raw [body], and its
+ * top-level string JSON [fields] (e.g. `redirect_url`, `state`) parsed for convenience.
+ */
+data class FlowCall(
+    val status: Int,
+    val location: String?,
+    val body: String,
+    val fields: Map<String, String>,
+)


### PR DESCRIPTION
## Context

Follow-up to #289 (typed end-of-flow redirect + user cancellation), tracked by #290. #289 added
`POST /api/v1/flow/cancel` and the cancel-redirect semantics but left integration-test coverage (and the
native gate) out of scope.

## What changed

Two new integration tests (`@ParameterizedTest @EnumSource(Database)`, H2 + PostgreSQL), driven through
the generated Micronaut client + the signed internal state:

- **`security/OAuth2AuthorizeCancelIT`** — cancelling an authorization returns the client `redirect_uri`
  with `error=access_denied` and the client `state` echoed, and **never mints an authorization code**
  (RFC 6749 §4.1.2.1).
- **`security/CancelledFlowStateNotReplayableIT`** — after cancel the signed state is spent; replaying it
  against a step that requires an ongoing session (`GET /api/v1/flow/mfa/challenge`) is rejected with
  `400 ctrl.flow.not_ongoing`.

Plumbing: `FlowHttpClient`, a non-redirect-following `@Client("sympauthy")` wrapper that reads the
`/authorize` `303` `Location` (which carries the signed state) and drives the state-secured `/flow/cancel`
endpoint, plus `withFlowClient` / query-param helpers on `AbstractSympauthyIT`.

## Scope decisions (rationale on #290)

- **`testcontainers-sympauthy` DSL / publish (issue task 2): not needed.** 0.5.0 already covers the
  MFA-enrollment cancel path, and OAuth2-authorize cancel is driven via the consumer's Micronaut client.
  No flow-config **response** resource changed, so no version bump.
- **MFA-enrollment cancel feature ITs: dropped** — already covered upstream by the library's
  `ClientInitiatedMfaEnrollmentIT`.

## Verification

`:integration-tests:integrationTest` against a working-tree JVM image (`server:latest`):
**BUILD SUCCESSFUL — 46 passed / 0 failed** (23 IT classes × H2 + PostgreSQL); the two new scenarios pass
on both databases and nothing else regressed. CI's **native** `sympauthy:it` run is the authoritative gate
(issue task 1).

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
