### PR TITLE
Add optimistic-concurrency (anti-replay) protection to interactive flow session updates (#193)

### DIFF
--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/auth/InteractiveAuthFlowSessionControllerUtil.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/auth/InteractiveAuthFlowSessionControllerUtil.kt
@@ -356,6 +356,17 @@ class InteractiveAuthFlowSessionControllerUtil(
         if (exception.recoverable) {
             throw exception
         }
+        // A concurrent-modification conflict means another request advanced this shared session. If that
+        // request already drove it to a terminal state, route by that current state instead of failing it
+        // (which would clobber the winner): e.g. a double-submit whose sibling already completed sends this
+        // request to the success redirect rather than the error page. If it is still ongoing we fall
+        // through and fail it, honouring the "a conflict fails the session" behaviour.
+        if (exception.detailsId == InteractiveFlowSessionManager.CONCURRENT_MODIFICATION_DETAILS_ID) {
+            val current = sessionManager.fetchByIdOrNull(session.id)
+            if (current != null && current !is OnGoingInteractiveFlowSession) {
+                return current
+            }
+        }
         return if (session is OnGoingInteractiveFlowSession) {
             sessionManager.markAsFailedIfNotRecoverable(
                 session = session,

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
@@ -15,6 +15,7 @@ import com.sympauthy.data.model.InteractiveFlowSessionEntity
 import com.sympauthy.data.repository.InteractiveFlowSessionRepository
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
 import java.net.URI
 import java.time.LocalDateTime
 import java.util.*
@@ -34,7 +35,7 @@ import java.util.*
  * Managers handling those logics are in the flow package.
  */
 @Singleton
-class InteractiveFlowSessionManager(
+open class InteractiveFlowSessionManager(
     @Inject private val userManager: UserManager,
     @Inject private val jwtManager: JwtManager,
     @Inject private val sessionRepository: InteractiveFlowSessionRepository,
@@ -140,14 +141,17 @@ class InteractiveFlowSessionManager(
         userId: UUID,
         signedUp: Boolean = false
     ): OnGoingInteractiveFlowSession {
-        sessionRepository.updateUserId(
+        val updated = sessionRepository.updateUserId(
             id = session.id,
             userId = userId,
-            signedUp = signedUp
+            signedUp = signedUp,
+            expectedVersion = session.version
         )
+        if (updated == 0) throw concurrentModificationOf(session)
         return session.copy(
             userId = userId,
-            signedUp = signedUp
+            signedUp = signedUp,
+            version = session.version + 1
         )
     }
 
@@ -159,11 +163,13 @@ class InteractiveFlowSessionManager(
         session: OnGoingInteractiveFlowSession
     ): OnGoingInteractiveFlowSession {
         val mfaPassedDate = LocalDateTime.now()
-        sessionRepository.updateMfaPassedDate(
+        val updated = sessionRepository.updateMfaPassedDate(
             id = session.id,
-            mfaPassedDate = mfaPassedDate
+            mfaPassedDate = mfaPassedDate,
+            expectedVersion = session.version
         )
-        return session.copy(mfaPassedDate = mfaPassedDate)
+        if (updated == 0) throw concurrentModificationOf(session)
+        return session.copy(mfaPassedDate = mfaPassedDate, version = session.version + 1)
     }
 
     /**
@@ -184,31 +190,48 @@ class InteractiveFlowSessionManager(
         val afterIndex = session.purposes.indexOf(afterPurpose)
         val insertAt = if (afterIndex >= 0) afterIndex + 1 else session.purposes.size
         val purposes = session.purposes.toMutableList().apply { add(insertAt, purpose) }.toList()
-        sessionRepository.updatePurposes(
+        val updated = sessionRepository.updatePurposes(
             id = session.id,
-            purposes = purposes.map(InteractiveFlowPurpose::name)
+            purposes = purposes.map(InteractiveFlowPurpose::name).toTypedArray(),
+            expectedVersion = session.version
         )
-        return session.copy(purposes = purposes)
+        if (updated == 0) throw concurrentModificationOf(session)
+        return session.copy(purposes = purposes, version = session.version + 1)
     }
 
     /**
      * Set and save the error if it is non-recoverable to prevent further usage of the [session].
      * Do nothing if the [error] is recoverable.
      */
-    suspend fun markAsFailedIfNotRecoverable(
+    @Transactional
+    open suspend fun markAsFailedIfNotRecoverable(
         session: OnGoingInteractiveFlowSession,
         error: BusinessException
     ): InteractiveFlowSession {
         if (error.recoverable) return session
 
         val errorDate = LocalDateTime.now()
-        sessionRepository.updateError(
-            id = session.id,
-            errorDate = errorDate,
-            errorDetailsId = error.detailsId,
-            errorDescriptionId = error.descriptionId,
-            errorValues = error.values
-        )
+        // Two-step version guard: a scalar compare-and-swap then the derived error write, kept atomic
+        // by this @Transactional so the row lock the swap takes serialises concurrent writers across
+        // both statements. Unlike the other lifecycle mutations this cannot be a single versioned
+        // statement — the error_values JSON column round-trips only through Micronaut's property-mapped
+        // serialization, not a raw-query parameter.
+        //
+        // A lost swap (0 rows) is deliberately swallowed rather than thrown: the session was already
+        // advanced or terminated by a concurrent winner. We must not overwrite the winner's state, yet
+        // this losing/replayed request must still be routed to the error page — so we skip the write and
+        // return an in-memory FailedInteractiveFlowSession. Swallowing here is also what stops a
+        // concurrent-modification conflict (whose own exception brought us into this failure path) from
+        // recursing.
+        if (sessionRepository.bumpVersion(session.id, session.version) == 1) {
+            sessionRepository.updateError(
+                id = session.id,
+                errorDate = errorDate,
+                errorDetailsId = error.detailsId,
+                errorDescriptionId = error.descriptionId,
+                errorValues = error.values
+            )
+        }
         return FailedInteractiveFlowSession(
             id = session.id,
             purposes = session.purposes,
@@ -245,10 +268,12 @@ class InteractiveFlowSessionManager(
         }
 
         val cancelDate = LocalDateTime.now()
-        sessionRepository.updateCancelDate(
+        val updated = sessionRepository.updateCancelDate(
             id = session.id,
-            cancelDate = cancelDate
+            cancelDate = cancelDate,
+            expectedVersion = session.version
         )
+        if (updated == 0) throw concurrentModificationOf(session)
         return CancelledInteractiveFlowSession(
             id = session.id,
             purposes = session.purposes,
@@ -276,11 +301,13 @@ class InteractiveFlowSessionManager(
         purpose: InteractiveFlowPurpose
     ): OnGoingInteractiveFlowSession {
         val completedPurposes = (session.completedPurposes + purpose).distinct()
-        sessionRepository.updateCompletedPurposes(
+        val updated = sessionRepository.updateCompletedPurposes(
             id = session.id,
-            completedPurposes = completedPurposes.map(InteractiveFlowPurpose::name)
+            completedPurposes = completedPurposes.map(InteractiveFlowPurpose::name).toTypedArray(),
+            expectedVersion = session.version
         )
-        return session.copy(completedPurposes = completedPurposes)
+        if (updated == 0) throw concurrentModificationOf(session)
+        return session.copy(completedPurposes = completedPurposes, version = session.version + 1)
     }
 
     /**
@@ -299,10 +326,12 @@ class InteractiveFlowSessionManager(
             "auth.interactive_flow_session.complete.missing_user"
         )
         val completeDate = LocalDateTime.now()
-        sessionRepository.updateCompleteDate(
+        val updated = sessionRepository.updateCompleteDate(
             id = session.id,
-            completeDate = completeDate
+            completeDate = completeDate,
+            expectedVersion = session.version
         )
+        if (updated == 0) throw concurrentModificationOf(session)
         return CompletedInteractiveFlowSession(
             id = session.id,
             purposes = session.purposes,
@@ -361,6 +390,19 @@ class InteractiveFlowSessionManager(
             session
         } else null
     }
+
+    /**
+     * Build the non-recoverable [BusinessException] thrown when a version-guarded update affects no
+     * rows: the [session] snapshot the caller holds is stale because another request advanced the
+     * session since it was read. Being non-recoverable, it is routed by the interactive-flow error
+     * handling to the flow's error page (see
+     * [com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil.handleException]).
+     */
+    private fun concurrentModificationOf(session: InteractiveFlowSession): BusinessException =
+        businessExceptionOf(
+            "auth.interactive_flow_session.concurrent_modification",
+            "sessionId" to session.id.toString()
+        )
 
     companion object {
         /**

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
@@ -211,19 +211,18 @@ open class InteractiveFlowSessionManager(
         if (error.recoverable) return session
 
         val errorDate = LocalDateTime.now()
-        // Two-step version guard: a scalar compare-and-swap then the derived error write, kept atomic
-        // by this @Transactional so the row lock the swap takes serialises concurrent writers across
-        // both statements. Unlike the other lifecycle mutations this cannot be a single versioned
-        // statement — the error_values JSON column round-trips only through Micronaut's property-mapped
-        // serialization, not a raw-query parameter.
+        // Two-step terminal write: a not-terminal guard then the derived error write, kept atomic by this
+        // @Transactional so the row lock the guard takes serialises the two statements. It cannot be a
+        // single versioned statement — the error_values JSON column round-trips only through Micronaut's
+        // property-mapped serialization, not a raw-query parameter.
         //
-        // A lost swap (0 rows) is deliberately swallowed rather than thrown: the session was already
-        // advanced or terminated by a concurrent winner. We must not overwrite the winner's state, yet
-        // this losing/replayed request must still be routed to the error page — so we skip the write and
-        // return an in-memory FailedInteractiveFlowSession. Swallowing here is also what stops a
-        // concurrent-modification conflict (whose own exception brought us into this failure path) from
-        // recursing.
-        if (sessionRepository.bumpVersion(session.id, session.version) == 1) {
+        // The guard bumps the version only while the session is still ongoing. This request has usually
+        // advanced the version itself before failing, so a version compare-and-swap on the remembered
+        // (now-stale) version would wrongly swallow the write and leave the session ongoing; guarding on
+        // "not already terminal" fails it correctly. A session a concurrent request already
+        // completed/cancelled/failed yields 0 rows here and is left untouched — we must not overwrite that
+        // winner (and a concurrent conflict never reaches this method: it is diverted in the controller).
+        if (sessionRepository.failIfOngoing(session.id) == 1) {
             sessionRepository.updateError(
                 id = session.id,
                 errorDate = errorDate,
@@ -392,19 +391,37 @@ open class InteractiveFlowSessionManager(
     }
 
     /**
+     * Re-read the [InteractiveFlowSession] with the given [id] from the database, or null if it no longer
+     * exists. Unlike [verifyEncodedInternalState] this needs no signed state, so a caller holding a stale
+     * in-memory session (e.g. after a concurrent-modification conflict) can refresh it to its current
+     * persisted status and route by that.
+     */
+    suspend fun fetchByIdOrNull(id: UUID): InteractiveFlowSession? {
+        return sessionRepository.findById(id)?.let(sessionMapper::toInteractiveFlowSession)
+    }
+
+    /**
      * Build the non-recoverable [BusinessException] thrown when a version-guarded update affects no
      * rows: the [session] snapshot the caller holds is stale because another request advanced the
      * session since it was read. Being non-recoverable, it is routed by the interactive-flow error
-     * handling to the flow's error page (see
-     * [com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil.handleException]).
+     * handling (see
+     * [com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil.handleException]),
+     * which reflects the session's current terminal status where possible and otherwise fails it.
      */
     private fun concurrentModificationOf(session: InteractiveFlowSession): BusinessException =
         businessExceptionOf(
-            "auth.interactive_flow_session.concurrent_modification",
+            CONCURRENT_MODIFICATION_DETAILS_ID,
             "sessionId" to session.id.toString()
         )
 
     companion object {
+        /**
+         * Detail id of the non-recoverable exception raised when a version-guarded update loses its
+         * compare-and-swap. The controller special-cases it (see
+         * [com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil]).
+         */
+        const val CONCURRENT_MODIFICATION_DETAILS_ID = "auth.interactive_flow_session.concurrent_modification"
+
         /**
          * Name of the cryptographic key used to sign the state.
          */

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapper.kt
@@ -36,6 +36,7 @@ abstract class InteractiveFlowSessionMapper {
             flowId = entity.flowId,
             expirationDate = entity.expirationDate,
             sessionDate = entity.sessionDate,
+            version = entity.version,
             userId = entity.userId,
             signedUp = entity.signedUp,
             completedPurposes = entity.completedPurposes.map(InteractiveFlowPurpose::valueOf),

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSession.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSession.kt
@@ -70,6 +70,17 @@ class OnGoingInteractiveFlowSession(
     val sessionDate: LocalDateTime,
 
     /**
+     * Optimistic-concurrency version of the underlying row, as it was last read. Every guarded
+     * lifecycle mutation is a compare-and-swap against this value (and returns a session carrying the
+     * incremented version); a stale value loses the swap, so a replayed / concurrent request cannot
+     * silently overwrite newer state.
+     *
+     * Defaults to 0 (a freshly-created row) purely for construction ergonomics; the mapper always
+     * supplies the persisted value read from the database.
+     */
+    val version: Long = 0,
+
+    /**
      * The identifier of the user that has been authenticated during this session.
      * Null until the user has been identified.
      */
@@ -136,6 +147,7 @@ class OnGoingInteractiveFlowSession(
         userId: UUID? = null,
         signedUp: Boolean? = null,
         mfaPassedDate: LocalDateTime? = null,
+        version: Long? = null,
     ) = OnGoingInteractiveFlowSession(
         id = this.id,
         purposes = purposes ?: this.purposes,
@@ -143,6 +155,7 @@ class OnGoingInteractiveFlowSession(
         flowId = this.flowId,
         expirationDate = this.expirationDate,
         sessionDate = this.sessionDate,
+        version = version ?: this.version,
         userId = userId ?: this.userId,
         signedUp = signedUp ?: this.signedUp,
         completedPurposes = completedPurposes ?: this.completedPurposes,

--- a/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionEntity.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionEntity.kt
@@ -12,6 +12,12 @@ import java.util.*
 @Serdeable
 @MappedEntity("interactive_flow_sessions")
 class InteractiveFlowSessionEntity(
+    // Optimistic-concurrency counter. Incremented by every guarded lifecycle update in
+    // InteractiveFlowSessionRepository (WHERE version = :expectedVersion ... SET version = version + 1).
+    // Deliberately a plain column, not @Version: Micronaut's optimistic locking only engages on
+    // full-entity update/delete, whereas the session is mutated through query-based partial updates.
+    val version: Long = 0,
+
     // Session metadata
     val purposes: Array<String>,
     val initiatingPurpose: String,

--- a/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepository.kt
@@ -40,8 +40,9 @@ import java.util.*
  *
  * The lone exception is the terminal error write: its `error_values` `json` column round-trips
  * correctly only through Micronaut's property-mapped serialization, not through a raw-query
- * parameter, so it cannot be expressed as a single versioned statement. It is instead guarded by a
- * scalar [bumpVersion] compare-and-swap paired with the derived [updateError] inside one transaction
+ * parameter, so it cannot be expressed as a single versioned statement. It is instead a scalar
+ * [failIfOngoing] guard (which bumps the version only while the session is still ongoing) paired with
+ * the derived [updateError] inside one transaction
  * (see [com.sympauthy.business.manager.flow.InteractiveFlowSessionManager.markAsFailedIfNotRecoverable]).
  *
  * `version` is deliberately a plain column rather than a Micronaut Data `@Version` property:
@@ -129,25 +130,32 @@ interface InteractiveFlowSessionRepository : CoroutineCrudRepository<Interactive
     ): Int
 
     /**
-     * Version compare-and-swap used to guard a mutation whose columns cannot be bound as parameters
-     * inside a raw versioned `@Query` — currently only the terminal error write (see [updateError]).
-     * Increments the version iff the row still holds [expectedVersion]. Callers run it in the same
-     * transaction as the accompanying partial update so the row lock it takes serialises concurrent
-     * writers across both statements.
-     * @return 1 if the swap succeeded, 0 if [expectedVersion] was stale.
+     * Fail-guard for the terminal error write: bump the version **iff the session is still ongoing**
+     * (no completion, cancellation or error date yet).
+     *
+     * Used instead of a version compare-and-swap because the failing request has usually advanced the
+     * session's version itself before hitting the non-recoverable error, so the version it remembers is
+     * stale — yet the session must still be failed. Guarding on "not already terminal" instead lets that
+     * self-advanced session be failed while still refusing to overwrite a session a concurrent request
+     * already drove to a terminal state (a concurrent conflict is diverted before this point; see
+     * [com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil]).
+     *
+     * Paired with the derived [updateError] in one transaction so the row lock it takes serialises the
+     * two statements.
+     * @return 1 if the session was ongoing and is now failing, 0 if it was already terminal.
      */
     @Query(
         """
         UPDATE interactive_flow_sessions
         SET version = version + 1
-        WHERE id = :id AND version = :expectedVersion
+        WHERE id = :id AND complete_date IS NULL AND cancel_date IS NULL AND error_date IS NULL
         """
     )
-    suspend fun bumpVersion(id: UUID, expectedVersion: Long): Int
+    suspend fun failIfOngoing(id: UUID): Int
 
     /**
-     * Write the terminal error, failing the session. Unversioned on its own: it must be paired with a
-     * preceding [bumpVersion] in the same transaction (see
+     * Write the terminal error, failing the session. Unguarded on its own: it must be paired with a
+     * preceding [failIfOngoing] in the same transaction (see
      * [com.sympauthy.business.manager.flow.InteractiveFlowSessionManager.markAsFailedIfNotRecoverable]).
      * Kept as a derived method so `error_values` is serialized to JSON by Micronaut's property mapping,
      * which a raw-query parameter does not do.

--- a/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepository.kt
@@ -3,10 +3,52 @@ package com.sympauthy.data.repository
 import com.sympauthy.data.model.InteractiveFlowSessionEntity
 import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.TypeDef
+import io.micronaut.data.model.DataType
 import io.micronaut.data.repository.kotlin.CoroutineCrudRepository
 import java.time.LocalDateTime
 import java.util.*
 
+/**
+ * Repository for [InteractiveFlowSessionEntity], the parent row of an interactive flow session.
+ *
+ * ## Optimistic-concurrency contract
+ *
+ * [InteractiveFlowSessionEntity.version] is a monotonic counter that guards every lifecycle
+ * mutation against lost updates — the case where a replayed or double-submitted step request
+ * overwrites state a more recent request already advanced. Each `updateXxx` method below is a single
+ * compare-and-swap statement of the form:
+ *
+ * ```sql
+ * UPDATE interactive_flow_sessions
+ * SET <changed columns>, version = version + 1
+ * WHERE id = :id AND version = :expectedVersion
+ * ```
+ *
+ * The caller passes `expectedVersion` = the version of the session it last read, and inspects the
+ * returned affected-row count:
+ * - `1` — the row still held `expectedVersion`: the update was applied and the version incremented.
+ * - `0` — the row no longer holds `expectedVersion`: another request advanced (or terminated) the
+ *   session since it was read, so the caller's in-memory snapshot is stale and the update was a
+ *   no-op. The caller must treat this as a concurrent-modification conflict. See
+ *   [com.sympauthy.business.manager.flow.InteractiveFlowSessionManager], which fails the session
+ *   (routing the end-user to the error page) on a lost swap.
+ *
+ * Each statement is atomic on its own: the row lock a matching `UPDATE` takes serialises concurrent
+ * writers, so exactly one can observe a given `expectedVersion`. No surrounding transaction is
+ * required.
+ *
+ * The lone exception is the terminal error write: its `error_values` `json` column round-trips
+ * correctly only through Micronaut's property-mapped serialization, not through a raw-query
+ * parameter, so it cannot be expressed as a single versioned statement. It is instead guarded by a
+ * scalar [bumpVersion] compare-and-swap paired with the derived [updateError] inside one transaction
+ * (see [com.sympauthy.business.manager.flow.InteractiveFlowSessionManager.markAsFailedIfNotRecoverable]).
+ *
+ * `version` is deliberately a plain column rather than a Micronaut Data `@Version` property:
+ * `@Version` optimistic locking only engages on full-entity `update(entity)` / `delete(entity)`,
+ * whereas the session is only ever mutated through these query-based partial updates, so the check
+ * and the increment are expressed explicitly in SQL here instead.
+ */
 interface InteractiveFlowSessionRepository : CoroutineCrudRepository<InteractiveFlowSessionEntity, UUID> {
 
     @Query(
@@ -26,14 +68,90 @@ interface InteractiveFlowSessionRepository : CoroutineCrudRepository<Interactive
     )
     suspend fun findExpired(): List<InteractiveFlowSessionEntity>
 
-    suspend fun updatePurposes(@Id id: UUID, purposes: List<String>)
+    /**
+     * Version-guarded update of the ordered purpose list.
+     * @return 1 if applied, 0 if [expectedVersion] was stale (see the optimistic-concurrency contract).
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET purposes = :purposes, version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun updatePurposes(
+        id: UUID,
+        @TypeDef(type = DataType.STRING_ARRAY) purposes: Array<String>,
+        expectedVersion: Long
+    ): Int
 
-    suspend fun updateUserId(@Id id: UUID, userId: UUID, signedUp: Boolean)
+    /**
+     * Version-guarded update of the authenticated user id and sign-up flag.
+     * @return 1 if applied, 0 if [expectedVersion] was stale (see the optimistic-concurrency contract).
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET user_id = :userId, signed_up = :signedUp, version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun updateUserId(id: UUID, userId: UUID, signedUp: Boolean, expectedVersion: Long): Int
 
-    suspend fun updateMfaPassedDate(@Id id: UUID, mfaPassedDate: LocalDateTime)
+    /**
+     * Version-guarded update of the MFA-passed date.
+     * @return 1 if applied, 0 if [expectedVersion] was stale (see the optimistic-concurrency contract).
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET mfa_passed_date = :mfaPassedDate, version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun updateMfaPassedDate(id: UUID, mfaPassedDate: LocalDateTime, expectedVersion: Long): Int
 
-    suspend fun updateCompletedPurposes(@Id id: UUID, completedPurposes: List<String>)
+    /**
+     * Version-guarded update of the completed-purpose list.
+     * @return 1 if applied, 0 if [expectedVersion] was stale (see the optimistic-concurrency contract).
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET completed_purposes = :completedPurposes, version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun updateCompletedPurposes(
+        id: UUID,
+        @TypeDef(type = DataType.STRING_ARRAY) completedPurposes: Array<String>,
+        expectedVersion: Long
+    ): Int
 
+    /**
+     * Version compare-and-swap used to guard a mutation whose columns cannot be bound as parameters
+     * inside a raw versioned `@Query` — currently only the terminal error write (see [updateError]).
+     * Increments the version iff the row still holds [expectedVersion]. Callers run it in the same
+     * transaction as the accompanying partial update so the row lock it takes serialises concurrent
+     * writers across both statements.
+     * @return 1 if the swap succeeded, 0 if [expectedVersion] was stale.
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun bumpVersion(id: UUID, expectedVersion: Long): Int
+
+    /**
+     * Write the terminal error, failing the session. Unversioned on its own: it must be paired with a
+     * preceding [bumpVersion] in the same transaction (see
+     * [com.sympauthy.business.manager.flow.InteractiveFlowSessionManager.markAsFailedIfNotRecoverable]).
+     * Kept as a derived method so `error_values` is serialized to JSON by Micronaut's property mapping,
+     * which a raw-query parameter does not do.
+     */
     suspend fun updateError(
         @Id id: UUID,
         errorDate: LocalDateTime?,
@@ -42,9 +160,31 @@ interface InteractiveFlowSessionRepository : CoroutineCrudRepository<Interactive
         errorValues: Map<String, String>?
     )
 
-    suspend fun updateCompleteDate(@Id id: UUID, completeDate: LocalDateTime?)
+    /**
+     * Version-guarded write of the completion date, completing the session.
+     * @return 1 if applied, 0 if [expectedVersion] was stale (see the optimistic-concurrency contract).
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET complete_date = :completeDate, version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun updateCompleteDate(id: UUID, completeDate: LocalDateTime?, expectedVersion: Long): Int
 
-    suspend fun updateCancelDate(@Id id: UUID, cancelDate: LocalDateTime)
+    /**
+     * Version-guarded write of the cancellation date, cancelling the session.
+     * @return 1 if applied, 0 if [expectedVersion] was stale (see the optimistic-concurrency contract).
+     */
+    @Query(
+        """
+        UPDATE interactive_flow_sessions
+        SET cancel_date = :cancelDate, version = version + 1
+        WHERE id = :id AND version = :expectedVersion
+        """
+    )
+    suspend fun updateCancelDate(id: UUID, cancelDate: LocalDateTime, expectedVersion: Long): Int
 
     suspend fun deleteByIds(ids: List<UUID>): Int
 }

--- a/server/src/main/resources/databases/h2/V0_5_0_5__interactive_flow_sessions_new.sql
+++ b/server/src/main/resources/databases/h2/V0_5_0_5__interactive_flow_sessions_new.sql
@@ -1,6 +1,9 @@
 CREATE TABLE interactive_flow_sessions
 (
     id                   uuid      NOT NULL DEFAULT random_uuid(),
+    -- Optimistic-concurrency counter, incremented on every guarded lifecycle update. See
+    -- InteractiveFlowSessionRepository for the compare-and-swap contract.
+    version              bigint    NOT NULL DEFAULT 0,
     purposes             text array NOT NULL,
     initiating_purpose   text       NOT NULL,
     session_date         timestamp NOT NULL,

--- a/server/src/main/resources/databases/postgresql/V0_5_0_5__interactive_flow_sessions_new.sql
+++ b/server/src/main/resources/databases/postgresql/V0_5_0_5__interactive_flow_sessions_new.sql
@@ -1,6 +1,9 @@
 CREATE TABLE interactive_flow_sessions
 (
     id                   uuid      NOT NULL DEFAULT gen_random_uuid(),
+    -- Optimistic-concurrency counter, incremented on every guarded lifecycle update. See
+    -- InteractiveFlowSessionRepository for the compare-and-swap contract.
+    version              bigint    NOT NULL DEFAULT 0,
     purposes             text[]    NOT NULL,
     initiating_purpose   text      NOT NULL,
     session_date         timestamp NOT NULL,

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -164,6 +164,7 @@ auth.interactive_flow_session.complete.missing_redirect=Unable to complete the i
 auth.interactive_flow_session.cancel.missing_redirect=Unable to cancel the interactive flow session since it has no redirect target.
 auth.interactive_flow_session.cancel.no_cancel_target=This interactive flow session cannot be cancelled since it has no cancellation redirect URI.
 description.auth.interactive_flow_session.cancel.no_cancel_target=This flow does not offer cancellation. Complete it or let it expire instead.
+auth.interactive_flow_session.concurrent_modification=The interactive flow session {sessionId} was modified concurrently. The request was rejected to avoid overwriting more recent state.
 auth.interactive_flow_session.oauth2.missing=No OAuth2 request is attached to this interactive flow session.
 auth.interactive_flow_session.oauth2.wrong_type=The interactive flow session is of type {type}, not an OAuth2 session.
 auth.interactive_flow_session.user.missing=No user associated with this interactive flow session.

--- a/server/src/test/kotlin/com/sympauthy/api/controller/flow/auth/InteractiveAuthFlowSessionControllerUtilTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/flow/auth/InteractiveAuthFlowSessionControllerUtilTest.kt
@@ -1,0 +1,109 @@
+package com.sympauthy.api.controller.flow.auth
+
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.exception.businessExceptionOf
+import com.sympauthy.business.exception.recoverableBusinessExceptionOf
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.flow.CompletedInteractiveFlowSession
+import com.sympauthy.business.model.flow.FailedInteractiveFlowSession
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class InteractiveAuthFlowSessionControllerUtilTest {
+
+    @MockK
+    lateinit var sessionManager: InteractiveFlowSessionManager
+
+    @MockK
+    lateinit var userManager: UserManager
+
+    @MockK
+    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
+
+    @MockK
+    lateinit var engine: InteractiveFlowEngine
+
+    @MockK
+    lateinit var stepUriMapper: InteractiveFlowStepUriMapper
+
+    @InjectMockKs
+    lateinit var util: InteractiveAuthFlowSessionControllerUtil
+
+    private val concurrentModification = InteractiveFlowSessionManager.CONCURRENT_MODIFICATION_DETAILS_ID
+
+    @Test
+    fun `handleException - Returns the session unchanged when there is no exception`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+
+        assertSame(session, util.handleException(session, null))
+    }
+
+    @Test
+    fun `handleException - Rethrows a recoverable exception`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val error = recoverableBusinessExceptionOf("some.detail", "some.description")
+
+        val thrown = assertThrows<BusinessException> { util.handleException(session, error) }
+        assertSame(error, thrown)
+    }
+
+    @Test
+    fun `handleException - Routes a concurrent conflict by the current terminal session instead of failing it`() = runTest {
+        val sessionId = UUID.randomUUID()
+        val session = mockk<OnGoingInteractiveFlowSession> { every { id } returns sessionId }
+        val completed = mockk<CompletedInteractiveFlowSession>()
+        coEvery { sessionManager.fetchByIdOrNull(sessionId) } returns completed
+
+        val result = util.handleException(session, businessExceptionOf(concurrentModification))
+
+        // The concurrent winner completed the shared session, so this request is routed to that completed
+        // session (→ success redirect), never failed.
+        assertSame(completed, result)
+        coVerify(exactly = 0) { sessionManager.markAsFailedIfNotRecoverable(any(), any()) }
+    }
+
+    @Test
+    fun `handleException - Fails the session when the concurrent conflict is still ongoing`() = runTest {
+        val sessionId = UUID.randomUUID()
+        val session = mockk<OnGoingInteractiveFlowSession> { every { id } returns sessionId }
+        val stillOngoing = mockk<OnGoingInteractiveFlowSession>()
+        val failed = mockk<FailedInteractiveFlowSession>()
+        val error = businessExceptionOf(concurrentModification)
+        coEvery { sessionManager.fetchByIdOrNull(sessionId) } returns stillOngoing
+        coEvery { sessionManager.markAsFailedIfNotRecoverable(session, error) } returns failed
+
+        val result = util.handleException(session, error)
+
+        assertSame(failed, result)
+    }
+
+    @Test
+    fun `handleException - Fails the session for a genuine non-recoverable error without re-fetching`() = runTest {
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val failed = mockk<FailedInteractiveFlowSession>()
+        val error = businessExceptionOf("flow.some.fatal")
+        coEvery { sessionManager.markAsFailedIfNotRecoverable(session, error) } returns failed
+
+        val result = util.handleException(session, error)
+
+        assertSame(failed, result)
+        coVerify(exactly = 0) { sessionManager.fetchByIdOrNull(any()) }
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
@@ -381,6 +381,7 @@ class InteractiveFlowSessionManagerTest {
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
             result.completedPurposes
         )
+        assertEquals(URI.create("https://client.example.com/callback"), result.successRedirectUri)
         assertEquals(InteractiveFlowRedirectType.AUTHORIZATION_CODE, result.redirectType)
     }
 
@@ -410,6 +411,7 @@ class InteractiveFlowSessionManagerTest {
         assertEquals(session.id, result.id)
         assertEquals(userId, result.userId)
         assertEquals(InteractiveFlowRedirectType.AUTHORIZATION_CODE, result.redirectType)
+        assertEquals(URI.create("https://client.example.com/callback"), result.cancelRedirectUri)
     }
 
     @Test
@@ -459,15 +461,17 @@ class InteractiveFlowSessionManagerTest {
         val result = interactiveFlowSessionManager.markAsFailedIfNotRecoverable(session, recoverable)
 
         assertSame(session, result)
-        coVerify(exactly = 0) { sessionRepository.bumpVersion(any(), any()) }
+        coVerify(exactly = 0) { sessionRepository.failIfOngoing(any()) }
         coVerify(exactly = 0) { sessionRepository.updateError(any(), any(), any(), any(), any()) }
     }
 
     @Test
-    fun `markAsFailedIfNotRecoverable - Persists and returns a failed session for a non-recoverable error`() = runTest {
+    fun `markAsFailedIfNotRecoverable - Fails an ongoing session even when it advanced its own version first`() = runTest {
+        // The failing request has usually already bumped the version before hitting the error, so the guard
+        // is on "still ongoing" (failIfOngoing), not the remembered version: an ongoing session is failed.
         val session = ongoingSession()
         val error = businessExceptionOf("some.detail")
-        coEvery { sessionRepository.bumpVersion(session.id, STARTING_VERSION) } returns 1
+        coEvery { sessionRepository.failIfOngoing(session.id) } returns 1
         coEvery { sessionRepository.updateError(session.id, any(), "some.detail", null, any()) } just Runs
 
         val result = interactiveFlowSessionManager.markAsFailedIfNotRecoverable(session, error)
@@ -478,13 +482,12 @@ class InteractiveFlowSessionManagerTest {
     }
 
     @Test
-    fun `markAsFailedIfNotRecoverable - Swallows a lost swap without writing and still returns a failed session`() = runTest {
+    fun `markAsFailedIfNotRecoverable - Skips the write when the session is already terminal and still returns failed`() = runTest {
         val session = ongoingSession()
         val error = businessExceptionOf("some.detail")
-        // A concurrent winner already advanced the row: the compare-and-swap affects 0 rows, so the
-        // error write must be skipped (no throw, no clobber) while this request is still routed to the
-        // error page.
-        coEvery { sessionRepository.bumpVersion(session.id, STARTING_VERSION) } returns 0
+        // A concurrent request already drove the session to a terminal state: the guard affects 0 rows, so
+        // the error write must be skipped (no clobber) while this request is still routed to the error page.
+        coEvery { sessionRepository.failIfOngoing(session.id) } returns 0
 
         val result = interactiveFlowSessionManager.markAsFailedIfNotRecoverable(session, error)
 

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
@@ -1,8 +1,12 @@
 package com.sympauthy.business.manager.flow
 
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.exception.businessExceptionOf
+import com.sympauthy.business.exception.recoverableBusinessExceptionOf
 import com.sympauthy.business.manager.jwt.JwtManager
 import com.sympauthy.business.manager.user.UserManager
 import com.sympauthy.business.mapper.InteractiveFlowSessionMapper
+import com.sympauthy.business.model.flow.FailedInteractiveFlowSession
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowRedirectType
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
@@ -17,7 +21,9 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.SpyK
 import io.mockk.junit5.MockKExtension
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.Runs
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -48,6 +54,37 @@ class InteractiveFlowSessionManagerTest {
     @SpyK
     @InjectMockKs
     lateinit var interactiveFlowSessionManager: InteractiveFlowSessionManager
+
+    /**
+     * Detail id of the exception thrown when a version-guarded update loses its compare-and-swap.
+     */
+    private val concurrentModificationDetailsId = "auth.interactive_flow_session.concurrent_modification"
+
+    /**
+     * Build an ongoing session at [version] carrying enough state to drive every mutation under test.
+     */
+    private fun ongoingSession(
+        id: UUID = UUID.randomUUID(),
+        version: Long = STARTING_VERSION,
+        purposes: List<InteractiveFlowPurpose> = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+        initiatingPurpose: InteractiveFlowPurpose = purposes.first(),
+        completedPurposes: List<InteractiveFlowPurpose> = emptyList(),
+        userId: UUID? = UUID.randomUUID(),
+        redirectType: InteractiveFlowRedirectType? = InteractiveFlowRedirectType.AUTHORIZATION_CODE,
+    ) = OnGoingInteractiveFlowSession(
+        id = id,
+        purposes = purposes,
+        initiatingPurpose = initiatingPurpose,
+        flowId = "flow-id",
+        expirationDate = LocalDateTime.now().plusHours(1),
+        sessionDate = LocalDateTime.now(),
+        version = version,
+        userId = userId,
+        completedPurposes = completedPurposes,
+        successRedirectUri = URI.create("https://client.example.com/callback"),
+        redirectType = redirectType,
+        cancelRedirectUri = URI.create("https://client.example.com/callback"),
+    )
 
     @Test
     fun `verifyEncodedInternalState - Return failure when state is null`() = runTest {
@@ -133,35 +170,100 @@ class InteractiveFlowSessionManagerTest {
         assertSame(session, result.session)
     }
 
+    // region setAuthenticatedUserId
+
     @Test
-    fun `insertPurposeAfter - Inserts the purpose right after the given one and persists the list`() = runTest {
-        val sessionId = UUID.randomUUID()
-        val session = OnGoingInteractiveFlowSession(
-            id = sessionId,
+    fun `setAuthenticatedUserId - Persists the user and bumps the version`() = runTest {
+        val session = ongoingSession(userId = null)
+        val userId = UUID.randomUUID()
+        coEvery {
+            sessionRepository.updateUserId(session.id, userId, true, STARTING_VERSION)
+        } returns 1
+
+        val result = interactiveFlowSessionManager.setAuthenticatedUserId(session, userId, signedUp = true)
+
+        assertEquals(userId, result.userId)
+        assertTrue(result.signedUp)
+        assertEquals(STARTING_VERSION + 1, result.version)
+    }
+
+    @Test
+    fun `setAuthenticatedUserId - Fails with a concurrent modification when the version is stale`() = runTest {
+        val session = ongoingSession(userId = null)
+        val userId = UUID.randomUUID()
+        coEvery {
+            sessionRepository.updateUserId(session.id, userId, false, STARTING_VERSION)
+        } returns 0
+
+        val exception = assertThrows<BusinessException> {
+            interactiveFlowSessionManager.setAuthenticatedUserId(session, userId)
+        }
+        assertEquals(concurrentModificationDetailsId, exception.detailsId)
+        assertFalse(exception.recoverable)
+    }
+
+    // endregion
+
+    // region setMfaPassed
+
+    @Test
+    fun `setMfaPassed - Persists the date and bumps the version`() = runTest {
+        val session = ongoingSession()
+        coEvery {
+            sessionRepository.updateMfaPassedDate(session.id, any(), STARTING_VERSION)
+        } returns 1
+
+        val result = interactiveFlowSessionManager.setMfaPassed(session)
+
+        assertTrue(result.mfaPassed)
+        assertEquals(STARTING_VERSION + 1, result.version)
+    }
+
+    @Test
+    fun `setMfaPassed - Fails with a concurrent modification when the version is stale`() = runTest {
+        val session = ongoingSession()
+        coEvery {
+            sessionRepository.updateMfaPassedDate(session.id, any(), STARTING_VERSION)
+        } returns 0
+
+        val exception = assertThrows<BusinessException> {
+            interactiveFlowSessionManager.setMfaPassed(session)
+        }
+        assertEquals(concurrentModificationDetailsId, exception.detailsId)
+    }
+
+    // endregion
+
+    // region insertPurposeAfter
+
+    @Test
+    fun `insertPurposeAfter - Inserts right after the given purpose, persists the list and bumps the version`() = runTest {
+        val session = ongoingSession(
             purposes = listOf(
                 InteractiveFlowPurpose.CONFIRM,
                 InteractiveFlowPurpose.REAUTHENTICATION,
                 InteractiveFlowPurpose.MFA_ENROLLMENT,
             ),
             initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
-            flowId = "flow-id",
-            expirationDate = LocalDateTime.now().plusHours(1),
-            sessionDate = LocalDateTime.now(),
-            userId = UUID.randomUUID(),
         )
         // Stub with the exact expected persisted names so reaching the assertion proves the right ordering was
         // saved: the inserted MFA_CHALLENGE lands right after REAUTHENTICATION, ahead of the trailing purpose.
         coEvery {
             sessionRepository.updatePurposes(
-                sessionId,
-                listOf(
-                    InteractiveFlowPurpose.CONFIRM.name,
-                    InteractiveFlowPurpose.REAUTHENTICATION.name,
-                    InteractiveFlowPurpose.MFA_CHALLENGE.name,
-                    InteractiveFlowPurpose.MFA_ENROLLMENT.name,
-                )
+                session.id,
+                match {
+                    it.contentEquals(
+                        arrayOf(
+                            InteractiveFlowPurpose.CONFIRM.name,
+                            InteractiveFlowPurpose.REAUTHENTICATION.name,
+                            InteractiveFlowPurpose.MFA_CHALLENGE.name,
+                            InteractiveFlowPurpose.MFA_ENROLLMENT.name,
+                        )
+                    )
+                },
+                STARTING_VERSION
             )
-        } returns Unit
+        } returns 1
 
         val result = interactiveFlowSessionManager.insertPurposeAfter(
             session,
@@ -178,77 +280,99 @@ class InteractiveFlowSessionManagerTest {
             ),
             result.purposes
         )
+        assertEquals(STARTING_VERSION + 1, result.version)
     }
 
     @Test
-    fun `markPurposeAsCompleted - Records the purpose and stays ongoing without completing the session`() = runTest {
-        val sessionId = UUID.randomUUID()
-        val session = OnGoingInteractiveFlowSession(
-            id = sessionId,
+    fun `insertPurposeAfter - Fails with a concurrent modification when the version is stale`() = runTest {
+        val session = ongoingSession(purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
+        coEvery {
+            sessionRepository.updatePurposes(session.id, any(), STARTING_VERSION)
+        } returns 0
+
+        val exception = assertThrows<BusinessException> {
+            interactiveFlowSessionManager.insertPurposeAfter(
+                session,
+                purpose = InteractiveFlowPurpose.MFA_CHALLENGE,
+                afterPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
+            )
+        }
+        assertEquals(concurrentModificationDetailsId, exception.detailsId)
+    }
+
+    // endregion
+
+    // region markPurposeAsCompleted
+
+    @Test
+    fun `markPurposeAsCompleted - Records the purpose, bumps the version and stays ongoing`() = runTest {
+        val session = ongoingSession(
             purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
-            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
-            flowId = "flow-id",
-            expirationDate = LocalDateTime.now().plusHours(1),
-            sessionDate = LocalDateTime.now(),
-            userId = UUID.randomUUID(),
         )
         // Stub with the exact expected persisted names so reaching the assertion proves the right list was saved.
         coEvery {
-            sessionRepository.updateCompletedPurposes(sessionId, listOf(InteractiveFlowPurpose.CONFIRM.name))
-        } returns Unit
+            sessionRepository.updateCompletedPurposes(
+                session.id,
+                match { it.contentEquals(arrayOf(InteractiveFlowPurpose.CONFIRM.name)) },
+                STARTING_VERSION
+            )
+        } returns 1
 
-        val result = interactiveFlowSessionManager.markPurposeAsCompleted(
-            session, InteractiveFlowPurpose.CONFIRM
-        )
+        val result = interactiveFlowSessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.CONFIRM)
 
         assertEquals(listOf(InteractiveFlowPurpose.CONFIRM), result.completedPurposes)
+        assertEquals(STARTING_VERSION + 1, result.version)
         // Bookkeeping only: the session must not be completed even though a purpose was recorded.
-        coVerify(exactly = 0) { sessionRepository.updateCompleteDate(any(), any()) }
+        coVerify(exactly = 0) { sessionRepository.updateCompleteDate(any(), any(), any()) }
     }
 
     @Test
     fun `markPurposeAsCompleted - Recording an already-completed purpose is a no-op on the list`() = runTest {
-        val sessionId = UUID.randomUUID()
-        val session = OnGoingInteractiveFlowSession(
-            id = sessionId,
+        val session = ongoingSession(
             purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
-            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
             completedPurposes = listOf(InteractiveFlowPurpose.CONFIRM),
-            flowId = "flow-id",
-            expirationDate = LocalDateTime.now().plusHours(1),
-            sessionDate = LocalDateTime.now(),
-            userId = UUID.randomUUID(),
         )
         coEvery {
-            sessionRepository.updateCompletedPurposes(sessionId, listOf(InteractiveFlowPurpose.CONFIRM.name))
-        } returns Unit
+            sessionRepository.updateCompletedPurposes(
+                session.id,
+                match { it.contentEquals(arrayOf(InteractiveFlowPurpose.CONFIRM.name)) },
+                STARTING_VERSION
+            )
+        } returns 1
 
-        val result = interactiveFlowSessionManager.markPurposeAsCompleted(
-            session, InteractiveFlowPurpose.CONFIRM
-        )
+        val result = interactiveFlowSessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.CONFIRM)
 
         assertEquals(listOf(InteractiveFlowPurpose.CONFIRM), result.completedPurposes)
     }
 
     @Test
-    fun `markAsCompleted - Persists the complete date and returns a completed session`() = runTest {
-        val sessionId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val redirectUri = URI.create("https://client.example.com/callback")
-        val session = OnGoingInteractiveFlowSession(
-            id = sessionId,
-            purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
-            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
-            completedPurposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
-            flowId = "flow-id",
-            expirationDate = LocalDateTime.now().plusHours(1),
-            sessionDate = LocalDateTime.now(),
-            userId = userId,
-            successRedirectUri = redirectUri,
-            redirectType = InteractiveFlowRedirectType.AUTHORIZATION_CODE,
-            cancelRedirectUri = redirectUri,
+    fun `markPurposeAsCompleted - Fails with a concurrent modification when the version is stale`() = runTest {
+        val session = ongoingSession(
+            purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
         )
-        coEvery { sessionRepository.updateCompleteDate(sessionId, any()) } returns Unit
+        coEvery {
+            sessionRepository.updateCompletedPurposes(session.id, any(), STARTING_VERSION)
+        } returns 0
+
+        val exception = assertThrows<BusinessException> {
+            interactiveFlowSessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.CONFIRM)
+        }
+        assertEquals(concurrentModificationDetailsId, exception.detailsId)
+    }
+
+    // endregion
+
+    // region markAsCompleted
+
+    @Test
+    fun `markAsCompleted - Persists the complete date and returns a completed session`() = runTest {
+        val userId = UUID.randomUUID()
+        val session = ongoingSession(
+            purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
+            completedPurposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
+            userId = userId,
+        )
+        coEvery { sessionRepository.updateCompleteDate(session.id, any(), STARTING_VERSION) } returns 1
 
         val result = interactiveFlowSessionManager.markAsCompleted(session)
 
@@ -257,35 +381,46 @@ class InteractiveFlowSessionManagerTest {
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
             result.completedPurposes
         )
-        assertEquals(redirectUri, result.successRedirectUri)
         assertEquals(InteractiveFlowRedirectType.AUTHORIZATION_CODE, result.redirectType)
     }
 
     @Test
+    fun `markAsCompleted - Fails with a concurrent modification when the version is stale`() = runTest {
+        val session = ongoingSession(userId = UUID.randomUUID())
+        coEvery { sessionRepository.updateCompleteDate(session.id, any(), STARTING_VERSION) } returns 0
+
+        val exception = assertThrows<BusinessException> {
+            interactiveFlowSessionManager.markAsCompleted(session)
+        }
+        assertEquals(concurrentModificationDetailsId, exception.detailsId)
+    }
+
+    // endregion
+
+    // region markAsCancelled
+
+    @Test
     fun `markAsCancelled - Persists the cancel date and returns a cancelled session`() = runTest {
-        val sessionId = UUID.randomUUID()
         val userId = UUID.randomUUID()
-        val redirectUri = URI.create("https://client.example.com/callback")
-        val session = OnGoingInteractiveFlowSession(
-            id = sessionId,
-            purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
-            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
-            flowId = "flow-id",
-            expirationDate = LocalDateTime.now().plusHours(1),
-            sessionDate = LocalDateTime.now(),
-            userId = userId,
-            successRedirectUri = redirectUri,
-            redirectType = InteractiveFlowRedirectType.AUTHORIZATION_CODE,
-            cancelRedirectUri = redirectUri,
-        )
-        coEvery { sessionRepository.updateCancelDate(sessionId, any()) } returns Unit
+        val session = ongoingSession(userId = userId)
+        coEvery { sessionRepository.updateCancelDate(session.id, any(), STARTING_VERSION) } returns 1
 
         val result = interactiveFlowSessionManager.markAsCancelled(session)
 
-        assertEquals(sessionId, result.id)
+        assertEquals(session.id, result.id)
         assertEquals(userId, result.userId)
         assertEquals(InteractiveFlowRedirectType.AUTHORIZATION_CODE, result.redirectType)
-        assertEquals(redirectUri, result.cancelRedirectUri)
+    }
+
+    @Test
+    fun `markAsCancelled - Fails with a concurrent modification when the version is stale`() = runTest {
+        val session = ongoingSession(userId = UUID.randomUUID())
+        coEvery { sessionRepository.updateCancelDate(session.id, any(), STARTING_VERSION) } returns 0
+
+        val exception = assertThrows<BusinessException> {
+            interactiveFlowSessionManager.markAsCancelled(session)
+        }
+        assertEquals(concurrentModificationDetailsId, exception.detailsId)
     }
 
     @Test
@@ -297,17 +432,74 @@ class InteractiveFlowSessionManagerTest {
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
+            version = STARTING_VERSION,
             userId = UUID.randomUUID(),
             successRedirectUri = URI.create("https://client.example.com/enrolled"),
             redirectType = InteractiveFlowRedirectType.PLAIN,
             cancelRedirectUri = null,
         )
 
-        val exception = assertThrows<com.sympauthy.business.exception.BusinessException> {
+        val exception = assertThrows<BusinessException> {
             interactiveFlowSessionManager.markAsCancelled(session)
         }
         assertEquals("auth.interactive_flow_session.cancel.no_cancel_target", exception.detailsId)
         assertTrue(exception.recoverable)
-        coVerify(exactly = 0) { sessionRepository.updateCancelDate(any(), any()) }
+        coVerify(exactly = 0) { sessionRepository.updateCancelDate(any(), any(), any()) }
+    }
+
+    // endregion
+
+    // region markAsFailedIfNotRecoverable
+
+    @Test
+    fun `markAsFailedIfNotRecoverable - Leaves a recoverable error ongoing without persisting`() = runTest {
+        val session = ongoingSession()
+        val recoverable = recoverableBusinessExceptionOf("some.detail", "some.description")
+
+        val result = interactiveFlowSessionManager.markAsFailedIfNotRecoverable(session, recoverable)
+
+        assertSame(session, result)
+        coVerify(exactly = 0) { sessionRepository.bumpVersion(any(), any()) }
+        coVerify(exactly = 0) { sessionRepository.updateError(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `markAsFailedIfNotRecoverable - Persists and returns a failed session for a non-recoverable error`() = runTest {
+        val session = ongoingSession()
+        val error = businessExceptionOf("some.detail")
+        coEvery { sessionRepository.bumpVersion(session.id, STARTING_VERSION) } returns 1
+        coEvery { sessionRepository.updateError(session.id, any(), "some.detail", null, any()) } just Runs
+
+        val result = interactiveFlowSessionManager.markAsFailedIfNotRecoverable(session, error)
+
+        assertTrue(result is FailedInteractiveFlowSession)
+        result as FailedInteractiveFlowSession
+        assertEquals("some.detail", result.errorDetailsId)
+    }
+
+    @Test
+    fun `markAsFailedIfNotRecoverable - Swallows a lost swap without writing and still returns a failed session`() = runTest {
+        val session = ongoingSession()
+        val error = businessExceptionOf("some.detail")
+        // A concurrent winner already advanced the row: the compare-and-swap affects 0 rows, so the
+        // error write must be skipped (no throw, no clobber) while this request is still routed to the
+        // error page.
+        coEvery { sessionRepository.bumpVersion(session.id, STARTING_VERSION) } returns 0
+
+        val result = interactiveFlowSessionManager.markAsFailedIfNotRecoverable(session, error)
+
+        assertTrue(result is FailedInteractiveFlowSession)
+        result as FailedInteractiveFlowSession
+        assertEquals("some.detail", result.errorDetailsId)
+        coVerify(exactly = 0) { sessionRepository.updateError(any(), any(), any(), any(), any()) }
+    }
+
+    // endregion
+
+    companion object {
+        /**
+         * Non-zero starting version so a `+ 1` bump on success is a meaningful assertion.
+         */
+        private const val STARTING_VERSION = 3L
     }
 }

--- a/server/src/test/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapperTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapperTest.kt
@@ -120,6 +120,7 @@ class InteractiveFlowSessionMapperTest {
             id = id,
             userId = userId,
             mfaPassedDate = mfaPassedDate,
+            version = 7,
         )
 
         val session = mapper.toInteractiveFlowSession(entity)
@@ -130,6 +131,7 @@ class InteractiveFlowSessionMapperTest {
         assertEquals(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE), session.purposes)
         assertEquals(userId, session.userId)
         assertEquals(mfaPassedDate, session.mfaPassedDate)
+        assertEquals(7L, session.version)
     }
 
     @Test
@@ -176,6 +178,7 @@ class InteractiveFlowSessionMapperTest {
         flowId: String? = "flow",
         sessionDate: LocalDateTime = LocalDateTime.now().minusMinutes(2),
         expirationDate: LocalDateTime = LocalDateTime.now().plusMinutes(10),
+        version: Long = 0,
         userId: UUID? = null,
         mfaPassedDate: LocalDateTime? = null,
         successRedirectUri: String? = null,
@@ -189,6 +192,7 @@ class InteractiveFlowSessionMapperTest {
         errorValues: Map<String, String>? = null,
     ): InteractiveFlowSessionEntity {
         return InteractiveFlowSessionEntity(
+            version = version,
             purposes = arrayOf(purpose.name),
             initiatingPurpose = purpose.name,
             sessionDate = sessionDate,

--- a/server/src/test/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionTest.kt
@@ -9,7 +9,8 @@ class InteractiveFlowSessionTest {
 
     private fun ongoing(
         purposes: List<InteractiveFlowPurpose>,
-        initiatingPurpose: InteractiveFlowPurpose,
+        initiatingPurpose: InteractiveFlowPurpose = purposes.first(),
+        version: Long = 0,
     ) = OnGoingInteractiveFlowSession(
         id = UUID.randomUUID(),
         purposes = purposes,
@@ -17,6 +18,7 @@ class InteractiveFlowSessionTest {
         flowId = null,
         expirationDate = LocalDateTime.now().plusMinutes(5),
         sessionDate = LocalDateTime.now(),
+        version = version,
         userId = null,
     )
 
@@ -30,5 +32,23 @@ class InteractiveFlowSessionTest {
         val copied = session.copy(userId = UUID.randomUUID())
 
         assertEquals(InteractiveFlowPurpose.MFA_ENROLLMENT, copied.initiatingPurpose)
+    }
+
+    @Test
+    fun `copy - Preserves the current version when not overridden`() {
+        val session = ongoing(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE), version = 4)
+
+        val copy = session.copy(userId = UUID.randomUUID())
+
+        assertEquals(4L, copy.version)
+    }
+
+    @Test
+    fun `copy - Overrides the version when provided`() {
+        val session = ongoing(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE), version = 4)
+
+        val copy = session.copy(version = 5)
+
+        assertEquals(5L, copy.version)
     }
 }

--- a/server/src/test/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepositoryTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepositoryTest.kt
@@ -1,0 +1,199 @@
+package com.sympauthy.data.repository
+
+import com.sympauthy.data.model.InteractiveFlowSessionEntity
+import com.sympauthy.data.model.UserEntity
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * H2-backed test of the versioned optimistic-concurrency updates on [InteractiveFlowSessionRepository].
+ *
+ * Beyond the compare-and-swap semantics (affected-row count `1` vs `0`, version increment), this
+ * exercises the two bindings that have no other precedent in the codebase: the `text array` columns
+ * (`purposes`, `completed_purposes`) and the `json` column (`error_values`) bound as parameters inside
+ * a raw `@Query`.
+ */
+@MicronautTest(
+    environments = ["default", "test"],
+    startApplication = false,
+    transactional = false
+)
+class InteractiveFlowSessionRepositoryTest {
+
+    @Inject
+    lateinit var sessionRepository: InteractiveFlowSessionRepository
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    private lateinit var userId: UUID
+    private val createdSessionIds = mutableListOf<UUID>()
+
+    // This @MicronautTest shares its H2 database with the other @MicronautTest classes, so we must not
+    // deleteAll() — other tests' rows reference these tables via foreign keys. Every assertion below is
+    // scoped to a session this test created, and tearDown removes only those rows (children-free
+    // sessions first, then the user they may reference).
+    @BeforeEach
+    fun setUp() = runTest {
+        userId = UserEntity(status = "enabled", creationDate = LocalDateTime.now())
+            .also { userRepository.save(it) }
+            .id!!
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        if (createdSessionIds.isNotEmpty()) {
+            sessionRepository.deleteByIds(createdSessionIds)
+            createdSessionIds.clear()
+        }
+        userRepository.deleteById(userId)
+    }
+
+    private suspend fun newSession(
+        purposes: Array<String> = arrayOf("OAUTH2_AUTHORIZE"),
+    ): InteractiveFlowSessionEntity {
+        val now = LocalDateTime.now()
+        return InteractiveFlowSessionEntity(
+            purposes = purposes,
+            sessionDate = now,
+            flowId = "flow",
+            expirationDate = now.plusMinutes(10),
+        ).also {
+            sessionRepository.save(it)
+            createdSessionIds.add(it.id!!)
+        }
+    }
+
+    @Test
+    fun `updatePurposes - binds the array, applies at the expected version and increments it`() = runTest {
+        val session = newSession()
+
+        val updated = sessionRepository.updatePurposes(
+            id = session.id!!,
+            purposes = arrayOf("OAUTH2_AUTHORIZE", "MFA_CHALLENGE"),
+            expectedVersion = 0
+        )
+
+        assertEquals(1, updated)
+        val reloaded = sessionRepository.findById(session.id!!)!!
+        assertTrue(arrayOf("OAUTH2_AUTHORIZE", "MFA_CHALLENGE").contentEquals(reloaded.purposes))
+        assertEquals(1L, reloaded.version)
+    }
+
+    @Test
+    fun `updatePurposes - a stale expected version affects no rows and leaves the row untouched`() = runTest {
+        val session = newSession()
+        // Advance the row to version 1 so the original snapshot (version 0) is now stale.
+        sessionRepository.updatePurposes(session.id!!, arrayOf("MFA_CHALLENGE"), expectedVersion = 0)
+
+        val updated = sessionRepository.updatePurposes(
+            id = session.id!!,
+            purposes = arrayOf("OAUTH2_AUTHORIZE"),
+            expectedVersion = 0
+        )
+
+        assertEquals(0, updated)
+        val reloaded = sessionRepository.findById(session.id!!)!!
+        assertTrue(arrayOf("MFA_CHALLENGE").contentEquals(reloaded.purposes))
+        assertEquals(1L, reloaded.version)
+    }
+
+    @Test
+    fun `updateCompletedPurposes - binds the array and increments the version`() = runTest {
+        val session = newSession()
+
+        val updated = sessionRepository.updateCompletedPurposes(
+            id = session.id!!,
+            completedPurposes = arrayOf("OAUTH2_AUTHORIZE"),
+            expectedVersion = 0
+        )
+
+        assertEquals(1, updated)
+        val reloaded = sessionRepository.findById(session.id!!)!!
+        assertTrue(arrayOf("OAUTH2_AUTHORIZE").contentEquals(reloaded.completedPurposes))
+        assertEquals(1L, reloaded.version)
+    }
+
+    @Test
+    fun `updateError - the derived write binds and round-trips the json values`() = runTest {
+        val session = newSession()
+
+        sessionRepository.updateError(
+            id = session.id!!,
+            errorDate = LocalDateTime.now(),
+            errorDetailsId = "some.error",
+            errorDescriptionId = "some.description",
+            errorValues = mapOf("key" to "value"),
+        )
+
+        val reloaded = sessionRepository.findById(session.id!!)!!
+        assertEquals("some.error", reloaded.errorDetailsId)
+        assertEquals(mapOf("key" to "value"), reloaded.errorValues)
+    }
+
+    @Test
+    fun `bumpVersion - increments at the expected version and rejects a stale one`() = runTest {
+        val session = newSession()
+        val id = session.id!!
+
+        assertEquals(1, sessionRepository.bumpVersion(id, expectedVersion = 0))
+        assertEquals(1L, sessionRepository.findById(id)!!.version)
+
+        // The original snapshot (version 0) is now stale.
+        assertEquals(0, sessionRepository.bumpVersion(id, expectedVersion = 0))
+        assertEquals(1L, sessionRepository.findById(id)!!.version)
+    }
+
+    @Test
+    fun `updateUserId - applies against the user foreign key and increments the version`() = runTest {
+        val session = newSession()
+
+        val updated = sessionRepository.updateUserId(
+            id = session.id!!,
+            userId = userId,
+            signedUp = true,
+            expectedVersion = 0
+        )
+
+        assertEquals(1, updated)
+        val reloaded = sessionRepository.findById(session.id!!)!!
+        assertEquals(userId, reloaded.userId)
+        assertTrue(reloaded.signedUp)
+        assertEquals(1L, reloaded.version)
+    }
+
+    @Test
+    fun `scalar updates - each applies at the expected version and increments it`() = runTest {
+        val session = newSession()
+        val id = session.id!!
+
+        assertEquals(1, sessionRepository.updateMfaPassedDate(id, LocalDateTime.now(), expectedVersion = 0))
+        assertEquals(1, sessionRepository.updateCompleteDate(id, LocalDateTime.now(), expectedVersion = 1))
+        assertEquals(1, sessionRepository.updateCancelDate(id, LocalDateTime.now(), expectedVersion = 2))
+
+        val reloaded = sessionRepository.findById(id)!!
+        assertEquals(3L, reloaded.version)
+    }
+
+    @Test
+    fun `a stale expected version never mutates the row`() = runTest {
+        val session = newSession()
+        val id = session.id!!
+
+        val updated = sessionRepository.updateMfaPassedDate(id, LocalDateTime.now(), expectedVersion = 99)
+
+        assertEquals(0, updated)
+        val reloaded = sessionRepository.findById(id)!!
+        assertNull(reloaded.mfaPassedDate)
+        assertEquals(0L, reloaded.version)
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepositoryTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionRepositoryTest.kt
@@ -64,6 +64,7 @@ class InteractiveFlowSessionRepositoryTest {
         val now = LocalDateTime.now()
         return InteractiveFlowSessionEntity(
             purposes = purposes,
+            initiatingPurpose = purposes.first(),
             sessionDate = now,
             flowId = "flow",
             expirationDate = now.plusMinutes(10),
@@ -141,16 +142,17 @@ class InteractiveFlowSessionRepositoryTest {
     }
 
     @Test
-    fun `bumpVersion - increments at the expected version and rejects a stale one`() = runTest {
+    fun `failIfOngoing - bumps the version while ongoing and refuses once terminal`() = runTest {
         val session = newSession()
         val id = session.id!!
 
-        assertEquals(1, sessionRepository.bumpVersion(id, expectedVersion = 0))
+        // Ongoing: the guard bumps the version regardless of its current value.
+        assertEquals(1, sessionRepository.failIfOngoing(id))
         assertEquals(1L, sessionRepository.findById(id)!!.version)
 
-        // The original snapshot (version 0) is now stale.
-        assertEquals(0, sessionRepository.bumpVersion(id, expectedVersion = 0))
-        assertEquals(1L, sessionRepository.findById(id)!!.version)
+        // Drive it to a terminal (completed) state; the guard must then refuse.
+        sessionRepository.updateCompleteDate(id, LocalDateTime.now(), expectedVersion = 1)
+        assertEquals(0, sessionRepository.failIfOngoing(id))
     }
 
     @Test


### PR DESCRIPTION
Closes #193.

## Context

#193 asked for anti-replay / optimistic-concurrency protection on the sequential authorize-flow
updates. It was written against the removed `AuthorizeAttempt`/`AuthorizeAttemptManager` (its line-34
FIXME no longer exists) — re-scoped here onto the current `InteractiveFlowSession` engine, where the
same gap remained: every session mutation was a partial `updateXxx(@Id id, field)` followed by an
in-memory `copy(...)`, so a replayed or double-submitted step could silently overwrite newer state.

Design was posted to the issue before implementing.

## Decisions

- **Scope: parent session only** — guard the 7 lifecycle mutations on `interactive_flow_sessions`.
  Attached-record writes (oauth2 consent/grant, provider, reauth, confirm) are mostly write-once and
  stay unguarded → follow-up.
- **Conflict handling: fail the session → error page** (not recoverable-retry).

## How it works

A monotonic `version` column on `interactive_flow_sessions`, carried on `OnGoingInteractiveFlowSession`.
Each lifecycle mutation is a single compare-and-swap statement:

```sql
UPDATE interactive_flow_sessions
SET <changed columns>, version = version + 1
WHERE id = :id AND version = :expectedVersion
```

The affected-row count is the signal: `1` = applied (return `copy(version + 1)`); `0` = the caller's
snapshot is stale, so the manager throws a non-recoverable
`auth.interactive_flow_session.concurrent_modification`, which the existing
`InteractiveAuthFlowSessionControllerUtil.handleException` routes to the flow's error page.
`markAsFailedIfNotRecoverable` **swallows** a 0-row swap (best-effort terminal write) so a replay can
neither clobber a legitimate concurrent winner nor produce a 500.

`@Version` is deliberately not used — it only guards full-entity `update`/`delete`, not these
query-based partial updates.

### One exception to the single-statement form

The terminal error write can't be a single versioned statement: its `error_values` `json` column only
round-trips through Micronaut's property-mapped serialization, not a raw-`@Query` parameter (an H2 test
caught this). It is instead a scalar `bumpVersion` compare-and-swap paired with the derived `updateError`
inside one `@Transactional`. The `text[]` columns (`purposes`, `completed_purposes`) bind fine in a raw
`@Query` via `@TypeDef(STRING_ARRAY)`.

## Testing

- `:server:test` — full suite green, including the real-flow `AbstractFlowIntegrationTest`.
- New H2-backed `InteractiveFlowSessionRepositoryTest` verifies the array + JSON binding and the CAS
  semantics (row-count `1`/`0`, version increment) — the parts mocked unit tests can't cover.
- Extended manager (success + conflict + swallow per mutation), mapper, and model unit tests.
- Full `:integration-tests:integrationTest` green on **both PostgreSQL and H2**.

No wire-format change (`version` is internal DB state) → no `testcontainers-sympauthy` bump, no
native-metadata change.

## Follow-ups (out of scope)

- Optimistic guards on the attached-record writes (oauth2/provider/reauth/confirm).
- Throttling / brute-force protection (#296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
