### PR TITLE
Use configured identifier claims for the TOTP account label (#221)

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionTotpEnrollmentManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionTotpEnrollmentManager.kt
@@ -1,13 +1,13 @@
 package com.sympauthy.business.manager.flow.mfa
 
 import com.sympauthy.business.exception.recoverableBusinessExceptionOf
+import com.sympauthy.business.manager.ClaimManager
 import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
 import com.sympauthy.business.manager.mfa.TotpManager
 import com.sympauthy.business.manager.user.CollectedClaimManager
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.mfa.TotpEnrollment
 import com.sympauthy.business.model.user.User
-import com.sympauthy.business.model.user.claim.OpenIdConnectClaimId
 import com.sympauthy.config.model.AuthConfig
 import com.sympauthy.config.model.orThrow
 import jakarta.inject.Inject
@@ -18,6 +18,7 @@ import java.net.URI
 class InteractiveFlowSessionTotpEnrollmentManager(
     @Inject private val totpManager: TotpManager,
     @Inject private val sessionManager: InteractiveFlowSessionManager,
+    @Inject private val claimManager: ClaimManager,
     @Inject private val collectedClaimManager: CollectedClaimManager,
     @Inject private val uncheckedAuthConfig: AuthConfig
 ) {
@@ -88,12 +89,16 @@ class InteractiveFlowSessionTotpEnrollmentManager(
     }
 
     /**
-     * Returns the user's email address as the TOTP account label, falling back to the user ID.
+     * Returns the TOTP account label for [user]: the first collected value among the configured
+     * identifier claims (in configured priority order), falling back to the user ID when none are available.
      */
     private suspend fun getAccount(user: User): String {
-        return collectedClaimManager.findByUserId(user.id)
-            .firstOrNull { it.claim.id == OpenIdConnectClaimId.EMAIL }
-            ?.value?.toString()
+        val collectedClaims = collectedClaimManager.findIdentifierByUserId(user.id)
+        return claimManager.listIdentifierClaims()
+            .firstNotNullOfOrNull { claim ->
+                collectedClaims.firstOrNull { it.claim.id == claim.id }?.value
+            }
+            ?.toString()
             ?: user.id.toString()
     }
 }

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionTotpEnrollmentManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionTotpEnrollmentManagerTest.kt
@@ -1,0 +1,216 @@
+package com.sympauthy.business.manager.flow.mfa
+
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.mfa.TotpManager
+import com.sympauthy.business.manager.user.CollectedClaimManager
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.mfa.TotpEnrollment
+import com.sympauthy.business.model.user.CollectedClaim
+import com.sympauthy.business.model.user.User
+import com.sympauthy.business.model.user.claim.Claim
+import com.sympauthy.config.model.EnabledAuthConfig
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class InteractiveFlowSessionTotpEnrollmentManagerTest {
+
+    @MockK
+    lateinit var totpManager: TotpManager
+
+    @MockK
+    lateinit var sessionManager: InteractiveFlowSessionManager
+
+    @MockK
+    lateinit var claimManager: ClaimManager
+
+    @MockK
+    lateinit var collectedClaimManager: CollectedClaimManager
+
+    @MockK
+    lateinit var uncheckedAuthConfig: EnabledAuthConfig
+
+    @InjectMockKs
+    lateinit var manager: InteractiveFlowSessionTotpEnrollmentManager
+
+    private val userId = UUID.randomUUID()
+    private val user = mockk<User> { every { id } returns userId }
+
+    // --- getEnrollmentData / getAccount ---
+
+    @Test
+    fun `getAccount - uses the first configured identifier claim regardless of collected order`() = runTest {
+        // Config order (username before email) must win over collection/DB order (email first).
+        val account = accountLabelFor(
+            identifierClaims = listOf(claim("preferred_username"), claim("email")),
+            collected = listOf(
+                collectedClaim("email", "alice@example.com"),
+                collectedClaim("preferred_username", "alice")
+            )
+        )
+        assertEquals("alice", account)
+    }
+
+    @Test
+    fun `getAccount - falls back to the next identifier claim when the first is not collected`() = runTest {
+        val account = accountLabelFor(
+            identifierClaims = listOf(claim("preferred_username"), claim("email")),
+            collected = listOf(collectedClaim("email", "alice@example.com"))
+        )
+        assertEquals("alice@example.com", account)
+    }
+
+    @Test
+    fun `getAccount - skips an identifier claim whose collected value is null`() = runTest {
+        val account = accountLabelFor(
+            identifierClaims = listOf(claim("preferred_username"), claim("email")),
+            collected = listOf(
+                collectedClaim("preferred_username", null),
+                collectedClaim("email", "alice@example.com")
+            )
+        )
+        assertEquals("alice@example.com", account)
+    }
+
+    @Test
+    fun `getAccount - falls back to the user id when no identifier claim is collected`() = runTest {
+        val account = accountLabelFor(
+            identifierClaims = listOf(claim("preferred_username"), claim("email")),
+            collected = emptyList()
+        )
+        assertEquals(userId.toString(), account)
+    }
+
+    @Test
+    fun `getAccount - falls back to the user id when no identifier claim is configured`() = runTest {
+        val account = accountLabelFor(
+            identifierClaims = emptyList(),
+            collected = listOf(collectedClaim("email", "alice@example.com"))
+        )
+        assertEquals(userId.toString(), account)
+    }
+
+    @Test
+    fun `getEnrollmentData - derives the issuer host, builds the otpauth uri and returns the base32 secret`() =
+        runTest {
+            val enrollment = enrollment()
+            coEvery { totpManager.initiateEnrollment(user) } returns enrollment
+            every { uncheckedAuthConfig.issuer } returns "https://auth.example.com"
+            coEvery { collectedClaimManager.findIdentifierByUserId(userId) } returns
+                    listOf(collectedClaim("email", "alice@example.com"))
+            every { claimManager.listIdentifierClaims() } returns listOf(claim("email"))
+            val issuerSlot = slot<String>()
+            every {
+                totpManager.buildOtpauthUri(capture(issuerSlot), any(), enrollment.secret)
+            } returns "otpauth://totp/stub"
+            every { totpManager.encodeSecretToBase32(enrollment.secret) } returns "BASE32SECRET"
+
+            val data = manager.getEnrollmentData(user)
+
+            assertEquals("auth.example.com", issuerSlot.captured)
+            assertEquals(enrollment, data.enrollment)
+            assertEquals("otpauth://totp/stub", data.uri)
+            assertEquals("BASE32SECRET", data.secret)
+        }
+
+    // --- confirmEnrollment ---
+
+    @Test
+    fun `confirmEnrollment - marks the MFA step as passed when the pending enrollment is confirmed`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val updatedSession = mockk<OnGoingInteractiveFlowSession>()
+        val pending = enrollment()
+        coEvery { totpManager.findPendingEnrollmentOrNull(userId) } returns pending
+        coEvery { totpManager.confirmEnrollment(pending, "123456") } returns
+                pending.copy(confirmedDate = LocalDateTime.now())
+        coEvery { sessionManager.setMfaPassed(session) } returns updatedSession
+
+        val result = manager.confirmEnrollment(session, user, "123456")
+
+        assertSame(updatedSession, result)
+    }
+
+    @Test
+    fun `confirmEnrollment - throws when there is no pending enrollment`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        coEvery { totpManager.findPendingEnrollmentOrNull(userId) } returns null
+
+        val exception = assertThrows<BusinessException> {
+            manager.confirmEnrollment(session, user, "123456")
+        }
+        assertEquals("flow.mfa.totp.enroll.no_pending_enrollment", exception.detailsId)
+        coVerify(exactly = 0) { sessionManager.setMfaPassed(any()) }
+    }
+
+    @Test
+    fun `confirmEnrollment - throws when the submitted code is invalid`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val pending = enrollment()
+        coEvery { totpManager.findPendingEnrollmentOrNull(userId) } returns pending
+        coEvery { totpManager.confirmEnrollment(pending, "000000") } returns null
+
+        val exception = assertThrows<BusinessException> {
+            manager.confirmEnrollment(session, user, "000000")
+        }
+        assertEquals("flow.mfa.totp.enroll.invalid_code", exception.detailsId)
+        coVerify(exactly = 0) { sessionManager.setMfaPassed(any()) }
+    }
+
+    /**
+     * Sets up [getEnrollmentData] with the given identifier claims and collected claims,
+     * runs it, and returns the account label passed to [TotpManager.buildOtpauthUri].
+     */
+    private suspend fun accountLabelFor(
+        identifierClaims: List<Claim>,
+        collected: List<CollectedClaim>
+    ): String {
+        val enrollment = enrollment()
+        coEvery { totpManager.initiateEnrollment(user) } returns enrollment
+        every { uncheckedAuthConfig.issuer } returns "https://auth.example.com"
+        coEvery { collectedClaimManager.findIdentifierByUserId(userId) } returns collected
+        every { claimManager.listIdentifierClaims() } returns identifierClaims
+        val accountSlot = slot<String>()
+        every { totpManager.buildOtpauthUri(any(), capture(accountSlot), any()) } returns "otpauth://totp/stub"
+        every { totpManager.encodeSecretToBase32(any()) } returns "BASE32SECRET"
+
+        manager.getEnrollmentData(user)
+
+        return accountSlot.captured
+    }
+
+    private fun enrollment() = TotpEnrollment(
+        id = UUID.randomUUID(),
+        userId = userId,
+        secret = byteArrayOf(1, 2, 3),
+        creationDate = LocalDateTime.now(),
+        confirmedDate = null
+    )
+
+    private fun claim(id: String): Claim = mockk {
+        every { this@mockk.id } returns id
+    }
+
+    private fun collectedClaim(claimId: String, collectedValue: Any?): CollectedClaim {
+        val claim = claim(claimId)
+        return mockk {
+            every { this@mockk.claim } returns claim
+            every { value } returns collectedValue
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #221. The TOTP enrollment flow hardcoded the `email` OpenID Connect claim as the account label embedded in the `otpauth://` URI displayed by authenticator apps. When the operator configures different identifier claims (e.g. `preferred_username`), the label no longer matched how the system actually identifies the user.

`getAccount` in `InteractiveFlowSessionTotpEnrollmentManager` now resolves the label from `claimManager.listIdentifierClaims()`:

- picks the **first collected value in configured priority order** (iterating the configured claims, not the collected rows, so the operator's priority order wins regardless of DB row order);
- skips `null` collected values (deliberately-deleted claims);
- falls back to `user.id` when no identifier claim is available.

## Why it's safe

The label is **display-only** metadata. Per RFC 6238/4226 the TOTP code is derived solely from the shared secret and the current time step — the account label/issuer never enter the computation (`TotpManager.generateCode` takes only `secret` + `step`). So this change is cosmetic at the crypto level and does not affect or invalidate existing enrollments.

## Tests

Adds `InteractiveFlowSessionTotpEnrollmentManagerTest` (the manager previously had no unit tests) — 9 tests, all green:

- **Label resolution:** config-priority order beats collection order; fallback to the next claim when the first isn't collected; skip `null` values; fallback to `user.id` when nothing is collected or no identifier claim is configured.
- **`getEnrollmentData` wiring:** issuer-host derivation, otpauth URI, base32 secret.
- **`confirmEnrollment`:** marks the MFA step passed on success; throws the correct recoverable `BusinessException` (`no_pending_enrollment` / `invalid_code`) without passing MFA on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)