### PR TITLE
Client & admin API to link an identity provider to a user (LINK_PROVIDER, #294)

### DIFF
--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AdminUserProviderLinkFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AdminUserProviderLinkFeatureIT.kt
@@ -1,0 +1,230 @@
+package com.sympauthy.it.feature
+
+import com.sympauthy.api.client.api.AdminApi
+import com.sympauthy.api.client.model.AdminUserProviderLinkInputResource
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import com.sympauthy.it.DatabaseFixture
+import com.sympauthy.it.SympauthyImage
+import com.sympauthy.testcontainers.SympauthyContainer
+import com.sympauthy.testcontainers.flow.InteractiveFlowRegistry
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.UUID
+
+/**
+ * Feature scenarios for **admin-initiated provider linking**
+ * (`POST /api/v1/admin/users/{userId}/providers/{providerId}/link`).
+ *
+ * These cover the endpoint's **start contract** — an administrator (the bootstrap first-admin, whose flow
+ * token carries `admin:users:write`) names a user, a client and a configured provider and receives a
+ * `redirect_url` to hand to the end-user — and the endpoint's **rejection paths** (missing user, missing
+ * client, unknown provider).
+ *
+ * As with the client twin, the full end-to-end round-trip (confirm → re-authentication → provider
+ * authorization → link) is **deferred**: the pinned `testcontainers-sympauthy` mock frontend has no sign-in
+ * handler and no mock third-party provider. Reference: issue
+ * [#294](https://github.com/sympauthy/sympauthy/issues/294).
+ */
+@Tag("feature")
+class AdminUserProviderLinkFeatureIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "admin-initiated provider link returns a redirect_url on {0}")
+    @EnumSource(Database::class)
+    fun startsLinkAndReturnsRedirectUrl(database: Database) {
+        withCustomContainer(
+            database,
+            build = { fixture, registry -> adminProviderLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            val admin = signUpFirstAdmin(sympauthy, registry)
+
+            val link = withApiClient(sympauthy, token = admin.token) { ctx ->
+                ctx.getBean(AdminApi::class.java).startLink(
+                    admin.userId,
+                    PROVIDER_ID,
+                    AdminUserProviderLinkInputResource(
+                        clientId = registry.clientId(),
+                        returnUri = registry.redirectUri(),
+                        cancelUri = null,
+                    ),
+                ).block()
+            } ?: fail("admin link init should return a redirect_url")
+
+            assertNotNull(link.redirectUrl, "admin link init should return a redirect_url")
+        }
+    }
+
+    @ParameterizedTest(name = "admin provider link for a missing user is rejected on {0}")
+    @EnumSource(Database::class)
+    fun rejectsMissingUser(database: Database) {
+        withCustomContainer(
+            database,
+            build = { fixture, registry -> adminProviderLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            val admin = signUpFirstAdmin(sympauthy, registry)
+
+            val rejection = linkRejection(
+                sympauthy,
+                admin.token,
+                userId = UUID.randomUUID(),
+                providerId = PROVIDER_ID,
+                input = AdminUserProviderLinkInputResource(
+                    clientId = registry.clientId(),
+                    returnUri = registry.redirectUri(),
+                    cancelUri = null,
+                ),
+            )
+            assertEquals(404, rejection.status, "linking an unknown user should be rejected as not found")
+        }
+    }
+
+    @ParameterizedTest(name = "admin provider link with a missing client is rejected on {0}")
+    @EnumSource(Database::class)
+    fun rejectsMissingClient(database: Database) {
+        withCustomContainer(
+            database,
+            build = { fixture, registry -> adminProviderLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            val admin = signUpFirstAdmin(sympauthy, registry)
+
+            val rejection = linkRejection(
+                sympauthy,
+                admin.token,
+                userId = admin.userId,
+                providerId = PROVIDER_ID,
+                input = AdminUserProviderLinkInputResource(
+                    clientId = "no-such-client",
+                    returnUri = registry.redirectUri(),
+                    cancelUri = null,
+                ),
+            )
+            assertEquals(404, rejection.status, "naming an unknown client should be rejected as not found")
+        }
+    }
+
+    @ParameterizedTest(name = "admin provider link with an unknown provider is rejected on {0}")
+    @EnumSource(Database::class)
+    fun rejectsUnknownProvider(database: Database) {
+        withCustomContainer(
+            database,
+            build = { fixture, registry -> adminProviderLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            val admin = signUpFirstAdmin(sympauthy, registry)
+
+            val rejection = linkRejection(
+                sympauthy,
+                admin.token,
+                userId = admin.userId,
+                providerId = "not-a-provider",
+                input = AdminUserProviderLinkInputResource(
+                    clientId = registry.clientId(),
+                    returnUri = registry.redirectUri(),
+                    cancelUri = null,
+                ),
+            )
+            assertEquals(400, rejection.status, "an unknown provider should be rejected as a bad request")
+            assertTrue(
+                rejection.body.contains("provider.missing"),
+                "should be rejected because the provider is unknown, was: ${rejection.body}",
+            )
+        }
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------------
+
+    /**
+     * Builds the admin-enabled container for [registry]: password auth, the first-admin bootstrap, an admin
+     * client whose flow token is granted `admin:users:write`, and a configured OAuth2 provider (dummy
+     * endpoints — the start endpoint only needs it to resolve as enabled, not to be reachable).
+     */
+    private fun adminProviderLinkContainer(
+        fixture: DatabaseFixture,
+        registry: InteractiveFlowRegistry,
+    ): SympauthyContainer {
+        registry.withScopes("openid")
+        return fixture.applyTo(
+            SympauthyContainer(SympauthyImage.resolve())
+                .withAdmin()
+                .withConfig(adminProviderLinkConfig())
+                .withFlows(registry)
+                .withAdminClient(registry, "openid", "admin:users:write"),
+        )
+    }
+
+    /** Password auth + a single OAuth2 provider; the admin client itself is layered on by `withAdminClient`. */
+    private fun adminProviderLinkConfig(): Map<String, Any> = mapOf(
+        "auth" to mapOf(
+            "by-password" to mapOf("enabled" to true),
+            "identifier-claims" to listOf("email"),
+        ),
+        "claims" to mapOf("email" to mapOf("enabled" to true)),
+        "providers" to mapOf(
+            PROVIDER_ID to mapOf(
+                "name" to "Test Provider",
+                "oauth2" to mapOf(
+                    "client-id" to "provider-client-id",
+                    "client-secret" to "provider-client-secret",
+                    "authorization-url" to "https://provider.example.com/oauth2/authorize",
+                    "token-url" to "https://provider.example.com/oauth2/token",
+                ),
+                "user-info" to mapOf(
+                    "url" to "https://provider.example.com/oauth2/userinfo",
+                    "paths" to mapOf("sub" to "\$.id", "email" to "\$.email"),
+                ),
+            ),
+        ),
+    )
+
+    /** Redeems the first-admin bootstrap invitation, signs up, and returns the admin's token + user id. */
+    private fun signUpFirstAdmin(sympauthy: SympauthyContainer, registry: InteractiveFlowRegistry): Admin {
+        val invitationToken = sympauthy.getBootstrapInvitationToken("first-admin")
+        val tokens = registry.newFlow()
+            .withInvitationToken(invitationToken)
+            .withSignUpHandler { mapOf("email" to "admin@example.com", "password" to PASSWORD) }
+            .run()
+            .exchange()
+        val token = tokens.accessToken() ?: fail("first-admin sign-up should yield an access token")
+        assertTrue(
+            tokens.scope()?.split(" ")?.contains("admin:users:write") == true,
+            "the first admin should be granted admin:users:write, was: ${tokens.scope()}",
+        )
+        val idToken = tokens.idToken() ?: fail("the openid scope should yield an id_token")
+        val userId = UUID.fromString(verifyIdTokenSignature(sympauthy, idToken).subject)
+        return Admin(token, userId)
+    }
+
+    private data class Admin(val token: String, val userId: UUID)
+
+    /**
+     * Calls `POST /api/v1/admin/users/{userId}/providers/{providerId}/link` expecting a rejection, capturing
+     * the HTTP status and error body **inside** the client's context (its response buffer is released once
+     * [withApiClient] closes the context).
+     */
+    private fun linkRejection(
+        sympauthy: SympauthyContainer,
+        adminToken: String,
+        userId: UUID,
+        providerId: String,
+        input: AdminUserProviderLinkInputResource,
+    ): RejectedLink = withApiClient(sympauthy, token = adminToken) { ctx ->
+        try {
+            ctx.getBean(AdminApi::class.java).startLink(userId, providerId, input).block()
+            fail("expected the admin link request to be rejected, but it succeeded")
+        } catch (error: HttpClientResponseException) {
+            RejectedLink(error.status.code, error.response.getBody(String::class.java).orElse(""))
+        }
+    }
+
+    private data class RejectedLink(val status: Int, val body: String)
+
+    private companion object {
+        const val PASSWORD = "Str0ngP@ssw0rd!"
+        const val PROVIDER_ID = "test-provider"
+    }
+}

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AdminUserProviderLinkFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AdminUserProviderLinkFeatureIT.kt
@@ -128,10 +128,10 @@ class AdminUserProviderLinkFeatureIT : AbstractSympauthyIT() {
                     cancelUri = null,
                 ),
             )
-            assertEquals(400, rejection.status, "an unknown provider should be rejected as a bad request")
-            assertTrue(
-                rejection.body.contains("provider.missing"),
-                "should be rejected because the provider is unknown, was: ${rejection.body}",
+            assertEquals(
+                404,
+                rejection.status,
+                "an unknown provider should be rejected as not found (coherent with unknown user/client), was: ${rejection.body}",
             )
         }
     }

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/ClientProviderLinkFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/ClientProviderLinkFeatureIT.kt
@@ -140,10 +140,10 @@ class ClientProviderLinkFeatureIT : AbstractSympauthyIT() {
                 ),
                 providerId = "not-a-provider",
             )
-            assertEquals(400, rejection.status, "an unknown provider should be rejected as a bad request")
-            assertTrue(
-                rejection.body.contains("provider.missing"),
-                "should be rejected because the provider is unknown, was: ${rejection.body}",
+            assertEquals(
+                404,
+                rejection.status,
+                "an unknown provider should be rejected as not found (coherent with unknown user/client), was: ${rejection.body}",
             )
         }
     }

--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/ClientProviderLinkFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/ClientProviderLinkFeatureIT.kt
@@ -1,0 +1,325 @@
+package com.sympauthy.it.feature
+
+import com.sympauthy.api.client.api.ClientApi
+import com.sympauthy.api.client.model.ClientProviderLinkInputResource
+import com.sympauthy.it.AbstractSympauthyIT
+import com.sympauthy.it.Database
+import com.sympauthy.it.DatabaseFixture
+import com.sympauthy.it.SympauthyImage
+import com.sympauthy.testcontainers.Client
+import com.sympauthy.testcontainers.SympauthyContainer
+import com.sympauthy.testcontainers.flow.InteractiveFlowRegistry
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Feature scenarios for **client-initiated provider linking** (`POST /api/v1/client/providers/{providerId}/link`).
+ *
+ * These cover the endpoint's **start contract** — a confidential client authenticates with a
+ * `client_credentials` token holding `users:providers:write`, names one of its signed-in end-users (via that
+ * user's access token) and a configured, enabled provider, and receives a signed `state` + a `redirect_url`
+ * to drive the end-user's browser to — and the endpoint's **rejection paths** (unregistered `return_uri`,
+ * caller missing the scope, unknown provider, an end-user token issued to a different client).
+ *
+ * The full end-to-end round-trip (confirm → re-authentication → provider authorization → link → `return_uri`)
+ * is **deferred**: the pinned `testcontainers-sympauthy` mock frontend has no sign-in handler and no mock
+ * third-party provider, so it cannot drive the re-authentication and provider-authorization steps. Driving
+ * the link to completion needs a `testcontainers-sympauthy` enhancement (a follow-up).
+ *
+ * Reference: issue [#294](https://github.com/sympauthy/sympauthy/issues/294).
+ */
+@Tag("feature")
+class ClientProviderLinkFeatureIT : AbstractSympauthyIT() {
+
+    @ParameterizedTest(name = "client-initiated provider link returns state and redirect_url on {0}")
+    @EnumSource(Database::class)
+    fun startsLinkAndReturnsRedirectUrl(database: Database) {
+        withCustomContainer(
+            database,
+            client = Client.confidentialClient(clientId, CLIENT_SECRET),
+            build = { fixture, registry -> providerLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            // The calling client authenticates with a client-credentials token holding users:providers:write.
+            val callerToken = clientCredentialsToken(sympauthy, registry, "users:providers:write")
+            // An end-user of that client, and the access token identifying them to the link endpoint.
+            val userToken = signUpAccessToken(registry, "ada@example.com")
+
+            val link = withApiClient(sympauthy, token = callerToken) { ctx ->
+                ctx.getBean(ClientApi::class.java).startLink1(
+                    PROVIDER_ID,
+                    ClientProviderLinkInputResource(
+                        accessToken = userToken,
+                        returnUri = providerLinkReturnUri(registry),
+                        cancelUri = providerLinkCancelUri(registry),
+                    ),
+                ).block()
+            } ?: fail("link init should return a state and redirect_url")
+
+            assertNotNull(link.state, "link init should return a signed state")
+            assertNotNull(link.redirectUrl, "link init should return a redirect_url to drive the end-user to")
+        }
+    }
+
+    @ParameterizedTest(name = "provider link with an unregistered return_uri is rejected on {0}")
+    @EnumSource(Database::class)
+    fun rejectsUnregisteredReturnUri(database: Database) {
+        withCustomContainer(
+            database,
+            client = Client.confidentialClient(clientId, CLIENT_SECRET),
+            build = { fixture, registry -> providerLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            val callerToken = clientCredentialsToken(sympauthy, registry, "users:providers:write")
+            val userToken = signUpAccessToken(registry, "no-return@example.com")
+
+            val rejection = linkRejection(
+                sympauthy,
+                callerToken,
+                ClientProviderLinkInputResource(
+                    accessToken = userToken,
+                    returnUri = "https://unregistered.example.com/return",
+                    cancelUri = null,
+                ),
+            )
+            assertEquals(400, rejection.status, "an unregistered return_uri should be rejected as a bad request")
+            assertTrue(
+                rejection.body.contains("client.redirect_uri.not_allowed"),
+                "should be rejected as a disallowed redirect URI, was: ${rejection.body}",
+            )
+        }
+    }
+
+    @ParameterizedTest(name = "provider link by a caller lacking users:providers:write is forbidden on {0}")
+    @EnumSource(Database::class)
+    fun rejectsCallerWithoutProvidersWriteScope(database: Database) {
+        withCustomContainer(
+            database,
+            client = Client.confidentialClient(clientId, CLIENT_SECRET),
+            build = { fixture, registry -> providerLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            // A client-credentials token WITHOUT users:providers:write — authenticates the client but lacks the scope.
+            val callerToken = clientCredentialsToken(sympauthy, registry)
+            val userToken = signUpAccessToken(registry, "no-scope@example.com")
+
+            val rejection = linkRejection(
+                sympauthy,
+                callerToken,
+                ClientProviderLinkInputResource(
+                    accessToken = userToken,
+                    returnUri = providerLinkReturnUri(registry),
+                    cancelUri = null,
+                ),
+            )
+            assertEquals(403, rejection.status, "a caller without users:providers:write should be forbidden")
+        }
+    }
+
+    @ParameterizedTest(name = "provider link with an unknown provider is rejected on {0}")
+    @EnumSource(Database::class)
+    fun rejectsUnknownProvider(database: Database) {
+        withCustomContainer(
+            database,
+            client = Client.confidentialClient(clientId, CLIENT_SECRET),
+            build = { fixture, registry -> providerLinkContainer(fixture, registry) },
+        ) { sympauthy, registry ->
+            val callerToken = clientCredentialsToken(sympauthy, registry, "users:providers:write")
+            val userToken = signUpAccessToken(registry, "unknown-provider@example.com")
+
+            val rejection = linkRejection(
+                sympauthy,
+                callerToken,
+                ClientProviderLinkInputResource(
+                    accessToken = userToken,
+                    returnUri = providerLinkReturnUri(registry),
+                    cancelUri = null,
+                ),
+                providerId = "not-a-provider",
+            )
+            assertEquals(400, rejection.status, "an unknown provider should be rejected as a bad request")
+            assertTrue(
+                rejection.body.contains("provider.missing"),
+                "should be rejected because the provider is unknown, was: ${rejection.body}",
+            )
+        }
+    }
+
+    @ParameterizedTest(name = "provider link with an end-user token issued to another client is rejected on {0}")
+    @EnumSource(Database::class)
+    fun rejectsUserTokenIssuedToAnotherClient(database: Database) {
+        // Two clients, each with its own mock frontend: the caller (holding users:providers:write) and another
+        // client whose end-user token we present to the caller's link endpoint.
+        database.createFixture().use { fixture ->
+            InteractiveFlowRegistry.forClient(Client.confidentialClient(clientId, CLIENT_SECRET))
+                .withScopes("openid").use { caller ->
+                    InteractiveFlowRegistry.forClient(Client.publicClient(OTHER_CLIENT_ID))
+                        .withFlowId("other").withScopes("openid").use { other ->
+                            fixture.applyTo(
+                                SympauthyContainer(SympauthyImage.resolve())
+                                    .withConfig(twoClientConfig(caller, other))
+                                    .withFlows(caller)
+                                    .withFlows(other),
+                            ).use { sympauthy ->
+                                withStartedContainer(sympauthy) {
+                                    val callerToken = clientCredentialsToken(sympauthy, caller, "users:providers:write")
+                                    val foreignUserToken = signUpAccessToken(other, "eve@example.com")
+
+                                    val rejection = linkRejection(
+                                        sympauthy,
+                                        callerToken,
+                                        ClientProviderLinkInputResource(
+                                            accessToken = foreignUserToken,
+                                            returnUri = providerLinkReturnUri(caller),
+                                            cancelUri = null,
+                                        ),
+                                    )
+                                    assertEquals(400, rejection.status, "a token issued to another client should be rejected")
+                                    assertTrue(
+                                        rejection.body.contains("invalid_access_token"),
+                                        "should be rejected as an invalid access token, was: ${rejection.body}",
+                                    )
+                                }
+                            }
+                        }
+                }
+        }
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------------
+
+    /** The `return_uri` a provider-link flow redirects the end-user to on success. */
+    private fun providerLinkReturnUri(registry: InteractiveFlowRegistry): String =
+        "${registry.frontendUrl()}/link-return"
+
+    /** The `cancel_uri` a provider-link flow redirects the end-user to on cancellation. */
+    private fun providerLinkCancelUri(registry: InteractiveFlowRegistry): String =
+        "${registry.frontendUrl()}/link-cancel"
+
+    /**
+     * The full server configuration for the client provider-link API: password auth, a confidential client
+     * that owns [registry]'s flow and is allowed both the `authorization_code` grant (to obtain an end-user
+     * access token) and the `client_credentials` grant carrying `users:providers:write` (to call the link
+     * endpoint), with the return/cancel URIs registered as redirect URIs, plus a configured OAuth2 provider
+     * (dummy endpoints — the start endpoint only needs it to resolve as enabled, not to be reachable).
+     */
+    private fun providerLinkConfig(registry: InteractiveFlowRegistry): Map<String, Any> {
+        val secret = registry.clientSecret()
+            ?: error("client-initiated provider link requires a confidential client (client_credentials grant)")
+        return linkedMapOf(
+            "auth" to mapOf(
+                "by-password" to mapOf("enabled" to true),
+                "identifier-claims" to listOf("email"),
+            ),
+            "claims" to mapOf("email" to mapOf("enabled" to true)),
+            "features" to mapOf("grant-unhandled-scopes" to true),
+            "templates" to mapOf(
+                "clients" to mapOf("default" to mapOf("authorization-flow" to registry.flowId())),
+            ),
+            "providers" to mapOf(
+                PROVIDER_ID to mapOf(
+                    "name" to "Test Provider",
+                    "oauth2" to mapOf(
+                        "client-id" to "provider-client-id",
+                        "client-secret" to "provider-client-secret",
+                        "authorization-url" to "https://provider.example.com/oauth2/authorize",
+                        "token-url" to "https://provider.example.com/oauth2/token",
+                    ),
+                    "user-info" to mapOf(
+                        "url" to "https://provider.example.com/oauth2/userinfo",
+                        "paths" to mapOf("sub" to "\$.id", "email" to "\$.email"),
+                    ),
+                ),
+            ),
+            "clients" to mapOf(
+                registry.clientId() to mapOf(
+                    "secret" to secret,
+                    "authorizationFlow" to registry.flowId(),
+                    "allowed-grant-types" to listOf("authorization_code", "client_credentials"),
+                    "allowed-scopes" to listOf("openid", "users:providers:write"),
+                    "default-scopes" to listOf("openid"),
+                    "allowed-redirect-uris" to listOf(
+                        registry.redirectUri(),
+                        providerLinkReturnUri(registry),
+                        providerLinkCancelUri(registry),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    /** Builds the standard single-client provider-link container for [registry] (a confidential client). */
+    private fun providerLinkContainer(
+        fixture: DatabaseFixture,
+        registry: InteractiveFlowRegistry,
+    ): SympauthyContainer {
+        registry.withScopes("openid")
+        return fixture.applyTo(
+            SympauthyContainer(SympauthyImage.resolve())
+                .withConfig(providerLinkConfig(registry))
+                .withFlows(registry),
+        )
+    }
+
+    /** [providerLinkConfig] for [caller] plus a second, public [other] client with its own flow. */
+    private fun twoClientConfig(
+        caller: InteractiveFlowRegistry,
+        other: InteractiveFlowRegistry,
+    ): Map<String, Any> {
+        val base = providerLinkConfig(caller)
+        @Suppress("UNCHECKED_CAST")
+        val clients = (base["clients"] as Map<String, Any>) + (
+            other.clientId() to mapOf(
+                "public" to true,
+                "authorizationFlow" to other.flowId(),
+                "allowed-grant-types" to listOf("authorization_code"),
+                "allowed-scopes" to listOf("openid"),
+                "allowed-redirect-uris" to listOf(other.redirectUri()),
+            )
+            )
+        return base + mapOf("clients" to clients)
+    }
+
+    /** Signs up a fresh end-user through [registry]'s flow and returns their access token. */
+    private fun signUpAccessToken(registry: InteractiveFlowRegistry, email: String): String {
+        val token = registry.newFlow()
+            .withSignUpHandler { mapOf("email" to email, "password" to PASSWORD) }
+            .run()
+            .exchange()
+            .accessToken()
+        assertNotNull(token, "sign-up should yield an end-user access token")
+        return token
+    }
+
+    /**
+     * Calls `POST /api/v1/client/providers/{providerId}/link` expecting a rejection, and captures the HTTP
+     * status and error body **inside** the client's context (its response buffer is released once
+     * [withApiClient] closes the context, so the body must be read before returning).
+     */
+    private fun linkRejection(
+        sympauthy: SympauthyContainer,
+        callerToken: String,
+        input: ClientProviderLinkInputResource,
+        providerId: String = PROVIDER_ID,
+    ): RejectedLink = withApiClient(sympauthy, token = callerToken) { ctx ->
+        try {
+            ctx.getBean(ClientApi::class.java).startLink1(providerId, input).block()
+            fail("expected the link request to be rejected, but it succeeded")
+        } catch (error: HttpClientResponseException) {
+            RejectedLink(error.status.code, error.response.getBody(String::class.java).orElse(""))
+        }
+    }
+
+    /** The HTTP status and raw error body (carrying the server's `error_code`) of a rejected link call. */
+    private data class RejectedLink(val status: Int, val body: String)
+
+    private companion object {
+        const val CLIENT_SECRET = "s3cr3t-link"
+        const val OTHER_CLIENT_ID = "other-app"
+        const val PASSWORD = "Str0ngP@ssw0rd!"
+        const val PROVIDER_ID = "test-provider"
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/OpenAPI.kt
+++ b/server/src/main/kotlin/com/sympauthy/OpenAPI.kt
@@ -95,7 +95,8 @@ import jakarta.inject.Singleton
                         OAuthScope(name = BuiltInClientScopeId.USERS_CLAIMS_READ),
                         OAuthScope(name = BuiltInClientScopeId.USERS_CLAIMS_WRITE),
                         OAuthScope(name = BuiltInClientScopeId.USERS_MFA_READ),
-                        OAuthScope(name = BuiltInClientScopeId.USERS_MFA_WRITE)
+                        OAuthScope(name = BuiltInClientScopeId.USERS_MFA_WRITE),
+                        OAuthScope(name = BuiltInClientScopeId.USERS_PROVIDERS_WRITE)
                     ]
                 )
             )

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
@@ -1,11 +1,20 @@
 package com.sympauthy.api.controller.admin
 
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.api.resource.admin.AdminUserProviderLinkInputResource
+import com.sympauthy.api.resource.admin.AdminUserProviderLinkResource
 import com.sympauthy.api.resource.admin.AdminUserProviderListResource
 import com.sympauthy.api.resource.admin.AdminUserProviderResource
 import com.sympauthy.api.resource.admin.AdminUserProviderUnlinkResource
 import com.sympauthy.api.util.orNotFound
 import com.sympauthy.api.util.resolvePageParams
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.client.ClientRedirectUriManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager
 import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.manager.provider.ProviderManager
 import com.sympauthy.business.manager.user.UserManager
 import com.sympauthy.business.model.oauth2.AdminScopeId
 import com.sympauthy.security.SecurityRule.ADMIN_USERS_READ
@@ -22,7 +31,14 @@ import java.util.*
 @Controller("/api/v1/admin/users/{userId}/providers")
 class AdminUserProviderController(
     @Inject private val userManager: UserManager,
-    @Inject private val providerClaimsManager: ProviderClaimsManager
+    @Inject private val providerClaimsManager: ProviderClaimsManager,
+    @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
+    @Inject private val clientRedirectUriManager: ClientRedirectUriManager,
+    @Inject private val clientManager: ClientManager,
+    @Inject private val providerManager: ProviderManager,
+    @Inject private val linkProviderManager: InteractiveFlowSessionLinkProviderManager,
+    @Inject private val engine: InteractiveFlowEngine,
+    @Inject private val stepUriMapper: InteractiveFlowStepUriMapper,
 ) {
 
     @Operation(
@@ -97,6 +113,75 @@ class AdminUserProviderController(
             userId = userId,
             providerId = providerId,
             unlinked = true
+        )
+    }
+
+    @Operation(
+        description = "Start linking an identity provider to a given user, initiated by an administrator. " +
+                "Validates that the user, the named client and the provider exist and that the return (and " +
+                "optional cancel) URI are registered redirect URIs of that client, then creates a link session " +
+                "gated by a confirmation the end-user must approve (shown as initiated by an administrator) and " +
+                "a forced re-authentication (linking a provider mints a durable login credential). Returns the " +
+                "redirect_url to hand or send to the user; once the link completes they are redirected to " +
+                "return_uri.",
+        tags = ["admin"],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The link session was started.",
+                useReturnTypeSchema = true
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Unknown or disabled provider, or invalid return or cancel URI."
+            ),
+            ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: admin:users:write."
+            ),
+            ApiResponse(responseCode = "404", description = "No user or client found with the given identifier.")
+        ]
+    )
+    @Post("/{providerId}/link")
+    @Secured(ADMIN_USERS_WRITE)
+    @SecurityRequirement(name = "admin", scopes = [AdminScopeId.USERS_WRITE])
+    suspend fun startLink(
+        @PathVariable @Parameter(description = "Unique identifier of the user.") userId: UUID,
+        @PathVariable @Parameter(description = "Identifier of the provider to link.") providerId: String,
+        @Body resource: AdminUserProviderLinkInputResource
+    ): AdminUserProviderLinkResource {
+        // Both the target user and the named client must exist.
+        userManager.findByIdOrNull(userId).orNotFound()
+        val client = resource.clientId
+            ?.let { clientManager.findClientByIdOrNull(it) }
+            .orNotFound()
+
+        // Fail fast (before creating any session) on an unknown or disabled provider (400).
+        providerManager.findByIdAndCheckEnabled(providerId)
+
+        // Validate the return URI (and the optional cancel URI) against the named client's registered redirect
+        // URIs to avoid open redirects. recoverable = true: a bad URI is a bad request (400), not a 500.
+        val returnUri = clientRedirectUriManager.parseRequestedRedirectUri(client, resource.returnUri, recoverable = true)
+        val cancelUri = resource.cancelUri
+            ?.let { clientRedirectUriManager.parseRequestedRedirectUri(client, it, recoverable = true) }
+
+        // Admin-initiated: pass a null client id so the confirmation shows "an administrator".
+        val flow = interactiveAuthFlowSessionManager.getDefaultInteractiveFlow()
+        val session = linkProviderManager.startLinkProviderSession(
+            userId = userId,
+            providerId = providerId,
+            returnUri = returnUri,
+            flow = flow,
+            initiatingClientId = null,
+            cancelUri = cancelUri
+        )
+
+        // The resulting redirect URI already carries the signed state as a query parameter.
+        val (steppedSession, step) = engine.advance(session)
+        val redirectUri = stepUriMapper.toRedirectUri(steppedSession, flow, step)
+        return AdminUserProviderLinkResource(
+            redirectUrl = redirectUri.toString()
         )
     }
 }

--- a/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderController.kt
@@ -133,14 +133,17 @@ class AdminUserProviderController(
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "Unknown or disabled provider, or invalid return or cancel URI."
+                description = "Invalid return or cancel URI."
             ),
             ApiResponse(responseCode = "401", description = "Missing or invalid access token."),
             ApiResponse(
                 responseCode = "403",
                 description = "The access token does not include the required scope: admin:users:write."
             ),
-            ApiResponse(responseCode = "404", description = "No user or client found with the given identifier.")
+            ApiResponse(
+                responseCode = "404",
+                description = "No user, client, or enabled provider found with the given identifier."
+            )
         ]
     )
     @Post("/{providerId}/link")
@@ -157,8 +160,9 @@ class AdminUserProviderController(
             ?.let { clientManager.findClientByIdOrNull(it) }
             .orNotFound()
 
-        // Fail fast (before creating any session) on an unknown or disabled provider (400).
-        providerManager.findByIdAndCheckEnabled(providerId)
+        // Fail fast (before creating any session) on an unknown or disabled provider. Like the unknown-user /
+        // unknown-client cases above, an absent named resource is a 404 (the provider id is a path variable).
+        providerManager.listEnabledProviders().find { it.id == providerId }.orNotFound()
 
         // Validate the return URI (and the optional cancel URI) against the named client's registered redirect
         // URIs to avoid open redirects. recoverable = true: a bad URI is a bad request (400), not a 500.

--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkController.kt
@@ -1,0 +1,138 @@
+package com.sympauthy.api.controller.client
+
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.api.resource.client.ClientProviderLinkInputResource
+import com.sympauthy.api.resource.client.ClientProviderLinkResource
+import com.sympauthy.business.exception.recoverableBusinessExceptionOf
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.auth.oauth2.TokenManager
+import com.sympauthy.business.manager.client.ClientRedirectUriManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager
+import com.sympauthy.business.manager.provider.ProviderManager
+import com.sympauthy.business.model.oauth2.BuiltInClientScopeId
+import com.sympauthy.security.SecurityRule.CLIENT_USERS_PROVIDERS_WRITE
+import com.sympauthy.security.clientAuthentication
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import jakarta.inject.Inject
+
+/**
+ * Client-API entry point for a client to start linking a third-party identity provider to one of its
+ * signed-in end-users, outside of an OAuth2 authorization (e.g. from a "manage sign-in methods" screen).
+ *
+ * Dual authentication:
+ * - the **calling client** authenticates with a client-credentials token holding the `users:providers:write`
+ *   scope.
+ * - the **end-user** is identified by their access token, passed in the request body and validated to have
+ *   been issued to the calling client.
+ *
+ * It starts an [com.sympauthy.business.model.flow.InteractiveFlowPurpose.LINK_PROVIDER] session for that
+ * end-user (gated by a confirmation and — because linking a provider mints a durable login credential — a
+ * forced re-authentication) and hands the caller the initial signed `state` + the page URL to drive the
+ * browser to. Once the link completes, the end-user is redirected back to the caller-provided `return_uri`.
+ */
+@Secured(CLIENT_USERS_PROVIDERS_WRITE)
+@Controller(ClientProviderLinkController.CLIENT_PROVIDER_LINK_ENDPOINT)
+class ClientProviderLinkController(
+    @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
+    @Inject private val clientRedirectUriManager: ClientRedirectUriManager,
+    @Inject private val clientManager: ClientManager,
+    @Inject private val tokenManager: TokenManager,
+    @Inject private val providerManager: ProviderManager,
+    @Inject private val linkProviderManager: InteractiveFlowSessionLinkProviderManager,
+    @Inject private val engine: InteractiveFlowEngine,
+    @Inject private val stepUriMapper: InteractiveFlowStepUriMapper,
+    @Inject private val sessionManager: InteractiveFlowSessionManager,
+) {
+
+    @Operation(
+        description = """
+Starts linking an identity provider to one of the calling client's signed-in end-users.
+
+Validates the end-user `access_token` (must be a valid, unexpired user access token issued to the calling
+client), the `{providerId}` (must be a known, enabled provider) and the `return_uri` (must be one of the
+calling client's registered redirect URIs), creates a link session and returns the signed `state` and the
+`redirect_url` the caller must navigate the end-user's browser to. The end-user is asked to confirm and to
+re-authenticate before the link is created; once it completes they are redirected to `return_uri`.
+        """,
+        tags = ["client"],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The link session was started.",
+                useReturnTypeSchema = true
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Invalid access token, unknown or disabled provider, or invalid return URI."
+            ),
+            ApiResponse(responseCode = "401", description = "Missing or invalid client access token."),
+            ApiResponse(
+                responseCode = "403",
+                description = "The access token does not include the required scope: users:providers:write."
+            )
+        ]
+    )
+    @Post
+    @Secured(CLIENT_USERS_PROVIDERS_WRITE)
+    @SecurityRequirement(name = "client", scopes = [BuiltInClientScopeId.USERS_PROVIDERS_WRITE])
+    suspend fun startLink(
+        authentication: Authentication,
+        @PathVariable @Parameter(description = "Identifier of the provider to link.") providerId: String,
+        @Body resource: ClientProviderLinkInputResource
+    ): ClientProviderLinkResource {
+        val client = clientManager.findClientById(authentication.clientAuthentication.clientId)
+
+        // Validate the end-user access token: signature, expiry, not revoked, issued to the calling client
+        // (enforced by introspectToken), and associated with an end-user (not a client-credentials token).
+        val userToken = resource.accessToken
+            ?.let { tokenManager.introspectToken(client, it, "access_token") }
+        val userId = userToken?.userId
+            ?: throw recoverableBusinessExceptionOf(
+                "client.providers.link.invalid_access_token",
+                "description.client.providers.link.invalid_access_token"
+            )
+
+        // Fail fast (before creating any session) on an unknown or disabled provider (400).
+        providerManager.findByIdAndCheckEnabled(providerId)
+
+        // Validate the return URI (and the optional cancel URI) against the calling client's registered
+        // redirect URIs to avoid open redirects. recoverable = true: a bad URI is a bad request from the
+        // calling client (400), not a server error.
+        val returnUri = clientRedirectUriManager.parseRequestedRedirectUri(client, resource.returnUri, recoverable = true)
+        val cancelUri = resource.cancelUri
+            ?.let { clientRedirectUriManager.parseRequestedRedirectUri(client, it, recoverable = true) }
+
+        val flow = interactiveAuthFlowSessionManager.getDefaultInteractiveFlow()
+        val session = linkProviderManager.startLinkProviderSession(
+            userId = userId,
+            providerId = providerId,
+            returnUri = returnUri,
+            flow = flow,
+            initiatingClientId = client.id,
+            cancelUri = cancelUri
+        )
+
+        val (steppedSession, step) = engine.advance(session)
+        val redirectUri = stepUriMapper.toRedirectUri(steppedSession, flow, step)
+        return ClientProviderLinkResource(
+            state = sessionManager.encodeState(steppedSession),
+            redirectUrl = redirectUri.toString()
+        )
+    }
+
+    companion object {
+        const val CLIENT_PROVIDER_LINK_ENDPOINT = "/api/v1/client/providers/{providerId}/link"
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkController.kt
@@ -3,6 +3,7 @@ package com.sympauthy.api.controller.client
 import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
 import com.sympauthy.api.resource.client.ClientProviderLinkInputResource
 import com.sympauthy.api.resource.client.ClientProviderLinkResource
+import com.sympauthy.api.util.orNotFound
 import com.sympauthy.business.exception.recoverableBusinessExceptionOf
 import com.sympauthy.business.manager.ClientManager
 import com.sympauthy.business.manager.auth.oauth2.TokenManager
@@ -75,13 +76,14 @@ re-authenticate before the link is created; once it completes they are redirecte
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "Invalid access token, unknown or disabled provider, or invalid return URI."
+                description = "Invalid access token, or invalid return URI."
             ),
             ApiResponse(responseCode = "401", description = "Missing or invalid client access token."),
             ApiResponse(
                 responseCode = "403",
                 description = "The access token does not include the required scope: users:providers:write."
-            )
+            ),
+            ApiResponse(responseCode = "404", description = "No enabled provider found with the given identifier.")
         ]
     )
     @Post
@@ -104,8 +106,9 @@ re-authenticate before the link is created; once it completes they are redirecte
                 "description.client.providers.link.invalid_access_token"
             )
 
-        // Fail fast (before creating any session) on an unknown or disabled provider (400).
-        providerManager.findByIdAndCheckEnabled(providerId)
+        // Fail fast (before creating any session) on an unknown or disabled provider. Like the unknown-user /
+        // unknown-client cases, an absent named resource is a 404 (the provider id is a path variable).
+        providerManager.listEnabledProviders().find { it.id == providerId }.orNotFound()
 
         // Validate the return URI (and the optional cancel URI) against the calling client's registered
         // redirect URIs to avoid open redirects. recoverable = true: a bad URI is a bad request from the

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/ConfirmController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/ConfirmController.kt
@@ -4,6 +4,7 @@ import com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControll
 import com.sympauthy.api.resource.flow.ConfirmFlowResource
 import com.sympauthy.api.resource.flow.SimpleFlowResource
 import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.security.SecurityRule.HAS_STATE
 import com.sympauthy.security.stateOrNull
 import io.micronaut.http.annotation.Controller
@@ -47,8 +48,15 @@ on-going flow. All URLs it contains already include the state query param.
             run = { session, _ ->
                 val confirm = confirmManager.fetchConfirmOrNull(session)
                 if (confirm != null && !confirm.confirmed) {
+                    // Warn the UI up front when a re-authentication step is still ahead in this session (server
+                    // -computed, not hardcoded per action): true when the chain carries an unresolved
+                    // REAUTHENTICATION purpose (e.g. provider link), false otherwise (e.g. MFA enrollment).
+                    val requiresReauthentication =
+                        InteractiveFlowPurpose.REAUTHENTICATION in session.purposes &&
+                            InteractiveFlowPurpose.REAUTHENTICATION !in session.completedPurposes
                     ConfirmFlowResource(
                         action = confirm.action.name,
+                        requiresReauthentication = requiresReauthentication,
                         initiatingClientId = confirm.clientId
                     )
                 } else {

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/InteractiveFlowStepUriMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/InteractiveFlowStepUriMapper.kt
@@ -70,6 +70,15 @@ class InteractiveFlowStepUriMapper(
             session,
             flow.confirmUri ?: throw internalBusinessExceptionOf("flow.confirm.uri.missing")
         )
+        // Drive the browser to the target provider's authorize endpoint (which then 303s to the provider),
+        // reusing the existing provider authorize/callback machinery. No configurable flow page is involved.
+        is InteractiveFlowStep.AuthorizeProvider -> appendState(
+            session,
+            uncheckedUrlsConfig.orThrow().getUri(
+                ProvidersController.FLOW_PROVIDER_ENDPOINTS + ProvidersController.FLOW_PROVIDER_AUTHORIZE_ENDPOINT,
+                "providerId" to step.providerId
+            )
+        )
         InteractiveFlowStep.CollectClaims -> appendState(session, flow.collectClaimsUri)
         is InteractiveFlowStep.ValidateClaims -> appendState(session, buildValidateClaimsUri(flow, step.media))
         InteractiveFlowStep.Error -> appendState(session, flow.errorUri)

--- a/server/src/main/kotlin/com/sympauthy/api/controller/flow/ProvidersController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/flow/ProvidersController.kt
@@ -2,7 +2,7 @@ package com.sympauthy.api.controller.flow
 
 import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_ENDPOINTS
 import com.sympauthy.api.controller.flow.auth.InteractiveAuthFlowSessionControllerUtil
-import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionOAuth2ProviderManager
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2ProviderManager
 import com.sympauthy.security.SecurityRule.HAS_STATE
 import com.sympauthy.security.stateOrNull
 import io.micronaut.http.HttpResponse
@@ -19,7 +19,7 @@ import jakarta.inject.Inject
 @Secured(HAS_STATE)
 @Controller(FLOW_PROVIDER_ENDPOINTS)
 class ProvidersController(
-    @Inject private val interactiveAuthFlowSessionOAuth2ProviderManager: InteractiveAuthFlowSessionOAuth2ProviderManager,
+    @Inject private val interactiveFlowSessionOAuth2ProviderManager: InteractiveFlowSessionOAuth2ProviderManager,
     @Inject private val interactiveAuthFlowSessionControllerUtil: InteractiveAuthFlowSessionControllerUtil
 ) {
 
@@ -46,7 +46,7 @@ defined in ```urls.flow.error``` configuration.
         interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect(
             state = authentication.stateOrNull,
             run = { session, _ ->
-                interactiveAuthFlowSessionOAuth2ProviderManager.authorizeWithProvider(
+                interactiveFlowSessionOAuth2ProviderManager.authorizeWithProvider(
                     session,
                     providerId = providerId
                 )
@@ -84,7 +84,7 @@ Redirection to either:
     ) = interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenUpdateAndRedirect(
         state = state,
         update = { session, _ ->
-            interactiveAuthFlowSessionOAuth2ProviderManager.signInOrSignUpUsingProvider(
+            interactiveFlowSessionOAuth2ProviderManager.signInOrSignUpUsingProvider(
                 session = session,
                 providerId = providerId,
                 authorizeCode = code,

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderLinkInputResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderLinkInputResource.kt
@@ -1,0 +1,38 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Request body for an administrator to start linking an identity provider to a given user."
+)
+@Serdeable
+data class AdminUserProviderLinkInputResource(
+    @get:Schema(
+        description = """
+Identifier of the client the end-user will be returned into once the link completes.
+The ```return_uri``` (and optional ```cancel_uri```) are validated against this client's registered redirect
+URIs, and the user is redirected back to it on completion.
+        """
+    )
+    @get:JsonProperty("client_id")
+    val clientId: String?,
+    @get:Schema(
+        description = """
+URI the end-user is returned to once the provider link completes.
+Must be one of the named client's registered redirect URIs.
+        """
+    )
+    @get:JsonProperty("return_uri")
+    val returnUri: String?,
+    @get:Schema(
+        description = """
+Optional URI the end-user is returned to if they cancel the provider link.
+When provided, must be one of the named client's registered redirect URIs. When omitted, the flow offers no
+cancellation.
+        """
+    )
+    @get:JsonProperty("cancel_uri")
+    val cancelUri: String? = null
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderLinkResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/admin/AdminUserProviderLinkResource.kt
@@ -1,0 +1,20 @@
+package com.sympauthy.api.resource.admin
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Response from starting an admin-initiated provider link: the link to hand to the user."
+)
+@Serdeable
+data class AdminUserProviderLinkResource(
+    @get:Schema(
+        description = """
+URL to hand or send to the end-user so they can link the provider. The signed ```state``` identifying the
+link session is already included as a query parameter.
+        """
+    )
+    @get:JsonProperty("redirect_url")
+    val redirectUrl: String
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientProviderLinkInputResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientProviderLinkInputResource.kt
@@ -1,0 +1,37 @@
+package com.sympauthy.api.resource.client
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Request body to start linking an identity provider to a signed-in end-user's account."
+)
+@Serdeable
+data class ClientProviderLinkInputResource(
+    @get:Schema(
+        description = """
+Access token identifying the end-user whose account the provider will be linked to.
+Must be a valid, unexpired user access token issued by this authorization server to the calling client.
+        """
+    )
+    @get:JsonProperty("access_token")
+    val accessToken: String?,
+    @get:Schema(
+        description = """
+URI the end-user is returned to once the provider link completes.
+Must be one of the calling client's registered redirect URIs.
+        """
+    )
+    @get:JsonProperty("return_uri")
+    val returnUri: String?,
+    @get:Schema(
+        description = """
+Optional URI the end-user is returned to if they cancel the provider link.
+When provided, must be one of the calling client's registered redirect URIs. When omitted, the flow offers
+no cancellation.
+        """
+    )
+    @get:JsonProperty("cancel_uri")
+    val cancelUri: String? = null
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientProviderLinkResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/client/ClientProviderLinkResource.kt
@@ -1,0 +1,21 @@
+package com.sympauthy.api.resource.client
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Response from starting a provider link: where to drive the end-user next."
+)
+@Serdeable
+data class ClientProviderLinkResource(
+    @get:Schema(
+        description = "Signed state identifying the link session, echoed by the flow endpoints."
+    )
+    val state: String,
+    @get:Schema(
+        description = "URL to navigate the end-user to in order to link the provider (state included)."
+    )
+    @get:JsonProperty("redirect_url")
+    val redirectUrl: String
+)

--- a/server/src/main/kotlin/com/sympauthy/api/resource/flow/ConfirmFlowResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/flow/ConfirmFlowResource.kt
@@ -31,6 +31,17 @@ resource carries a ```redirect_url```.
     )
     val action: String? = null,
     @get:Schema(
+        name = "requires_reauthentication",
+        description = """
+Whether the end-user will be asked to re-authenticate (prove they own the account) after approving this
+action, so the custom UI can warn them up front. Computed from the session's remaining steps: true when a
+re-authentication step is still ahead (e.g. linking a provider), false otherwise (e.g. MFA enrollment).
+Defaults to false; irrelevant when this resource carries a ```redirect_url```.
+        """
+    )
+    @get:JsonProperty("requires_reauthentication")
+    val requiresReauthentication: Boolean = false,
+    @get:Schema(
         name = "initiating_client_id",
         description = """
 Identifier of the client that initiated the action on the end-user's behalf. Null when the action was

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngine.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngine.kt
@@ -18,8 +18,9 @@ import jakarta.inject.Singleton
  *
  * The engine drives the purposes in order: it asks each [InteractiveFlowPurposeHandler], in turn, for the next
  * step of its purpose; the first purpose that still needs a step yields the step to present. As a purpose
- * resolves, the engine marks it complete and appends the follow-up purposes it declares — so completion is
- * recorded one purpose at a time as the engine hands off, even while later purposes still need steps. Once
+ * resolves, the engine marks it complete and inserts the follow-up purposes it declares right after it — so
+ * completion is recorded one purpose at a time as the engine hands off, even while later purposes still need
+ * steps. Once
  * every purpose has resolved, the engine runs each purpose's terminal effect and transitions the session to
  * completed (or failed). The engine is the sole owner of every session mutation — appending, completing,
  * failing — while the handlers only read the session and describe what their purpose needs.
@@ -82,28 +83,37 @@ class InteractiveFlowEngine(
             handler.nextStepOrNull(current)?.let { step ->
                 return InteractiveFlowStepResult(current, step)
             }
-            // The purpose has resolved: mark it complete as the engine hands off, then append the follow-up
-            // purposes it declares. Completion is recorded one purpose at a time, even when a later purpose
-            // still yields a step and the session as a whole is not yet complete.
+            // The purpose has resolved: mark it complete as the engine hands off, then insert the follow-up
+            // purposes it declares right after it. Completion is recorded one purpose at a time, even when a
+            // later purpose still yields a step and the session as a whole is not yet complete.
             current = sessionManager.markPurposeAsCompleted(current, purpose)
-            current = appendFollowUps(current, handler)
+            current = insertFollowUpsAfter(current, purpose, handler)
             index++
         }
         return complete(current)
     }
 
     /**
-     * Append the follow-up purposes [handler] declares for [session] that are not already present, persisting
-     * each, and return the possibly-grown session.
+     * Insert the follow-up purposes [handler] declares for [session] — that are not already present —
+     * immediately after the just-resolved [afterPurpose], in declared order, persisting each, and return the
+     * possibly-grown session.
+     *
+     * Inserting right after the resolving purpose (rather than appending at the end) keeps a follow-up ahead
+     * of any later purpose the session already carries: a re-authentication gate's MFA challenge lands before
+     * the sensitive purpose it guards (e.g. a provider link), never after it.
      */
-    private suspend fun appendFollowUps(
+    private suspend fun insertFollowUpsAfter(
         session: OnGoingInteractiveFlowSession,
+        afterPurpose: InteractiveFlowPurpose,
         handler: InteractiveFlowPurposeHandler
     ): OnGoingInteractiveFlowSession {
         var current = session
+        var previous = afterPurpose
         for (purpose in handler.followUpPurposes(current)) {
             if (purpose !in current.purposes) {
-                current = sessionManager.appendPurpose(current, purpose)
+                current = sessionManager.insertPurposeAfter(current, purpose, previous)
+                // Chain multiple follow-ups so they keep their declared order after the resolving purpose.
+                previous = purpose
             }
         }
         return current

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngine.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngine.kt
@@ -112,9 +112,11 @@ class InteractiveFlowEngine(
         for (purpose in handler.followUpPurposes(current)) {
             if (purpose !in current.purposes) {
                 current = sessionManager.insertPurposeAfter(current, purpose, previous)
-                // Chain multiple follow-ups so they keep their declared order after the resolving purpose.
-                previous = purpose
             }
+            // Advance the anchor to `purpose` whether or not it was inserted, so several follow-ups keep their
+            // declared order after the resolving purpose — a later new follow-up lands after an already-present
+            // earlier sibling, not back at the resolving purpose.
+            previous = purpose
         }
         return current
     }

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionCleaner.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionCleaner.kt
@@ -3,6 +3,7 @@ package com.sympauthy.business.manager.flow
 import com.sympauthy.data.model.InteractiveFlowSessionEntity
 import com.sympauthy.data.repository.AuthorizationCodeRepository
 import com.sympauthy.data.repository.InteractiveFlowSessionConfirmRepository
+import com.sympauthy.data.repository.InteractiveFlowSessionLinkProviderRepository
 import com.sympauthy.data.repository.InteractiveFlowSessionOAuth2Repository
 import com.sympauthy.data.repository.InteractiveFlowSessionProviderRepository
 import com.sympauthy.data.repository.InteractiveFlowSessionReauthenticationRepository
@@ -25,6 +26,7 @@ open class InteractiveFlowSessionCleaner(
     @Inject private val providerRepository: InteractiveFlowSessionProviderRepository,
     @Inject private val confirmRepository: InteractiveFlowSessionConfirmRepository,
     @Inject private val reauthenticationRepository: InteractiveFlowSessionReauthenticationRepository,
+    @Inject private val linkProviderRepository: InteractiveFlowSessionLinkProviderRepository,
     @Inject private val validationCodeRepository: ValidationCodeRepository,
     @Inject private val authorizationCodeRepository: AuthorizationCodeRepository,
 ) {
@@ -53,6 +55,9 @@ open class InteractiveFlowSessionCleaner(
         val deferredReauthenticationCount = async {
             reauthenticationRepository.deleteBySessionIdIn(expiredSessionIds)
         }
+        val deferredLinkProviderCount = async {
+            linkProviderRepository.deleteBySessionIdIn(expiredSessionIds)
+        }
 
         val authorizationCodesCount = deferredAuthorizationCodesCount.await()
         val validationCodesCount = deferredValidationCodesCount.await()
@@ -60,6 +65,7 @@ open class InteractiveFlowSessionCleaner(
         deferredProviderCount.await()
         deferredConfirmCount.await()
         deferredReauthenticationCount.await()
+        deferredLinkProviderCount.await()
 
         val sessionsCount = sessionRepository.deleteByIds(expiredSessionIds)
 

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
@@ -167,17 +167,23 @@ class InteractiveFlowSessionManager(
     }
 
     /**
-     * Append [purpose] to the ordered list of purposes of the [session], persist it, and return the updated
-     * session.
+     * Insert [purpose] into the ordered purpose list of the [session] immediately after [afterPurpose],
+     * persist it, and return the updated session. Falls back to appending at the end when [afterPurpose] is
+     * not present (which never happens for the engine's use — the resolving purpose is always in the list).
      *
-     * Used by a purpose handler that, as it resolves, needs a follow-up purpose to run before the session
-     * completes (e.g. the OAuth2 authorize purpose appending an MFA purpose).
+     * Used by the engine when a purpose resolves and declares a follow-up purpose that must run before the
+     * session completes (e.g. the re-authentication gate inserting an MFA challenge). Inserting **after** the
+     * resolving purpose — rather than at the end — keeps the follow-up ahead of any later purpose the session
+     * already carries, so e.g. a provider link never commits before its MFA challenge.
      */
-    suspend fun appendPurpose(
+    suspend fun insertPurposeAfter(
         session: OnGoingInteractiveFlowSession,
-        purpose: InteractiveFlowPurpose
+        purpose: InteractiveFlowPurpose,
+        afterPurpose: InteractiveFlowPurpose
     ): OnGoingInteractiveFlowSession {
-        val purposes = session.purposes + purpose
+        val afterIndex = session.purposes.indexOf(afterPurpose)
+        val insertAt = if (afterIndex >= 0) afterIndex + 1 else session.purposes.size
+        val purposes = session.purposes.toMutableList().apply { add(insertAt, purpose) }.toList()
         sessionRepository.updatePurposes(
             id = session.id,
             purposes = purposes.map(InteractiveFlowPurpose::name)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManager.kt
@@ -53,6 +53,7 @@ class InteractiveFlowSessionManager(
      */
     suspend fun newSession(
         purposes: List<InteractiveFlowPurpose>,
+        initiatingPurpose: InteractiveFlowPurpose,
         flow: AuthorizationFlow? = null,
         successRedirectUri: URI? = null,
         redirectType: InteractiveFlowRedirectType? = null,
@@ -62,6 +63,7 @@ class InteractiveFlowSessionManager(
         val now = LocalDateTime.now()
         val entity = InteractiveFlowSessionEntity(
             purposes = purposes.map(InteractiveFlowPurpose::name).toTypedArray(),
+            initiatingPurpose = initiatingPurpose.name,
             flowId = flow?.id,
             sessionDate = now,
             expirationDate = now.plus(uncheckedAuthConfig.orThrow().authorizationCode.expiration),
@@ -204,6 +206,7 @@ class InteractiveFlowSessionManager(
         return FailedInteractiveFlowSession(
             id = session.id,
             purposes = session.purposes,
+            initiatingPurpose = session.initiatingPurpose,
             flowId = session.flowId,
             errorDate = errorDate,
             errorDetailsId = error.detailsId,
@@ -243,6 +246,7 @@ class InteractiveFlowSessionManager(
         return CancelledInteractiveFlowSession(
             id = session.id,
             purposes = session.purposes,
+            initiatingPurpose = session.initiatingPurpose,
             flowId = session.flowId,
             expirationDate = session.expirationDate,
             userId = session.userId,
@@ -296,6 +300,7 @@ class InteractiveFlowSessionManager(
         return CompletedInteractiveFlowSession(
             id = session.id,
             purposes = session.purposes,
+            initiatingPurpose = session.initiatingPurpose,
             flowId = session.flowId,
             expirationDate = session.expirationDate,
             sessionDate = session.sessionDate,

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2Manager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2Manager.kt
@@ -64,6 +64,7 @@ open class InteractiveFlowSessionOAuth2Manager(
         // cancel target (the OAuth2 error=access_denied response is returned there).
         val session = sessionManager.newSession(
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flow = flow,
             successRedirectUri = redirectUri,
             redirectType = InteractiveFlowRedirectType.AUTHORIZATION_CODE,

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManager.kt
@@ -4,10 +4,12 @@ import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROV
 import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_ENDPOINTS
 import com.sympauthy.business.exception.businessExceptionOf
 import com.sympauthy.business.exception.recoverableBusinessExceptionOf
+import com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager
 import com.sympauthy.business.manager.flow.reauth.InteractiveFlowSessionReauthenticationManager
 import com.sympauthy.business.manager.provider.ProviderClaimsManager
 import com.sympauthy.business.manager.provider.ProviderClaimsResolver
 import com.sympauthy.business.manager.provider.ProviderManager
+import com.sympauthy.business.manager.user.UserManager
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowSession
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
@@ -24,9 +26,11 @@ import com.sympauthy.business.model.redirect.ProviderOpenIdConnectAuthorizationR
 import com.sympauthy.business.model.user.RawProviderClaims
 import com.sympauthy.client.oauth2.TokenEndpointClient
 import com.sympauthy.config.model.*
+import com.sympauthy.util.loggerForClass
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import java.net.URI
+import java.util.UUID
 
 /**
  * Manager owning the interaction with a third-party OAuth 2 / OpenID Connect provider within an interactive
@@ -52,8 +56,13 @@ open class InteractiveFlowSessionOAuth2ProviderManager(
     @Inject private val engine: InteractiveFlowEngine,
     @Inject private val tokenEndpointClient: TokenEndpointClient,
     @Inject private val establisher: ProviderUserEstablisher,
+    @Inject private val linkProviderManager: InteractiveFlowSessionLinkProviderManager,
+    @Inject private val userManager: UserManager,
+    @Inject private val uncheckedAuthConfig: AuthConfig,
     @Inject private val uncheckedUrlsConfig: UrlsConfig
 ) {
+
+    private val logger = loggerForClass()
 
     fun getOAuth2(provider: EnabledProvider): ProviderOAuth2Config {
         if (provider.auth !is ProviderOAuth2Config) {
@@ -85,11 +94,16 @@ open class InteractiveFlowSessionOAuth2ProviderManager(
     ): URI {
         val provider = providerConfigManager.findByIdAndCheckEnabled(providerId)
         // Once the session user is fixed, a provider round-trip may only re-confirm ownership with a provider
-        // already linked to that user — never establish a new identity (sign-in, which establishes, always runs
-        // with userId == null). A future LINK_PROVIDER purpose that authorizes a not-yet-linked provider is out
-        // of scope here and will relax this guard for its own purpose.
+        // already linked to that user — never establish a new identity (sign-in, which establishes, always
+        // runs with userId == null). The one exception is the LINK_PROVIDER purpose, which authorizes a
+        // not-yet-linked provider: there we instead require the provider to be exactly the link intent, so a
+        // stolen link-session state cannot authorize an arbitrary provider.
         if (session.userId != null) {
-            requireProviderLinkedToSessionUser(session, providerId)
+            if (engine.currentPurposeOrNull(session) == InteractiveFlowPurpose.LINK_PROVIDER) {
+                requireProviderIsLinkTarget(session, providerId)
+            } else {
+                requireProviderLinkedToSessionUser(session, providerId)
+            }
         }
         val state = sessionManager.encodeState(session)
         return when (val auth = provider.auth) {
@@ -173,14 +187,17 @@ open class InteractiveFlowSessionOAuth2ProviderManager(
 
         // Never switch an already-fixed session user via a provider round-trip:
         // - user already fixed under a re-authentication gate -> CONFIRM the resolved account is that user.
+        // - user already fixed under a provider-link gate -> LINK the resolved provider to the fixed user.
         // - user already fixed but a later purpose is now active -> provider sign-in no longer applies; return
         //   the session unchanged so the flow redirects to its current step, without switching identity.
         // Sign-in/up, which establishes identity below, only runs while userId == null.
         if (session.userId != null) {
-            return if (engine.currentPurposeOrNull(session) == InteractiveFlowPurpose.REAUTHENTICATION) {
-                confirmReauthenticatedProviderUser(session, existingUserInfo, rawUserInfo)
-            } else {
-                session
+            return when (engine.currentPurposeOrNull(session)) {
+                InteractiveFlowPurpose.REAUTHENTICATION ->
+                    confirmReauthenticatedProviderUser(session, existingUserInfo, rawUserInfo)
+                InteractiveFlowPurpose.LINK_PROVIDER ->
+                    linkProviderToSessionUser(session, provider, existingUserInfo, rawUserInfo)
+                else -> session
             }
         }
 
@@ -238,6 +255,94 @@ open class InteractiveFlowSessionOAuth2ProviderManager(
         providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo)
         reauthenticationManager.markPrimaryCredentialProven(session)
         return engine.completeIfNecessary(session)
+    }
+
+    /**
+     * Reject with a recoverable error unless [providerId] is exactly the provider the LINK_PROVIDER session was
+     * created to link (its link-provider record). This enforces the link intent so a leaked link-session state
+     * cannot be used to authorize — and then link — an arbitrary provider the attacker controls.
+     */
+    private suspend fun requireProviderIsLinkTarget(
+        session: OnGoingInteractiveFlowSession,
+        providerId: String
+    ) {
+        val targetProviderId = linkProviderManager.fetchLinkProviderOrNull(session)?.providerId
+        if (targetProviderId != providerId) {
+            throw recoverableBusinessExceptionOf(
+                detailsId = "flow.link_provider.wrong_provider",
+                descriptionId = "description.flow.link_provider.wrong_provider"
+            )
+        }
+    }
+
+    /**
+     * Provider-link path: link the resolved provider account to the session's **fixed**
+     * [OnGoingInteractiveFlowSession.userId], then advance. The session user is never switched — linking only
+     * ever attaches a provider to the already-identified account.
+     *
+     * Conflicts hard-fail (unrecoverable, so the flow fails and nothing is linked):
+     * - the provider subject is already linked to **another** account (an identity cannot belong to two users);
+     * - an identifier claim the provider asserts is already owned by **another** account.
+     *
+     * A subject already linked to **this** user is an idempotent success (the stored claims are refreshed).
+     */
+    private suspend fun linkProviderToSessionUser(
+        session: OnGoingInteractiveFlowSession,
+        provider: EnabledProvider,
+        existingUserInfo: ProviderUserInfo?,
+        rawUserInfo: RawProviderClaims
+    ): InteractiveFlowSession {
+        val userId = session.userId
+            ?: throw businessExceptionOf("flow.link_provider.missing_user")
+
+        if (existingUserInfo != null) {
+            if (existingUserInfo.userId == userId) {
+                // Already linked to this user: idempotent success.
+                providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo)
+                return engine.completeIfNecessary(session)
+            }
+            // Linked to a different account: an identity cannot belong to two accounts.
+            throw businessExceptionOf(
+                "flow.link_provider.subject_conflict",
+                "providerId" to provider.id
+            )
+        }
+
+        val identifierOwnerId = findUserOwningIdentifierClaimsOrNull(provider, rawUserInfo)
+        if (identifierOwnerId != null && identifierOwnerId != userId) {
+            throw businessExceptionOf(
+                "flow.link_provider.identifier_conflict",
+                "providerId" to provider.id
+            )
+        }
+
+        providerClaimsManager.saveUserInfo(provider, userId, rawUserInfo)
+        logger.info(
+            "Linked provider {} (subject {}) to user {}.",
+            provider.id,
+            rawUserInfo.subject,
+            userId
+        )
+        return engine.completeIfNecessary(session)
+    }
+
+    /**
+     * Return the id of a user that already owns the identifier claim values [provider] asserts in
+     * [rawUserInfo], or null when there is none — or when the conflict cannot be evaluated (no identifier
+     * claims configured, or the provider omits one), in which case the subject check remains the primary
+     * defense. Only the identifier **values** are needed here (not the resolved claim objects), so this is a
+     * plain lookup rather than the full sign-up claim resolution.
+     */
+    private suspend fun findUserOwningIdentifierClaimsOrNull(
+        provider: EnabledProvider,
+        rawUserInfo: RawProviderClaims
+    ): UUID? {
+        val identifierClaims = uncheckedAuthConfig.orThrow().identifierClaims
+        if (identifierClaims.isEmpty()) return null
+        val identifierValues = identifierClaims.associateWith { claimId ->
+            rawUserInfo.getClaimValueOrNull(claimId) ?: return null
+        }
+        return userManager.findByIdentifierClaims(identifierValues)?.id
     }
 
     suspend fun fetchTokens(

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManager.kt
@@ -1,23 +1,13 @@
-package com.sympauthy.business.manager.flow.auth
-
-import com.sympauthy.business.manager.flow.InteractiveFlowEngine
-import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
-import com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2Manager
-import com.sympauthy.business.manager.flow.InteractiveFlowSessionProviderManager
-import com.sympauthy.business.manager.flow.reauth.InteractiveFlowSessionReauthenticationManager
+package com.sympauthy.business.manager.flow
 
 import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_CALLBACK_ENDPOINT
 import com.sympauthy.api.controller.flow.ProvidersController.Companion.FLOW_PROVIDER_ENDPOINTS
 import com.sympauthy.business.exception.businessExceptionOf
 import com.sympauthy.business.exception.recoverableBusinessExceptionOf
-import com.sympauthy.business.manager.ClaimManager
-import com.sympauthy.business.manager.invitation.InvitationManager
+import com.sympauthy.business.manager.flow.reauth.InteractiveFlowSessionReauthenticationManager
 import com.sympauthy.business.manager.provider.ProviderClaimsManager
 import com.sympauthy.business.manager.provider.ProviderClaimsResolver
 import com.sympauthy.business.manager.provider.ProviderManager
-import com.sympauthy.business.manager.user.CollectedClaimManager
-import com.sympauthy.business.manager.user.CreateOrAssociateResult
-import com.sympauthy.business.manager.user.UserManager
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowSession
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
@@ -31,39 +21,37 @@ import com.sympauthy.business.model.provider.oauth2.ProviderOAuth2TokenRequest
 import com.sympauthy.business.model.provider.oauth2.ProviderOAuth2Tokens
 import com.sympauthy.business.model.redirect.ProviderOAuth2AuthorizationRedirect
 import com.sympauthy.business.model.redirect.ProviderOpenIdConnectAuthorizationRedirect
-import com.sympauthy.business.model.user.CollectedClaimUpdate
 import com.sympauthy.business.model.user.RawProviderClaims
-import com.sympauthy.business.model.user.User
-import com.sympauthy.business.model.user.claim.Claim
 import com.sympauthy.client.oauth2.TokenEndpointClient
 import com.sympauthy.config.model.*
-import io.micronaut.transaction.annotation.Transactional
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import java.net.URI
-import java.util.*
 
 /**
- * Manager in charge of the authentication and registration of an end-user going through an interactive auth flow
- * using an OAuth 2 or OIDC provider.
+ * Manager owning the interaction with a third-party OAuth 2 / OpenID Connect provider within an interactive
+ * flow session: it drives the end-user through the provider's authorization, handles the callback, exchanges
+ * the code for tokens and resolves the end-user claims, then routes the outcome by the session's current
+ * purpose.
+ *
+ * It is purpose-agnostic and shared by every consumer that authorizes with a provider — sign-in / sign-up
+ * ([InteractiveFlowPurpose.OAUTH2_AUTHORIZE]), ownership proof
+ * ([InteractiveFlowPurpose.REAUTHENTICATION]) and provider linking
+ * ([InteractiveFlowPurpose.LINK_PROVIDER]). The OAuth2-authorize-specific "establish a new user" outcome is
+ * delegated to the [ProviderUserEstablisher] seam so this manager stays free of consumer-specific identity
+ * logic.
  */
 @Singleton
-open class InteractiveAuthFlowSessionOAuth2ProviderManager(
+open class InteractiveFlowSessionOAuth2ProviderManager(
     @Inject private val sessionManager: InteractiveFlowSessionManager,
-    @Inject private val oauth2Manager: InteractiveFlowSessionOAuth2Manager,
     @Inject private val providerManager: InteractiveFlowSessionProviderManager,
     @Inject private val reauthenticationManager: InteractiveFlowSessionReauthenticationManager,
-    @Inject private val claimManager: ClaimManager,
-    @Inject private val collectedClaimManager: CollectedClaimManager,
-    @Inject private val invitationManager: InvitationManager,
     @Inject private val providerConfigManager: ProviderManager,
     @Inject private val providerClaimsManager: ProviderClaimsManager,
     @Inject private val providerClaimsResolver: ProviderClaimsResolver,
-    @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
     @Inject private val engine: InteractiveFlowEngine,
     @Inject private val tokenEndpointClient: TokenEndpointClient,
-    @Inject private val userManager: UserManager,
-    @Inject private val uncheckedAuthConfig: AuthConfig,
+    @Inject private val establisher: ProviderUserEstablisher,
     @Inject private val uncheckedUrlsConfig: UrlsConfig
 ) {
 
@@ -197,12 +185,8 @@ open class InteractiveAuthFlowSessionOAuth2ProviderManager(
         }
 
         val (userId, signedUp) = if (existingUserInfo == null) {
-            val oauth2 = oauth2Manager.fetchOAuth2(session)
-            interactiveAuthFlowSessionManager.checkSignUpAllowed(oauth2, recoverable = false)
-            val result = createOrAssociateUserWithProviderUserInfo(provider, rawUserInfo)
-            invitationManager.applyInvitationClaimsAndConsume(oauth2.invitationId, result.user.id)
-            // `created` is false when the provider was merged into an existing account (sign-in, not sign-up).
-            result.user.id to result.created
+            val establishment = establisher.establishNewProviderUser(session, provider, rawUserInfo)
+            establishment.userId to establishment.signedUp
         } else {
             providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo)
             existingUserInfo.userId to false
@@ -254,129 +238,6 @@ open class InteractiveAuthFlowSessionOAuth2ProviderManager(
         providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo)
         reauthenticationManager.markPrimaryCredentialProven(session)
         return engine.completeIfNecessary(session)
-    }
-
-    /**
-     * Create a new [com.sympauthy.business.model.user.User] or associate to an existing [com.sympauthy.business.model.user.User].
-     * Then update the provider user info with the newly collected [providerUserInfo].
-     *
-     * Depending on ```auth.user-merging-enabled```, we may instead associate the [providerUserInfo] to
-     * an existing user based on the configured identifier claims.
-     */
-    @Transactional
-    open suspend fun createOrAssociateUserWithProviderUserInfo(
-        provider: EnabledProvider,
-        providerUserInfo: RawProviderClaims
-    ): CreateOrAssociateResult {
-        val authConfig = uncheckedAuthConfig.orThrow()
-        val identifierClaims = resolveIdentifierClaims(authConfig, provider, providerUserInfo)
-        return if (authConfig.userMergingEnabled) {
-            createOrAssociateUserByIdentifierClaimsWithProviderUserInfo(identifierClaims, provider, providerUserInfo)
-        } else {
-            createUserWithProviderUserInfo(identifierClaims, provider, providerUserInfo)
-        }
-    }
-
-    /**
-     * Create a new [com.sympauthy.business.model.user.User] or associate it to an existing user
-     * that has matching values for all configured identifier claims.
-     *
-     * The identifier claim values are collected and copied as first-party data. We want this information
-     * to be stable and not be affected by changes from the third party in the future.
-     * Otherwise, an update from a provider may break our uniqueness and cause uncontrolled side effects.
-     */
-    @Transactional
-    internal open suspend fun createOrAssociateUserByIdentifierClaimsWithProviderUserInfo(
-        identifierClaims: Map<String, Pair<Claim, String>>,
-        provider: EnabledProvider,
-        providerUserInfo: RawProviderClaims
-    ): CreateOrAssociateResult {
-        val identifierMap = identifierClaims.map { (claimId, pair) -> claimId to pair.second }.toMap()
-        val existingUser = userManager.findByIdentifierClaims(identifierMap)
-
-        val user = existingUser ?: userManager.createUser().also { newUser ->
-            saveIdentifierClaims(newUser, identifierClaims)
-        }
-
-        providerClaimsManager.saveUserInfo(
-            provider = provider,
-            userId = user.id,
-            rawProviderClaims = providerUserInfo
-        )
-        return CreateOrAssociateResult(
-            created = existingUser == null,
-            user = user
-        )
-    }
-
-    /**
-     * Create a new [com.sympauthy.business.model.user.User] with the provider user info.
-     * Without user merging, if a user already exists with the same identifier claims, throw an error
-     * as the user must sign in with their existing account.
-     */
-    @Transactional
-    internal open suspend fun createUserWithProviderUserInfo(
-        identifierClaims: Map<String, Pair<Claim, String>>,
-        provider: EnabledProvider,
-        providerUserInfo: RawProviderClaims
-    ): CreateOrAssociateResult {
-        val identifierMap = identifierClaims.map { (claimId, pair) -> claimId to pair.second }.toMap()
-        val existingUser = userManager.findByIdentifierClaims(identifierMap)
-        if (existingUser != null) {
-            throw businessExceptionOf("user.create_with_provider.existing_user")
-        }
-
-        val user = userManager.createUser()
-        saveIdentifierClaims(user, identifierClaims)
-        providerClaimsManager.saveUserInfo(
-            provider = provider,
-            userId = user.id,
-            rawProviderClaims = providerUserInfo
-        )
-        return CreateOrAssociateResult(
-            created = true,
-            user = user
-        )
-    }
-
-    /**
-     * Extract identifier claim values from [providerUserInfo] and resolve the corresponding
-     * [Claim] business objects.
-     */
-    private suspend fun resolveIdentifierClaims(
-        authConfig: EnabledAuthConfig,
-        provider: EnabledProvider,
-        providerUserInfo: RawProviderClaims
-    ): Map<String, Pair<Claim, String>> {
-        return authConfig.identifierClaims.associateWith { claimId ->
-            val value = providerUserInfo.getClaimValueOrNull(claimId)
-                ?: throw businessExceptionOf(
-                    "user.create_with_provider.missing_identifier_claim",
-                    "providerId" to provider.id,
-                    "claim" to claimId
-                )
-            val claim = claimManager.findByIdOrNull(claimId)
-                ?: throw businessExceptionOf(
-                    "user.create_with_provider.missing_identifier_claim_config",
-                    "claim" to claimId
-                )
-            claim to value
-        }
-    }
-
-    private suspend fun saveIdentifierClaims(
-        user: User,
-        identifierClaims: Map<String, Pair<Claim, String>>
-    ) {
-        collectedClaimManager.update(
-            user = user,
-            updates = identifierClaims.map { (_, claimAndValue) ->
-                CollectedClaimUpdate(
-                    claim = claimAndValue.first,
-                    value = Optional.of(claimAndValue.second)
-                )
-            }
-        )
     }
 
     suspend fun fetchTokens(

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/ProviderUserEstablisher.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/ProviderUserEstablisher.kt
@@ -1,0 +1,40 @@
+package com.sympauthy.business.manager.flow
+
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.provider.EnabledProvider
+import com.sympauthy.business.model.user.RawProviderClaims
+import java.util.UUID
+
+/**
+ * Establishes (signs in or signs up) the end-user of an interactive flow from a third-party provider
+ * round-trip whose subject is not yet linked to any account.
+ *
+ * Creating or associating a user — enforcing sign-up rules, honoring `auth.user-merging-enabled` and the
+ * configured identifier claims, and consuming any invitation — is the OAuth2-authorize consumer's concern.
+ * The generic [InteractiveFlowSessionOAuth2ProviderManager] owns the provider protocol (authorize, callback,
+ * token exchange, claim resolution) and delegates this establish outcome here, so it stays free of
+ * consumer-specific identity logic. This is the same inversion as [InteractiveFlowPurposeHandler]: the
+ * generic layer owns the abstraction, the consumer (`business.manager.flow.auth`) implements it.
+ */
+interface ProviderUserEstablisher {
+
+    /**
+     * Establish the end-user of the [session] from the [rawUserInfo] just resolved from [provider], whose
+     * subject is not yet linked to any account. Returns the resulting user id and whether a new account was
+     * created (sign-up) versus an existing account associated (sign-in).
+     */
+    suspend fun establishNewProviderUser(
+        session: OnGoingInteractiveFlowSession,
+        provider: EnabledProvider,
+        rawUserInfo: RawProviderClaims
+    ): ProviderUserEstablishment
+}
+
+/**
+ * Outcome of [ProviderUserEstablisher.establishNewProviderUser]: the established [userId] and whether the
+ * account was created ([signedUp] `true`) rather than an existing one associated.
+ */
+data class ProviderUserEstablishment(
+    val userId: UUID,
+    val signedUp: Boolean
+)

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/auth/InteractiveAuthFlowSessionProviderEstablisher.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/auth/InteractiveAuthFlowSessionProviderEstablisher.kt
@@ -1,0 +1,184 @@
+package com.sympauthy.business.manager.flow.auth
+
+import com.sympauthy.business.exception.businessExceptionOf
+import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2Manager
+import com.sympauthy.business.manager.flow.ProviderUserEstablisher
+import com.sympauthy.business.manager.flow.ProviderUserEstablishment
+import com.sympauthy.business.manager.invitation.InvitationManager
+import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.manager.user.CollectedClaimManager
+import com.sympauthy.business.manager.user.CreateOrAssociateResult
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.provider.EnabledProvider
+import com.sympauthy.business.model.user.CollectedClaimUpdate
+import com.sympauthy.business.model.user.RawProviderClaims
+import com.sympauthy.business.model.user.User
+import com.sympauthy.business.model.user.claim.Claim
+import com.sympauthy.config.model.AuthConfig
+import com.sympauthy.config.model.EnabledAuthConfig
+import com.sympauthy.config.model.orThrow
+import io.micronaut.transaction.annotation.Transactional
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.util.*
+
+/**
+ * OAuth2-authorize consumer implementation of [ProviderUserEstablisher].
+ *
+ * Establishes the end-user from a provider round-trip during a sign-in / sign-up
+ * ([com.sympauthy.business.model.flow.InteractiveFlowPurpose.OAUTH2_AUTHORIZE]): it enforces the sign-up
+ * rules, creates or associates the [User] (honoring `auth.user-merging-enabled` and the configured
+ * identifier claims), and consumes any invitation. The generic
+ * [com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2ProviderManager] owns the provider
+ * protocol and delegates this outcome here.
+ */
+@Singleton
+open class InteractiveAuthFlowSessionProviderEstablisher(
+    @Inject private val oauth2Manager: InteractiveFlowSessionOAuth2Manager,
+    @Inject private val interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager,
+    @Inject private val invitationManager: InvitationManager,
+    @Inject private val userManager: UserManager,
+    @Inject private val providerClaimsManager: ProviderClaimsManager,
+    @Inject private val collectedClaimManager: CollectedClaimManager,
+    @Inject private val claimManager: ClaimManager,
+    @Inject private val uncheckedAuthConfig: AuthConfig,
+) : ProviderUserEstablisher {
+
+    override suspend fun establishNewProviderUser(
+        session: OnGoingInteractiveFlowSession,
+        provider: EnabledProvider,
+        rawUserInfo: RawProviderClaims
+    ): ProviderUserEstablishment {
+        val oauth2 = oauth2Manager.fetchOAuth2(session)
+        interactiveAuthFlowSessionManager.checkSignUpAllowed(oauth2, recoverable = false)
+        val result = createOrAssociateUserWithProviderUserInfo(provider, rawUserInfo)
+        invitationManager.applyInvitationClaimsAndConsume(oauth2.invitationId, result.user.id)
+        // `created` is false when the provider was merged into an existing account (sign-in, not sign-up).
+        return ProviderUserEstablishment(userId = result.user.id, signedUp = result.created)
+    }
+
+    /**
+     * Create a new [User] or associate the provider to an existing [User]. Then update the provider user
+     * info with the newly collected [providerUserInfo].
+     *
+     * Depending on ```auth.user-merging-enabled```, we may instead associate the [providerUserInfo] to
+     * an existing user based on the configured identifier claims.
+     */
+    @Transactional
+    open suspend fun createOrAssociateUserWithProviderUserInfo(
+        provider: EnabledProvider,
+        providerUserInfo: RawProviderClaims
+    ): CreateOrAssociateResult {
+        val authConfig = uncheckedAuthConfig.orThrow()
+        val identifierClaims = resolveIdentifierClaims(authConfig, provider, providerUserInfo)
+        return if (authConfig.userMergingEnabled) {
+            createOrAssociateUserByIdentifierClaimsWithProviderUserInfo(identifierClaims, provider, providerUserInfo)
+        } else {
+            createUserWithProviderUserInfo(identifierClaims, provider, providerUserInfo)
+        }
+    }
+
+    /**
+     * Create a new [User] or associate it to an existing user that has matching values for all configured
+     * identifier claims.
+     *
+     * The identifier claim values are collected and copied as first-party data. We want this information
+     * to be stable and not be affected by changes from the third party in the future.
+     * Otherwise, an update from a provider may break our uniqueness and cause uncontrolled side effects.
+     */
+    @Transactional
+    internal open suspend fun createOrAssociateUserByIdentifierClaimsWithProviderUserInfo(
+        identifierClaims: Map<String, Pair<Claim, String>>,
+        provider: EnabledProvider,
+        providerUserInfo: RawProviderClaims
+    ): CreateOrAssociateResult {
+        val identifierMap = identifierClaims.map { (claimId, pair) -> claimId to pair.second }.toMap()
+        val existingUser = userManager.findByIdentifierClaims(identifierMap)
+
+        val user = existingUser ?: userManager.createUser().also { newUser ->
+            saveIdentifierClaims(newUser, identifierClaims)
+        }
+
+        providerClaimsManager.saveUserInfo(
+            provider = provider,
+            userId = user.id,
+            rawProviderClaims = providerUserInfo
+        )
+        return CreateOrAssociateResult(
+            created = existingUser == null,
+            user = user
+        )
+    }
+
+    /**
+     * Create a new [User] with the provider user info.
+     * Without user merging, if a user already exists with the same identifier claims, throw an error
+     * as the user must sign in with their existing account.
+     */
+    @Transactional
+    internal open suspend fun createUserWithProviderUserInfo(
+        identifierClaims: Map<String, Pair<Claim, String>>,
+        provider: EnabledProvider,
+        providerUserInfo: RawProviderClaims
+    ): CreateOrAssociateResult {
+        val identifierMap = identifierClaims.map { (claimId, pair) -> claimId to pair.second }.toMap()
+        val existingUser = userManager.findByIdentifierClaims(identifierMap)
+        if (existingUser != null) {
+            throw businessExceptionOf("user.create_with_provider.existing_user")
+        }
+
+        val user = userManager.createUser()
+        saveIdentifierClaims(user, identifierClaims)
+        providerClaimsManager.saveUserInfo(
+            provider = provider,
+            userId = user.id,
+            rawProviderClaims = providerUserInfo
+        )
+        return CreateOrAssociateResult(
+            created = true,
+            user = user
+        )
+    }
+
+    /**
+     * Extract identifier claim values from [providerUserInfo] and resolve the corresponding
+     * [Claim] business objects.
+     */
+    private suspend fun resolveIdentifierClaims(
+        authConfig: EnabledAuthConfig,
+        provider: EnabledProvider,
+        providerUserInfo: RawProviderClaims
+    ): Map<String, Pair<Claim, String>> {
+        return authConfig.identifierClaims.associateWith { claimId ->
+            val value = providerUserInfo.getClaimValueOrNull(claimId)
+                ?: throw businessExceptionOf(
+                    "user.create_with_provider.missing_identifier_claim",
+                    "providerId" to provider.id,
+                    "claim" to claimId
+                )
+            val claim = claimManager.findByIdOrNull(claimId)
+                ?: throw businessExceptionOf(
+                    "user.create_with_provider.missing_identifier_claim_config",
+                    "claim" to claimId
+                )
+            claim to value
+        }
+    }
+
+    private suspend fun saveIdentifierClaims(
+        user: User,
+        identifierClaims: Map<String, Pair<Claim, String>>
+    ) {
+        collectedClaimManager.update(
+            user = user,
+            updates = identifierClaims.map { (_, claimAndValue) ->
+                CollectedClaimUpdate(
+                    claim = claimAndValue.first,
+                    value = Optional.of(claimAndValue.second)
+                )
+            }
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/link/InteractiveFlowSessionLinkProviderManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/link/InteractiveFlowSessionLinkProviderManager.kt
@@ -1,0 +1,127 @@
+package com.sympauthy.business.manager.flow.link
+
+import com.sympauthy.business.exception.internalBusinessExceptionOf
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
+import com.sympauthy.business.mapper.InteractiveFlowSessionLinkProviderMapper
+import com.sympauthy.business.model.flow.AuthorizationFlow
+import com.sympauthy.business.model.flow.ConfirmActionType
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
+import com.sympauthy.business.model.flow.InteractiveFlowRedirectType
+import com.sympauthy.business.model.flow.InteractiveFlowSession
+import com.sympauthy.business.model.flow.InteractiveFlowSessionLinkProvider
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.data.model.InteractiveFlowSessionLinkProviderEntity
+import com.sympauthy.data.repository.InteractiveFlowSessionLinkProviderRepository
+import io.micronaut.transaction.annotation.Transactional
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.net.URI
+import java.util.*
+
+/**
+ * Manager owning the [InteractiveFlowPurpose.LINK_PROVIDER] purpose end to end. It provides methods to:
+ * - fetch / store the link intent (the target provider) attached to a session.
+ * - start a standalone [InteractiveFlowPurpose.LINK_PROVIDER] session for an already-identified user
+ *   (client- or admin-initiated provider linking).
+ *
+ * The fetch / store methods are deliberately thin (repository + mapper only) so the purpose handler can inject
+ * this manager without introducing a dependency cycle through the flow engine.
+ */
+@Singleton
+open class InteractiveFlowSessionLinkProviderManager(
+    @Inject private val sessionManager: InteractiveFlowSessionManager,
+    @Inject private val confirmManager: InteractiveFlowSessionConfirmManager,
+    @Inject private val linkProviderRepository: InteractiveFlowSessionLinkProviderRepository,
+    @Inject private val linkProviderMapper: InteractiveFlowSessionLinkProviderMapper,
+) {
+
+    /**
+     * Return the [InteractiveFlowSessionLinkProvider] intent attached to the [session], or null if the session
+     * carries no link-provider purpose.
+     */
+    suspend fun fetchLinkProviderOrNull(session: InteractiveFlowSession): InteractiveFlowSessionLinkProvider? {
+        return linkProviderRepository.findBySessionId(session.id)
+            ?.let(linkProviderMapper::toInteractiveFlowSessionLinkProvider)
+    }
+
+    /**
+     * Store (upsert) the target [providerId] to link on the [session]'s link-provider record.
+     */
+    suspend fun setLinkProvider(
+        session: OnGoingInteractiveFlowSession,
+        providerId: String
+    ): InteractiveFlowSessionLinkProvider {
+        val entity = InteractiveFlowSessionLinkProviderEntity(
+            sessionId = session.id,
+            providerId = providerId
+        )
+        if (linkProviderRepository.findBySessionId(session.id) != null) {
+            linkProviderRepository.update(entity)
+        } else {
+            linkProviderRepository.save(entity)
+        }
+        return linkProviderMapper.toInteractiveFlowSessionLinkProvider(entity)
+    }
+
+    /**
+     * Start a [InteractiveFlowPurpose.LINK_PROVIDER] session for the already-identified [userId] to link the
+     * provider [providerId] to their account, returning the end-user to [returnUri] on success (or [cancelUri]
+     * on cancellation, as a [InteractiveFlowRedirectType.PLAIN] redirect), in a single transaction.
+     *
+     * The action is initiated on the end-user's behalf — by a client, or by an administrator when
+     * [initiatingClientId] is null — so the session is gated by a prepended [InteractiveFlowPurpose.CONFIRM]
+     * step whose parameter (including [initiatingClientId]) is stored on the confirm record. The session runs
+     * the ordered purposes `[CONFIRM, REAUTHENTICATION, LINK_PROVIDER]`.
+     *
+     * The [InteractiveFlowPurpose.REAUTHENTICATION] gate is a deliberate, security-load-bearing choice —
+     * **do not remove it**:
+     *
+     * Linking a provider mints a **durable login credential** on the account (unlike MFA enrollment, which only
+     * adds a factor). The caller merely *names* the end-user — a client through their access token, or an
+     * administrator through the user id — which authorizes the caller to act for that user but proves nothing
+     * about who is driving the browser that completes the link. A client-presented token cannot stand in for
+     * that proof: it is presented server-side, its `iat` is token-issuance (not an `auth_time`) and is
+     * refresh-forgeable, and there is no end-user browser session to measure freshness against. Without an
+     * interactive re-authentication bound to the fixed [OnGoingInteractiveFlowSession.userId], anyone able to
+     * drive the browser (a stolen token, a shared device, a compromised client) could attach a provider they
+     * control and take over the account. Re-authentication is the only proof that the browser user genuinely
+     * owns the account; it *confirms* the pre-set user and must never *establish* a different one.
+     *
+     * See #294 (this flow) and #295 (the REAUTHENTICATION purpose) for the full rationale.
+     *
+     * The [returnUri] and [cancelUri] must have been validated (e.g. against the named client's registered
+     * redirect URIs) by the caller before reaching here.
+     */
+    @Transactional
+    open suspend fun startLinkProviderSession(
+        userId: UUID,
+        providerId: String,
+        returnUri: URI,
+        flow: AuthorizationFlow,
+        initiatingClientId: String?,
+        cancelUri: URI? = null,
+    ): OnGoingInteractiveFlowSession {
+        val session = sessionManager.newSession(
+            purposes = listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.LINK_PROVIDER,
+            ),
+            initiatingPurpose = InteractiveFlowPurpose.LINK_PROVIDER,
+            flow = flow,
+            successRedirectUri = returnUri,
+            redirectType = InteractiveFlowRedirectType.PLAIN,
+            cancelRedirectUri = cancelUri,
+        ) as? OnGoingInteractiveFlowSession
+            ?: throw internalBusinessExceptionOf("flow.link_provider.start.not_ongoing")
+        val sessionWithUser = sessionManager.setAuthenticatedUserId(session, userId)
+        confirmManager.setConfirm(
+            session = sessionWithUser,
+            action = ConfirmActionType.LINK_PROVIDER,
+            clientId = initiatingClientId
+        )
+        setLinkProvider(sessionWithUser, providerId)
+        return sessionWithUser
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/link/LinkProviderInteractiveFlowPurposeHandler.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/link/LinkProviderInteractiveFlowPurposeHandler.kt
@@ -1,0 +1,38 @@
+package com.sympauthy.business.manager.flow.link
+
+import com.sympauthy.business.manager.flow.InteractiveFlowPurposeHandler
+import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * [InteractiveFlowPurposeHandler] for [InteractiveFlowPurpose.LINK_PROVIDER].
+ *
+ * Drives the end-user to authorize with the target provider (its id is on the session's link-provider record)
+ * so it can be linked to the session's already-fixed [OnGoingInteractiveFlowSession.userId]. The purpose is
+ * resolved once the durable link exists — i.e. the target provider is linked to the session user.
+ *
+ * The link itself is created in the provider callback
+ * ([com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2ProviderManager.signInOrSignUpUsingProvider]),
+ * next to claim resolution and behind the conflict checks — mirroring how the re-authentication gate confirms
+ * in the callback (the resolved provider claims exist only there). This handler stays pure: it only reads the
+ * durable link state, and has no terminal effect.
+ */
+@Singleton
+class LinkProviderInteractiveFlowPurposeHandler(
+    @Inject private val linkProviderManager: InteractiveFlowSessionLinkProviderManager,
+    @Inject private val providerClaimsManager: ProviderClaimsManager,
+) : InteractiveFlowPurposeHandler {
+
+    override val purpose = InteractiveFlowPurpose.LINK_PROVIDER
+
+    override suspend fun nextStepOrNull(session: OnGoingInteractiveFlowSession): InteractiveFlowStep? {
+        val providerId = linkProviderManager.fetchLinkProviderOrNull(session)?.providerId ?: return null
+        val userId = session.userId ?: return null
+        val alreadyLinked = providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, providerId) != null
+        return if (alreadyLinked) null else InteractiveFlowStep.AuthorizeProvider(providerId)
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManager.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManager.kt
@@ -118,6 +118,7 @@ open class InteractiveFlowSessionMfaEnrollmentManager(
     ): OnGoingInteractiveFlowSession {
         val session = sessionManager.newSession(
             purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
             flow = flow,
             successRedirectUri = returnUri,
             redirectType = InteractiveFlowRedirectType.PLAIN,

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/BusinessMapperFactory.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/BusinessMapperFactory.kt
@@ -76,4 +76,8 @@ class BusinessMapperFactory {
     @Singleton
     fun interactiveFlowSessionReauthenticationMapper() =
         Mappers.getMapper(InteractiveFlowSessionReauthenticationMapper::class.java)
+
+    @Singleton
+    fun interactiveFlowSessionLinkProviderMapper() =
+        Mappers.getMapper(InteractiveFlowSessionLinkProviderMapper::class.java)
 }

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionLinkProviderMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionLinkProviderMapper.kt
@@ -1,0 +1,25 @@
+package com.sympauthy.business.mapper
+
+import com.sympauthy.business.mapper.config.ToBusinessMapperConfig
+import com.sympauthy.business.model.flow.InteractiveFlowSessionLinkProvider
+import com.sympauthy.data.model.InteractiveFlowSessionLinkProviderEntity
+import org.mapstruct.Mapper
+
+/**
+ * Handle the mapping from the [InteractiveFlowSessionLinkProviderEntity] to the
+ * [InteractiveFlowSessionLinkProvider] business model.
+ */
+@Mapper(
+    config = ToBusinessMapperConfig::class
+)
+abstract class InteractiveFlowSessionLinkProviderMapper {
+
+    fun toInteractiveFlowSessionLinkProvider(
+        entity: InteractiveFlowSessionLinkProviderEntity
+    ): InteractiveFlowSessionLinkProvider {
+        return InteractiveFlowSessionLinkProvider(
+            sessionId = entity.sessionId,
+            providerId = entity.providerId,
+        )
+    }
+}

--- a/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapper.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapper.kt
@@ -32,6 +32,7 @@ abstract class InteractiveFlowSessionMapper {
         return OnGoingInteractiveFlowSession(
             id = entity.id ?: throw invalidBusinessException("id"),
             purposes = entity.purposes.map(InteractiveFlowPurpose::valueOf),
+            initiatingPurpose = InteractiveFlowPurpose.valueOf(entity.initiatingPurpose),
             flowId = entity.flowId,
             expirationDate = entity.expirationDate,
             sessionDate = entity.sessionDate,
@@ -49,6 +50,7 @@ abstract class InteractiveFlowSessionMapper {
         return CompletedInteractiveFlowSession(
             id = entity.id ?: throw invalidBusinessException("id"),
             purposes = entity.purposes.map(InteractiveFlowPurpose::valueOf),
+            initiatingPurpose = InteractiveFlowPurpose.valueOf(entity.initiatingPurpose),
             flowId = entity.flowId,
             expirationDate = entity.expirationDate,
             sessionDate = entity.sessionDate,
@@ -69,6 +71,7 @@ abstract class InteractiveFlowSessionMapper {
         return CancelledInteractiveFlowSession(
             id = entity.id ?: throw invalidBusinessException("id"),
             purposes = entity.purposes.map(InteractiveFlowPurpose::valueOf),
+            initiatingPurpose = InteractiveFlowPurpose.valueOf(entity.initiatingPurpose),
             flowId = entity.flowId,
             expirationDate = entity.expirationDate,
             userId = entity.userId,
@@ -84,6 +87,7 @@ abstract class InteractiveFlowSessionMapper {
         return FailedInteractiveFlowSession(
             id = entity.id ?: throw invalidBusinessException("id"),
             purposes = entity.purposes.map(InteractiveFlowPurpose::valueOf),
+            initiatingPurpose = InteractiveFlowPurpose.valueOf(entity.initiatingPurpose),
             flowId = entity.flowId,
             expirationDate = entity.expirationDate,
             errorDetailsId = entity.errorDetailsId ?: throw invalidBusinessException("errorDetailsId"),
@@ -97,6 +101,7 @@ abstract class InteractiveFlowSessionMapper {
         return FailedInteractiveFlowSession(
             id = entity.id ?: throw invalidBusinessException("id"),
             purposes = entity.purposes.map(InteractiveFlowPurpose::valueOf),
+            initiatingPurpose = InteractiveFlowPurpose.valueOf(entity.initiatingPurpose),
             flowId = entity.flowId,
             errorDetailsId = "auth.interactive_flow_session.validate.expired",
             errorDescriptionId = "description.oauth2.expired",

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/ConfirmActionType.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/ConfirmActionType.kt
@@ -12,5 +12,12 @@ enum class ConfirmActionType {
      * The end-user is asked to approve enrolling a multi-factor authentication method, initiated on their
      * behalf through a standalone MFA-enrollment endpoint by a client or by an administrator.
      */
-    ENROLL_MFA
+    ENROLL_MFA,
+
+    /**
+     * The end-user is asked to approve linking a third-party identity provider to their account, initiated on
+     * their behalf through a client or admin provider-link endpoint. They will be asked to re-authenticate
+     * before the link is created.
+     */
+    LINK_PROVIDER
 }

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowPurpose.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowPurpose.kt
@@ -48,5 +48,19 @@ enum class InteractiveFlowPurpose {
      * Prepended in front of a sensitive purpose by a consumer (e.g. provider-link); progress is tracked by the
      * session's attached re-authentication record ([InteractiveFlowSessionReauthentication]).
      */
-    REAUTHENTICATION
+    REAUTHENTICATION,
+
+    /**
+     * Link a third-party identity provider to the end-user's **already-fixed** account
+     * ([InteractiveFlowSession.userId] is set before this purpose runs). The end-user authorizes with the
+     * target provider — its id is stored on the session's attached link record
+     * ([InteractiveFlowSessionLinkProvider]) — and on the provider callback the resolved subject is linked to
+     * the fixed user, subject to hard-fail conflict checks (the subject, or an identifier claim, already owned
+     * by another account).
+     *
+     * Always gated by a [REAUTHENTICATION] step (and, for a client/admin-initiated link, driven behind a
+     * [CONFIRM] gate): linking a provider mints a durable login credential, so the browser must prove it
+     * genuinely owns the account before the link commits.
+     */
+    LINK_PROVIDER
 }

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSession.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSession.kt
@@ -35,23 +35,24 @@ sealed class InteractiveFlowSession(
     val purposes: List<InteractiveFlowPurpose>,
 
     /**
+     * The purpose that initiated the session and owns its terminal handoff.
+     *
+     * Set once when the session is created — the starter names the purpose it creates the session for — and
+     * carried for the whole life of the session. It is deliberately **stored** rather than derived from
+     * [purposes]: gate purposes ([InteractiveFlowPurpose.CONFIRM], [InteractiveFlowPurpose.REAUTHENTICATION])
+     * are prepended and second-factor purposes ([InteractiveFlowPurpose.MFA_CHALLENGE]) are inserted at
+     * runtime, so no positional rule over [purposes] stays correct as the chain grows.
+     */
+    val initiatingPurpose: InteractiveFlowPurpose,
+
+    /**
      * The identifier of the interactive flow the user is going through.
      * null for non-interactive flows.
      */
     val flowId: String?,
 
     override val expirationDate: LocalDateTime
-) : Expirable {
-
-    /**
-     * The purpose that initiated the session and owns its terminal handoff.
-     *
-     * [InteractiveFlowPurpose.CONFIRM] is a gate prepended in front of the initiating purpose, so it is
-     * skipped here: the initiating purpose is the first non-[InteractiveFlowPurpose.CONFIRM] purpose.
-     */
-    val initiatingPurpose: InteractiveFlowPurpose
-        get() = purposes.first { it != InteractiveFlowPurpose.CONFIRM }
-}
+) : Expirable
 
 /**
  * Represents an interactive flow session that is ongoing.
@@ -59,6 +60,7 @@ sealed class InteractiveFlowSession(
 class OnGoingInteractiveFlowSession(
     id: UUID,
     purposes: List<InteractiveFlowPurpose>,
+    initiatingPurpose: InteractiveFlowPurpose,
     flowId: String?,
     expirationDate: LocalDateTime,
 
@@ -119,6 +121,7 @@ class OnGoingInteractiveFlowSession(
 ) : InteractiveFlowSession(
     id = id,
     purposes = purposes,
+    initiatingPurpose = initiatingPurpose,
     flowId = flowId,
     expirationDate = expirationDate
 ) {
@@ -136,6 +139,7 @@ class OnGoingInteractiveFlowSession(
     ) = OnGoingInteractiveFlowSession(
         id = this.id,
         purposes = purposes ?: this.purposes,
+        initiatingPurpose = this.initiatingPurpose,
         flowId = this.flowId,
         expirationDate = this.expirationDate,
         sessionDate = this.sessionDate,
@@ -158,6 +162,7 @@ class OnGoingInteractiveFlowSession(
 class CompletedInteractiveFlowSession(
     id: UUID,
     purposes: List<InteractiveFlowPurpose>,
+    initiatingPurpose: InteractiveFlowPurpose,
     flowId: String?,
     expirationDate: LocalDateTime,
 
@@ -213,6 +218,7 @@ class CompletedInteractiveFlowSession(
 ) : InteractiveFlowSession(
     id = id,
     purposes = purposes,
+    initiatingPurpose = initiatingPurpose,
     flowId = flowId,
     expirationDate = expirationDate
 )
@@ -223,6 +229,7 @@ class CompletedInteractiveFlowSession(
 class FailedInteractiveFlowSession(
     id: UUID,
     purposes: List<InteractiveFlowPurpose>,
+    initiatingPurpose: InteractiveFlowPurpose,
     flowId: String?,
     expirationDate: LocalDateTime,
 
@@ -250,6 +257,7 @@ class FailedInteractiveFlowSession(
 ) : InteractiveFlowSession(
     id = id,
     purposes = purposes,
+    initiatingPurpose = initiatingPurpose,
     flowId = flowId,
     expirationDate = expirationDate
 )
@@ -264,6 +272,7 @@ class FailedInteractiveFlowSession(
 class CancelledInteractiveFlowSession(
     id: UUID,
     purposes: List<InteractiveFlowPurpose>,
+    initiatingPurpose: InteractiveFlowPurpose,
     flowId: String?,
     expirationDate: LocalDateTime,
 
@@ -298,6 +307,7 @@ class CancelledInteractiveFlowSession(
 ) : InteractiveFlowSession(
     id = id,
     purposes = purposes,
+    initiatingPurpose = initiatingPurpose,
     flowId = flowId,
     expirationDate = expirationDate
 )

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionLinkProvider.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionLinkProvider.kt
@@ -1,0 +1,26 @@
+package com.sympauthy.business.model.flow
+
+import java.util.*
+
+/**
+ * The intent of an [InteractiveFlowPurpose.LINK_PROVIDER] purpose: which third-party identity provider is to
+ * be linked to the session's already-fixed [InteractiveFlowSession.userId], attached to an
+ * [InteractiveFlowSession].
+ *
+ * Keyed by [sessionId] and fetched via
+ * [com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager], never carried on the
+ * session itself. It holds only the *intent* (the target provider, set at session start); the transient
+ * provider-authorization state (provider id + OIDC nonce) lives in [InteractiveFlowSessionProvider], and the
+ * durable link, once created, in the provider user-info store.
+ */
+data class InteractiveFlowSessionLinkProvider(
+    /**
+     * Identifier of the [InteractiveFlowSession] this link intent is attached to.
+     */
+    val sessionId: UUID,
+
+    /**
+     * Identifier of the third-party identity provider to link to the session's user.
+     */
+    val providerId: String,
+)

--- a/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowStep.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/flow/InteractiveFlowStep.kt
@@ -28,6 +28,13 @@ sealed interface InteractiveFlowStep {
     data object Confirm : InteractiveFlowStep
 
     /**
+     * The end-user must authorize with the specific third-party identity provider [providerId] — used to link
+     * that provider to the session's fixed user. Unlike [SignIn], which presents a choice of methods, this
+     * drives the browser straight to the target provider's authorization endpoint.
+     */
+    data class AuthorizeProvider(val providerId: String) : InteractiveFlowStep
+
+    /**
      * The end-user must choose which multi-factor authentication method to enroll (and may skip when the
      * enrollment is optional). The selection page auto-redirects to the method's enrollment step when there is
      * a single method to enroll and no skip is offered.

--- a/server/src/main/kotlin/com/sympauthy/business/model/oauth2/BuiltInClientScope.kt
+++ b/server/src/main/kotlin/com/sympauthy/business/model/oauth2/BuiltInClientScope.kt
@@ -16,6 +16,7 @@ enum class BuiltInClientScope(
     USERS_CLAIMS_WRITE(BuiltInClientScopeId.USERS_CLAIMS_WRITE),
     USERS_MFA_READ(BuiltInClientScopeId.USERS_MFA_READ),
     USERS_MFA_WRITE(BuiltInClientScopeId.USERS_MFA_WRITE),
+    USERS_PROVIDERS_WRITE(BuiltInClientScopeId.USERS_PROVIDERS_WRITE),
     INVITATIONS_READ(BuiltInClientScopeId.INVITATIONS_READ),
     INVITATIONS_WRITE(BuiltInClientScopeId.INVITATIONS_WRITE);
 }
@@ -31,6 +32,7 @@ object BuiltInClientScopeId {
     const val USERS_CLAIMS_WRITE = "users:claims:write"
     const val USERS_MFA_READ = "users:mfa:read"
     const val USERS_MFA_WRITE = "users:mfa:write"
+    const val USERS_PROVIDERS_WRITE = "users:providers:write"
     const val INVITATIONS_READ = "invitations:read"
     const val INVITATIONS_WRITE = "invitations:write"
 }

--- a/server/src/main/kotlin/com/sympauthy/data/h2/repository/H2InteractiveFlowSessionLinkProviderRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/h2/repository/H2InteractiveFlowSessionLinkProviderRepository.kt
@@ -1,0 +1,12 @@
+package com.sympauthy.data.h2.repository
+
+import com.sympauthy.data.h2.DefaultDataSourceIsH2
+import com.sympauthy.data.repository.InteractiveFlowSessionLinkProviderRepository
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.model.query.builder.sql.Dialect.H2
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@Suppress("unused")
+@Requires(condition = DefaultDataSourceIsH2::class)
+@R2dbcRepository(dialect = H2)
+interface H2InteractiveFlowSessionLinkProviderRepository : InteractiveFlowSessionLinkProviderRepository

--- a/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionEntity.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionEntity.kt
@@ -14,6 +14,7 @@ import java.util.*
 class InteractiveFlowSessionEntity(
     // Session metadata
     val purposes: Array<String>,
+    val initiatingPurpose: String,
     val sessionDate: LocalDateTime,
     val flowId: String? = null,
     val expirationDate: LocalDateTime,

--- a/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionLinkProviderEntity.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/model/InteractiveFlowSessionLinkProviderEntity.kt
@@ -1,0 +1,14 @@
+package com.sympauthy.data.model
+
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.serde.annotation.Serdeable
+import java.util.*
+
+@Serdeable
+@MappedEntity("interactive_flow_session_link_provider")
+data class InteractiveFlowSessionLinkProviderEntity(
+    @get:Id
+    val sessionId: UUID,
+    val providerId: String,
+)

--- a/server/src/main/kotlin/com/sympauthy/data/postgresql/repository/PostgreSQLInteractiveFlowSessionLinkProviderRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/postgresql/repository/PostgreSQLInteractiveFlowSessionLinkProviderRepository.kt
@@ -1,0 +1,13 @@
+package com.sympauthy.data.postgresql.repository
+
+import com.sympauthy.data.postgresql.DefaultDataSourceIsPostgreSQL
+import com.sympauthy.data.repository.InteractiveFlowSessionLinkProviderRepository
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@Suppress("unused")
+@Requires(condition = DefaultDataSourceIsPostgreSQL::class)
+@R2dbcRepository(dialect = POSTGRES)
+interface PostgreSQLInteractiveFlowSessionLinkProviderRepository :
+    InteractiveFlowSessionLinkProviderRepository

--- a/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionLinkProviderRepository.kt
+++ b/server/src/main/kotlin/com/sympauthy/data/repository/InteractiveFlowSessionLinkProviderRepository.kt
@@ -1,0 +1,13 @@
+package com.sympauthy.data.repository
+
+import com.sympauthy.data.model.InteractiveFlowSessionLinkProviderEntity
+import io.micronaut.data.repository.kotlin.CoroutineCrudRepository
+import java.util.*
+
+interface InteractiveFlowSessionLinkProviderRepository :
+    CoroutineCrudRepository<InteractiveFlowSessionLinkProviderEntity, UUID> {
+
+    suspend fun findBySessionId(sessionId: UUID): InteractiveFlowSessionLinkProviderEntity?
+
+    suspend fun deleteBySessionIdIn(sessionIds: List<UUID>): Int
+}

--- a/server/src/main/kotlin/com/sympauthy/security/SecurityRule.kt
+++ b/server/src/main/kotlin/com/sympauthy/security/SecurityRule.kt
@@ -27,6 +27,7 @@ object SecurityRule {
     const val CLIENT_USERS_CLAIMS_WRITE = "SCOPE_${BuiltInClientScopeId.USERS_CLAIMS_WRITE}"
     const val CLIENT_USERS_MFA_READ = "SCOPE_${BuiltInClientScopeId.USERS_MFA_READ}"
     const val CLIENT_USERS_MFA_WRITE = "SCOPE_${BuiltInClientScopeId.USERS_MFA_WRITE}"
+    const val CLIENT_USERS_PROVIDERS_WRITE = "SCOPE_${BuiltInClientScopeId.USERS_PROVIDERS_WRITE}"
     const val CLIENT_INVITATIONS_READ = "SCOPE_${BuiltInClientScopeId.INVITATIONS_READ}"
     const val CLIENT_INVITATIONS_WRITE = "SCOPE_${BuiltInClientScopeId.INVITATIONS_WRITE}"
 }

--- a/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/com.sympauthy/server/reflect-config.json
@@ -161,6 +161,15 @@
     ]
   },
   {
+    "name": "com.sympauthy.business.mapper.InteractiveFlowSessionLinkProviderMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sympauthy.business.mapper.ConsentMapperImpl",
     "methods": [
       {

--- a/server/src/main/resources/databases/h2/V0_5_0_19__interactive_flow_session_link_provider_new.sql
+++ b/server/src/main/resources/databases/h2/V0_5_0_19__interactive_flow_session_link_provider_new.sql
@@ -1,0 +1,8 @@
+CREATE TABLE interactive_flow_session_link_provider
+(
+    session_id  uuid NOT NULL,
+    provider_id text NOT NULL,
+
+    PRIMARY KEY (session_id),
+    FOREIGN KEY (session_id) REFERENCES interactive_flow_sessions (id)
+);

--- a/server/src/main/resources/databases/h2/V0_5_0_5__interactive_flow_sessions_new.sql
+++ b/server/src/main/resources/databases/h2/V0_5_0_5__interactive_flow_sessions_new.sql
@@ -2,6 +2,7 @@ CREATE TABLE interactive_flow_sessions
 (
     id                   uuid      NOT NULL DEFAULT random_uuid(),
     purposes             text array NOT NULL,
+    initiating_purpose   text       NOT NULL,
     session_date         timestamp NOT NULL,
     flow_id              text,
     expiration_date      timestamp NOT NULL,

--- a/server/src/main/resources/databases/postgresql/V0_5_0_19__interactive_flow_session_link_provider_new.sql
+++ b/server/src/main/resources/databases/postgresql/V0_5_0_19__interactive_flow_session_link_provider_new.sql
@@ -1,0 +1,8 @@
+CREATE TABLE interactive_flow_session_link_provider
+(
+    session_id  uuid NOT NULL,
+    provider_id text NOT NULL,
+
+    PRIMARY KEY (session_id),
+    FOREIGN KEY (session_id) REFERENCES interactive_flow_sessions (id)
+);

--- a/server/src/main/resources/databases/postgresql/V0_5_0_5__interactive_flow_sessions_new.sql
+++ b/server/src/main/resources/databases/postgresql/V0_5_0_5__interactive_flow_sessions_new.sql
@@ -2,6 +2,7 @@ CREATE TABLE interactive_flow_sessions
 (
     id                   uuid      NOT NULL DEFAULT gen_random_uuid(),
     purposes             text[]    NOT NULL,
+    initiating_purpose   text      NOT NULL,
     session_date         timestamp NOT NULL,
     flow_id              text,
     expiration_date      timestamp NOT NULL,

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -330,5 +330,7 @@ client.mfa.enrollment.mfa_disabled=Multi-factor authentication is not enabled on
 description.client.mfa.enrollment.mfa_disabled=This authorization server is not configured to support multi-factor authentication, so an enrollment cannot be started. Please contact the support of the application to report this issue.
 client.mfa.enrollment.invalid_access_token=The provided end-user access token is invalid.
 description.client.mfa.enrollment.invalid_access_token=The access token identifying the end-user is missing, expired, revoked, not associated with an end-user, or was not issued to your client. Obtain a fresh access token for the end-user and try again.
+client.providers.link.invalid_access_token=The provided end-user access token is invalid.
+description.client.providers.link.invalid_access_token=The access token identifying the end-user is missing, expired, revoked, not associated with an end-user, or was not issued to your client. Obtain a fresh access token for the end-user and try again.
 admin.users.mfa.enrollment.mfa_disabled=Multi-factor authentication is not enabled on this authorization server.
 description.admin.users.mfa.enrollment.mfa_disabled=This authorization server is not configured to support multi-factor authentication, so an enrollment cannot be started.

--- a/server/src/main/resources/error_messages.properties
+++ b/server/src/main/resources/error_messages.properties
@@ -227,6 +227,13 @@ flow.reauthentication.no_method=No re-authentication method is available for thi
 description.flow.reauthentication.no_method=This account has no credential that can be used to prove ownership. Please contact the support of the application.
 flow.reauthentication.provider_not_linked=This provider is not linked to your account.
 description.flow.reauthentication.provider_not_linked=Please re-authenticate using a credential or a provider already associated with your account.
+
+flow.link_provider.start.not_ongoing=Failed to start the provider link: the session was not created in an ongoing state.
+flow.link_provider.missing_user=Failed to link the provider: the session has no associated user.
+flow.link_provider.wrong_provider=This is not the provider you were asked to link.
+description.flow.link_provider.wrong_provider=Please restart the operation from the application to link the intended provider.
+flow.link_provider.subject_conflict=This {providerId} account is already linked to another account and cannot be linked here.
+flow.link_provider.identifier_conflict=This {providerId} account matches an identity that already belongs to another account.
 flow.web.invalid_flow=The authorization flow {flowId} does not exist or does not support web-based authorization.
 flow.web_oauth2_provider.missing_code=The provider did not return a code in the callback.
 flow.web_oauth2_provider.provider_error=The provider returned an error: {error}. {errorDescription}

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderControllerTest.kt
@@ -3,8 +3,6 @@ package com.sympauthy.api.controller.admin
 import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
 import com.sympauthy.api.exception.LocalizedHttpException
 import com.sympauthy.api.resource.admin.AdminUserProviderLinkInputResource
-import com.sympauthy.business.exception.BusinessException
-import com.sympauthy.business.exception.businessExceptionOf
 import com.sympauthy.business.manager.ClientManager
 import com.sympauthy.business.manager.client.ClientRedirectUriManager
 import com.sympauthy.business.manager.flow.InteractiveFlowEngine
@@ -195,7 +193,8 @@ class AdminUserProviderControllerTest {
 
         coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
         coEvery { clientManager.findClientByIdOrNull("client-id") } returns client
-        coEvery { providerManager.findByIdAndCheckEnabled("discord") } returns mockk<EnabledProvider>()
+        coEvery { providerManager.listEnabledProviders() } returns
+            listOf(mockk<EnabledProvider> { every { id } returns "discord" })
         every {
             clientRedirectUriManager.parseRequestedRedirectUri(client, "https://client.example.com/linked", recoverable = true)
         } returns returnUri
@@ -259,14 +258,14 @@ class AdminUserProviderControllerTest {
     }
 
     @Test
-    fun `startLink - Fails and starts no session for an unknown provider`() = runTest {
+    fun `startLink - Returns 404 and starts no session for an unknown provider`() = runTest {
         val client = mockk<Client>()
         coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
         coEvery { clientManager.findClientByIdOrNull("client-id") } returns client
-        coEvery { providerManager.findByIdAndCheckEnabled("bad-provider") } throws
-            businessExceptionOf("provider.missing", "providerId" to "bad-provider")
+        // No enabled provider matches the path id -> orNotFound() -> 404, coherent with unknown user/client.
+        coEvery { providerManager.listEnabledProviders() } returns emptyList()
 
-        val exception = assertThrows<BusinessException> {
+        val exception = assertThrows<LocalizedHttpException> {
             controller.startLink(
                 userId,
                 "bad-provider",
@@ -274,7 +273,7 @@ class AdminUserProviderControllerTest {
             )
         }
 
-        assertEquals("provider.missing", exception.detailsId)
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
         coVerify(exactly = 0) {
             linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
         }

--- a/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/admin/AdminUserProviderControllerTest.kt
@@ -1,14 +1,33 @@
 package com.sympauthy.api.controller.admin
 
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
 import com.sympauthy.api.exception.LocalizedHttpException
+import com.sympauthy.api.resource.admin.AdminUserProviderLinkInputResource
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.exception.businessExceptionOf
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.client.ClientRedirectUriManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager
 import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.manager.provider.ProviderManager
 import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.client.Client
+import com.sympauthy.business.model.flow.InteractiveFlow
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.InteractiveFlowStepResult
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.provider.EnabledProvider
 import com.sympauthy.business.model.provider.ProviderUserInfo
 import com.sympauthy.business.model.user.RawProviderClaims
 import com.sympauthy.business.model.user.User
 import io.micronaut.http.HttpStatus
+import java.net.URI
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -30,6 +49,27 @@ class AdminUserProviderControllerTest {
 
     @MockK
     lateinit var providerClaimsManager: ProviderClaimsManager
+
+    @MockK
+    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
+
+    @MockK
+    lateinit var clientRedirectUriManager: ClientRedirectUriManager
+
+    @MockK
+    lateinit var clientManager: ClientManager
+
+    @MockK
+    lateinit var providerManager: ProviderManager
+
+    @MockK
+    lateinit var linkProviderManager: InteractiveFlowSessionLinkProviderManager
+
+    @MockK
+    lateinit var engine: InteractiveFlowEngine
+
+    @MockK
+    lateinit var stepUriMapper: InteractiveFlowStepUriMapper
 
     @InjectMockKs
     lateinit var controller: AdminUserProviderController
@@ -142,5 +182,101 @@ class AdminUserProviderControllerTest {
         }
 
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
+    }
+
+    @Test
+    fun `startLink - Validates user, client, provider and URI, starts an admin-initiated link session`() = runTest {
+        val client = mockk<Client>()
+        val returnUri = URI.create("https://client.example.com/linked")
+        val flow = mockk<InteractiveFlow>()
+        val session = mockk<OnGoingInteractiveFlowSession>()
+        val steppedSession = mockk<OnGoingInteractiveFlowSession>()
+        val nextUri = URI.create("https://auth.example.com/flow/confirm?state=abc")
+
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { clientManager.findClientByIdOrNull("client-id") } returns client
+        coEvery { providerManager.findByIdAndCheckEnabled("discord") } returns mockk<EnabledProvider>()
+        every {
+            clientRedirectUriManager.parseRequestedRedirectUri(client, "https://client.example.com/linked", recoverable = true)
+        } returns returnUri
+        coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
+        // Admin-initiated: initiatingClientId must be null (confirmation shows "an administrator").
+        coEvery {
+            linkProviderManager.startLinkProviderSession(userId, "discord", returnUri, flow, null, null)
+        } returns session
+        coEvery { engine.advance(session) } returns
+            InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.Confirm)
+        coEvery { stepUriMapper.toRedirectUri(steppedSession, flow, InteractiveFlowStep.Confirm) } returns nextUri
+
+        val result = controller.startLink(
+            userId,
+            "discord",
+            AdminUserProviderLinkInputResource(
+                clientId = "client-id",
+                returnUri = "https://client.example.com/linked"
+            )
+        )
+
+        assertEquals(nextUri.toString(), result.redirectUrl)
+        coVerify { linkProviderManager.startLinkProviderSession(userId, "discord", returnUri, flow, null, null) }
+    }
+
+    @Test
+    fun `startLink - Returns 404 when the user is not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.startLink(
+                userId,
+                "discord",
+                AdminUserProviderLinkInputResource(clientId = "client-id", returnUri = "https://client.example.com/linked")
+            )
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+        coVerify(exactly = 0) {
+            linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `startLink - Returns 404 when the named client is not found`() = runTest {
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { clientManager.findClientByIdOrNull("missing-client") } returns null
+
+        val exception = assertThrows<LocalizedHttpException> {
+            controller.startLink(
+                userId,
+                "discord",
+                AdminUserProviderLinkInputResource(clientId = "missing-client", returnUri = "https://client.example.com/linked")
+            )
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
+        coVerify(exactly = 0) {
+            linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `startLink - Fails and starts no session for an unknown provider`() = runTest {
+        val client = mockk<Client>()
+        coEvery { userManager.findByIdOrNull(userId) } returns mockk<User>()
+        coEvery { clientManager.findClientByIdOrNull("client-id") } returns client
+        coEvery { providerManager.findByIdAndCheckEnabled("bad-provider") } throws
+            businessExceptionOf("provider.missing", "providerId" to "bad-provider")
+
+        val exception = assertThrows<BusinessException> {
+            controller.startLink(
+                userId,
+                "bad-provider",
+                AdminUserProviderLinkInputResource(clientId = "client-id", returnUri = "https://client.example.com/linked")
+            )
+        }
+
+        assertEquals("provider.missing", exception.detailsId)
+        coVerify(exactly = 0) {
+            linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
+        }
     }
 }

--- a/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkControllerTest.kt
@@ -1,0 +1,171 @@
+package com.sympauthy.api.controller.client
+
+import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.api.resource.client.ClientProviderLinkInputResource
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.exception.businessExceptionOf
+import com.sympauthy.business.manager.ClientManager
+import com.sympauthy.business.manager.auth.oauth2.TokenManager
+import com.sympauthy.business.manager.client.ClientRedirectUriManager
+import com.sympauthy.business.manager.flow.InteractiveFlowEngine
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.auth.InteractiveAuthFlowSessionManager
+import com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager
+import com.sympauthy.business.manager.provider.ProviderManager
+import com.sympauthy.business.model.client.Client
+import com.sympauthy.business.model.flow.InteractiveFlow
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.InteractiveFlowStepResult
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.oauth2.AuthenticationToken
+import com.sympauthy.business.model.provider.EnabledProvider
+import com.sympauthy.security.ClientAuthentication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class ClientProviderLinkControllerTest {
+
+    @MockK
+    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
+
+    @MockK
+    lateinit var clientRedirectUriManager: ClientRedirectUriManager
+
+    @MockK
+    lateinit var clientManager: ClientManager
+
+    @MockK
+    lateinit var tokenManager: TokenManager
+
+    @MockK
+    lateinit var providerManager: ProviderManager
+
+    @MockK
+    lateinit var linkProviderManager: InteractiveFlowSessionLinkProviderManager
+
+    @MockK
+    lateinit var engine: InteractiveFlowEngine
+
+    @MockK
+    lateinit var stepUriMapper: InteractiveFlowStepUriMapper
+
+    @MockK
+    lateinit var sessionManager: InteractiveFlowSessionManager
+
+    @InjectMockKs
+    lateinit var controller: ClientProviderLinkController
+
+    private fun clientAuthentication(clientId: String): ClientAuthentication {
+        val authenticationToken = mockk<AuthenticationToken> {
+            every { this@mockk.clientId } returns clientId
+        }
+        return ClientAuthentication(authenticationToken, emptyList())
+    }
+
+    @Test
+    fun `startLink - Validates token, provider and return URI, starts the session, returns state and redirect URL`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val authentication = clientAuthentication("client-id")
+            val client = mockk<Client> { every { id } returns "client-id" }
+            val userToken = mockk<AuthenticationToken> { every { this@mockk.userId } returns userId }
+            val returnUri = URI.create("https://client.example.com/linked")
+            val flow = mockk<InteractiveFlow>()
+            val session = mockk<OnGoingInteractiveFlowSession>()
+            val steppedSession = mockk<OnGoingInteractiveFlowSession>()
+            val nextUri = URI.create("https://auth.example.com/flow/confirm?state=abc")
+
+            coEvery { clientManager.findClientById("client-id") } returns client
+            coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
+            coEvery { providerManager.findByIdAndCheckEnabled("discord") } returns mockk<EnabledProvider>()
+            every {
+                clientRedirectUriManager.parseRequestedRedirectUri(client, "https://client.example.com/linked", recoverable = true)
+            } returns returnUri
+            coEvery { interactiveAuthFlowSessionManager.getDefaultInteractiveFlow() } returns flow
+            coEvery {
+                linkProviderManager.startLinkProviderSession(userId, "discord", returnUri, flow, "client-id", null)
+            } returns session
+            coEvery { engine.advance(session) } returns
+                InteractiveFlowStepResult(steppedSession, InteractiveFlowStep.Confirm)
+            coEvery { stepUriMapper.toRedirectUri(steppedSession, flow, InteractiveFlowStep.Confirm) } returns nextUri
+            coEvery { sessionManager.encodeState(steppedSession) } returns "encoded-state"
+
+            val result = controller.startLink(
+                authentication,
+                "discord",
+                ClientProviderLinkInputResource(
+                    accessToken = "user-access-token",
+                    returnUri = "https://client.example.com/linked"
+                )
+            )
+
+            assertEquals("encoded-state", result.state)
+            assertEquals(nextUri.toString(), result.redirectUrl)
+        }
+
+    @Test
+    fun `startLink - Fails with invalid_access_token when the token is not bound to an end-user`() = runTest {
+        val authentication = clientAuthentication("client-id")
+        val client = mockk<Client>()
+        val clientOnlyToken = mockk<AuthenticationToken> { every { userId } returns null }
+        coEvery { clientManager.findClientById("client-id") } returns client
+        coEvery { tokenManager.introspectToken(client, "client-token", "access_token") } returns clientOnlyToken
+
+        val exception = assertThrows<BusinessException> {
+            controller.startLink(
+                authentication,
+                "discord",
+                ClientProviderLinkInputResource(
+                    accessToken = "client-token",
+                    returnUri = "https://client.example.com/linked"
+                )
+            )
+        }
+
+        assertEquals("client.providers.link.invalid_access_token", exception.detailsId)
+        coVerify(exactly = 0) {
+            linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `startLink - Fails and starts no session for an unknown provider`() = runTest {
+        val userId = UUID.randomUUID()
+        val authentication = clientAuthentication("client-id")
+        val client = mockk<Client>()
+        val userToken = mockk<AuthenticationToken> { every { this@mockk.userId } returns userId }
+        coEvery { clientManager.findClientById("client-id") } returns client
+        coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
+        coEvery { providerManager.findByIdAndCheckEnabled("bad-provider") } throws
+            businessExceptionOf("provider.missing", "providerId" to "bad-provider")
+
+        val exception = assertThrows<BusinessException> {
+            controller.startLink(
+                authentication,
+                "bad-provider",
+                ClientProviderLinkInputResource(
+                    accessToken = "user-access-token",
+                    returnUri = "https://client.example.com/linked"
+                )
+            )
+        }
+
+        assertEquals("provider.missing", exception.detailsId)
+        coVerify(exactly = 0) {
+            linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
+        }
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/client/ClientProviderLinkControllerTest.kt
@@ -1,9 +1,9 @@
 package com.sympauthy.api.controller.client
 
 import com.sympauthy.api.controller.flow.InteractiveFlowStepUriMapper
+import com.sympauthy.api.exception.LocalizedHttpException
 import com.sympauthy.api.resource.client.ClientProviderLinkInputResource
 import com.sympauthy.business.exception.BusinessException
-import com.sympauthy.business.exception.businessExceptionOf
 import com.sympauthy.business.manager.ClientManager
 import com.sympauthy.business.manager.auth.oauth2.TokenManager
 import com.sympauthy.business.manager.client.ClientRedirectUriManager
@@ -20,6 +20,7 @@ import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.oauth2.AuthenticationToken
 import com.sympauthy.business.model.provider.EnabledProvider
 import com.sympauthy.security.ClientAuthentication
+import io.micronaut.http.HttpStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -90,7 +91,8 @@ class ClientProviderLinkControllerTest {
 
             coEvery { clientManager.findClientById("client-id") } returns client
             coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
-            coEvery { providerManager.findByIdAndCheckEnabled("discord") } returns mockk<EnabledProvider>()
+            coEvery { providerManager.listEnabledProviders() } returns
+                listOf(mockk<EnabledProvider> { every { id } returns "discord" })
             every {
                 clientRedirectUriManager.parseRequestedRedirectUri(client, "https://client.example.com/linked", recoverable = true)
             } returns returnUri
@@ -142,17 +144,17 @@ class ClientProviderLinkControllerTest {
     }
 
     @Test
-    fun `startLink - Fails and starts no session for an unknown provider`() = runTest {
+    fun `startLink - Returns 404 and starts no session for an unknown provider`() = runTest {
         val userId = UUID.randomUUID()
         val authentication = clientAuthentication("client-id")
         val client = mockk<Client>()
         val userToken = mockk<AuthenticationToken> { every { this@mockk.userId } returns userId }
         coEvery { clientManager.findClientById("client-id") } returns client
         coEvery { tokenManager.introspectToken(client, "user-access-token", "access_token") } returns userToken
-        coEvery { providerManager.findByIdAndCheckEnabled("bad-provider") } throws
-            businessExceptionOf("provider.missing", "providerId" to "bad-provider")
+        // No enabled provider matches the path id -> orNotFound() -> 404, coherent with unknown user/client.
+        coEvery { providerManager.listEnabledProviders() } returns emptyList()
 
-        val exception = assertThrows<BusinessException> {
+        val exception = assertThrows<LocalizedHttpException> {
             controller.startLink(
                 authentication,
                 "bad-provider",
@@ -163,7 +165,7 @@ class ClientProviderLinkControllerTest {
             )
         }
 
-        assertEquals("provider.missing", exception.detailsId)
+        assertEquals(HttpStatus.NOT_FOUND, exception.status)
         coVerify(exactly = 0) {
             linkProviderManager.startLinkProviderSession(any(), any(), any(), any(), any(), any())
         }

--- a/server/src/test/kotlin/com/sympauthy/api/controller/flow/ConfirmControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/flow/ConfirmControllerTest.kt
@@ -6,6 +6,7 @@ import com.sympauthy.api.resource.flow.SimpleFlowResource
 import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
 import com.sympauthy.business.model.flow.ConfirmActionType
 import com.sympauthy.business.model.flow.InteractiveFlow
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowSessionConfirm
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.security.StateAuthentication
@@ -17,8 +18,10 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
@@ -40,12 +43,49 @@ class ConfirmControllerTest {
     private val flow = mockk<InteractiveFlow>()
 
     @Test
-    fun `getConfirmation - Returns the action context while the confirmation is pending`() = runTest {
+    fun `getConfirmation - Returns the action context (no re-auth ahead) while the confirmation is pending`() =
+        runTest {
+            val confirm = mockk<InteractiveFlowSessionConfirm> {
+                every { confirmed } returns false
+                every { action } returns ConfirmActionType.ENROLL_MFA
+                every { clientId } returns "client-x"
+            }
+            every { session.purposes } returns
+                listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT)
+            every { session.completedPurposes } returns emptyList()
+            coEvery { confirmManager.fetchConfirmOrNull(session) } returns confirm
+            coEvery {
+                interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect<ConfirmFlowResource, ConfirmFlowResource>(
+                    eq("encoded-state"), any(), any(), any()
+                )
+            } coAnswers {
+                val run = arg<suspend (OnGoingInteractiveFlowSession, InteractiveFlow) -> ConfirmFlowResource?>(1)
+                val mapResultToResource = arg<suspend (ConfirmFlowResource) -> ConfirmFlowResource>(3)
+                mapResultToResource(run(session, flow)!!)
+            }
+
+            val result = controller.getConfirmation(StateAuthentication("encoded-state"))
+
+            assertEquals("ENROLL_MFA", result.action)
+            assertEquals("client-x", result.initiatingClientId)
+            // No REAUTHENTICATION purpose in the chain -> the UI is told no re-auth follows.
+            assertFalse(result.requiresReauthentication)
+            assertNull(result.redirectUrl)
+        }
+
+    @Test
+    fun `getConfirmation - Flags requires_reauthentication when a re-auth step is still ahead`() = runTest {
         val confirm = mockk<InteractiveFlowSessionConfirm> {
             every { confirmed } returns false
-            every { action } returns ConfirmActionType.ENROLL_MFA
-            every { clientId } returns "client-x"
+            every { action } returns ConfirmActionType.LINK_PROVIDER
+            every { clientId } returns null
         }
+        every { session.purposes } returns listOf(
+            InteractiveFlowPurpose.CONFIRM,
+            InteractiveFlowPurpose.REAUTHENTICATION,
+            InteractiveFlowPurpose.LINK_PROVIDER,
+        )
+        every { session.completedPurposes } returns emptyList()
         coEvery { confirmManager.fetchConfirmOrNull(session) } returns confirm
         coEvery {
             interactiveAuthFlowSessionControllerUtil.fetchOnGoingSessionThenRunAndRedirect<ConfirmFlowResource, ConfirmFlowResource>(
@@ -59,9 +99,10 @@ class ConfirmControllerTest {
 
         val result = controller.getConfirmation(StateAuthentication("encoded-state"))
 
-        assertEquals("ENROLL_MFA", result.action)
-        assertEquals("client-x", result.initiatingClientId)
-        assertNull(result.redirectUrl)
+        assertEquals("LINK_PROVIDER", result.action)
+        assertNull(result.initiatingClientId)
+        // An unresolved REAUTHENTICATION purpose is ahead -> warn the UI up front.
+        assertTrue(result.requiresReauthentication)
     }
 
     @Test

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/AuthorizationFlowManagerTest.kt
@@ -70,6 +70,7 @@ class AuthorizationFlowManagerTest {
         val failedSession = FailedInteractiveFlowSession(
             id = UUID.randomUUID(),
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             errorDetailsId = "some.error",
@@ -146,6 +147,7 @@ class AuthorizationFlowManagerTest {
         return OnGoingInteractiveFlowSession(
             id = UUID.randomUUID(),
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
@@ -160,6 +162,7 @@ class AuthorizationFlowManagerTest {
         return CompletedInteractiveFlowSession(
             id = UUID.randomUUID(),
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flowId = "flow-id",
             expirationDate = expirationDate,
             sessionDate = now,

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
@@ -144,8 +144,9 @@ class InteractiveFlowEngineTest {
     }
 
     @Test
-    fun `advance - Appends a follow-up purpose then visits it`() = runTest {
-        // The first purpose resolves and declares a follow-up; the engine appends it and the walk visits it.
+    fun `advance - Inserts a follow-up purpose right after the resolving one then visits it`() = runTest {
+        // The first purpose resolves and declares a follow-up; the engine inserts it right after and the walk
+        // visits it.
         val session = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
         val marked = onGoingSession(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE))
         val grown = onGoingSession(
@@ -161,7 +162,11 @@ class InteractiveFlowEngineTest {
         } returns marked
         coEvery { oauth2Handler.followUpPurposes(marked) } returns listOf(InteractiveFlowPurpose.MFA_CHALLENGE)
         coEvery {
-            sessionManager.appendPurpose(marked, InteractiveFlowPurpose.MFA_CHALLENGE)
+            sessionManager.insertPurposeAfter(
+                marked,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+                InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
+            )
         } returns grown
         coEvery { mfaHandler.nextStepOrNull(grown) } returns InteractiveFlowStep.MfaSelectionForChallenge
 
@@ -172,8 +177,82 @@ class InteractiveFlowEngineTest {
     }
 
     @Test
-    fun `advance - Does not re-append a follow-up purpose already present`() = runTest {
-        // The follow-up is already on the session, so no append happens; the walk moves on to it.
+    fun `advance - Inserts a follow-up right after a mid-list gate, ahead of the purpose it guards`() = runTest {
+        // REAUTHENTICATION is a *middle* gate: when it resolves and declares an MFA challenge, the engine must
+        // insert the challenge right after it (before the trailing sensitive purpose), not at the list end, so
+        // the guarded purpose (e.g. a provider link) can never run before the second factor. MFA_ENROLLMENT
+        // stands in here for the trailing sensitive purpose.
+        val session = onGoingSession(
+            listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            ),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
+        )
+        val afterConfirm = onGoingSession(
+            listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            ),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
+        )
+        val afterReauth = onGoingSession(
+            listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            ),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
+        )
+        val grown = onGoingSession(
+            listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            ),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
+        )
+        val confirmHandler = mockk<InteractiveFlowPurposeHandler>()
+        val reauthHandler = mockk<InteractiveFlowPurposeHandler>()
+        val mfaChallengeHandler = mockk<InteractiveFlowPurposeHandler>()
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.CONFIRM) } returns confirmHandler
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.REAUTHENTICATION) } returns reauthHandler
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.MFA_CHALLENGE) } returns mfaChallengeHandler
+        coEvery { confirmHandler.nextStepOrNull(session) } returns null
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.CONFIRM)
+        } returns afterConfirm
+        coEvery { confirmHandler.followUpPurposes(afterConfirm) } returns emptyList()
+        coEvery { reauthHandler.nextStepOrNull(afterConfirm) } returns null
+        coEvery {
+            sessionManager.markPurposeAsCompleted(afterConfirm, InteractiveFlowPurpose.REAUTHENTICATION)
+        } returns afterReauth
+        coEvery {
+            reauthHandler.followUpPurposes(afterReauth)
+        } returns listOf(InteractiveFlowPurpose.MFA_CHALLENGE)
+        coEvery {
+            sessionManager.insertPurposeAfter(
+                afterReauth,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+            )
+        } returns grown
+        coEvery {
+            mfaChallengeHandler.nextStepOrNull(grown)
+        } returns InteractiveFlowStep.MfaSelectionForChallenge
+
+        val result = engine.advance(session)
+
+        assertSame(grown, result.session)
+        assertEquals(InteractiveFlowStep.MfaSelectionForChallenge, result.step)
+    }
+
+    @Test
+    fun `advance - Does not re-insert a follow-up purpose already present`() = runTest {
+        // The follow-up is already on the session, so no insert happens; the walk moves on to it.
         val session = onGoingSession(
             listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE)
         )

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
@@ -11,6 +11,7 @@ import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.flow.TerminalEffectResult
 import java.net.URI
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
@@ -248,6 +249,61 @@ class InteractiveFlowEngineTest {
 
         assertSame(grown, result.session)
         assertEquals(InteractiveFlowStep.MfaSelectionForChallenge, result.step)
+    }
+
+    @Test
+    fun `advance - Inserts a new follow-up after an already-present sibling, keeping declared order`() = runTest {
+        // A handler declaring several follow-ups [alreadyPresent, new] must keep their declared order: the new
+        // one lands right after the already-present sibling, not back at the resolving purpose. Here
+        // OAUTH2_AUTHORIZE resolves and declares [MFA_ENROLLMENT (already present), MFA_CHALLENGE (new)], so
+        // MFA_CHALLENGE must be inserted after MFA_ENROLLMENT.
+        val session = onGoingSession(
+            listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_ENROLLMENT)
+        )
+        val marked = onGoingSession(
+            listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_ENROLLMENT)
+        )
+        val grown = onGoingSession(
+            listOf(
+                InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+            )
+        )
+        val oauth2Handler = mockk<InteractiveFlowPurposeHandler>()
+        val mfaEnrollmentHandler = mockk<InteractiveFlowPurposeHandler>()
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.OAUTH2_AUTHORIZE) } returns oauth2Handler
+        every { purposeRegistry.getForPurpose(InteractiveFlowPurpose.MFA_ENROLLMENT) } returns mfaEnrollmentHandler
+        coEvery { oauth2Handler.nextStepOrNull(session) } returns null
+        coEvery {
+            sessionManager.markPurposeAsCompleted(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        } returns marked
+        coEvery { oauth2Handler.followUpPurposes(marked) } returns listOf(
+            InteractiveFlowPurpose.MFA_ENROLLMENT,
+            InteractiveFlowPurpose.MFA_CHALLENGE,
+        )
+        coEvery {
+            sessionManager.insertPurposeAfter(
+                marked,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            )
+        } returns grown
+        coEvery {
+            mfaEnrollmentHandler.nextStepOrNull(grown)
+        } returns InteractiveFlowStep.MfaSelectionForEnrollment
+
+        val result = engine.advance(session)
+
+        assertEquals(InteractiveFlowStep.MfaSelectionForEnrollment, result.step)
+        // The new follow-up is inserted after the already-present sibling, not after the resolving purpose.
+        coVerify {
+            sessionManager.insertPurposeAfter(
+                marked,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            )
+        }
     }
 
     @Test

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowEngineTest.kt
@@ -296,9 +296,13 @@ class InteractiveFlowEngineTest {
         assertSame(completed, engine.completeIfNecessary(session))
     }
 
-    private fun onGoingSession(purposes: List<InteractiveFlowPurpose>) = OnGoingInteractiveFlowSession(
+    private fun onGoingSession(
+        purposes: List<InteractiveFlowPurpose>,
+        initiatingPurpose: InteractiveFlowPurpose = purposes.first(),
+    ) = OnGoingInteractiveFlowSession(
         id = UUID.randomUUID(),
         purposes = purposes,
+        initiatingPurpose = initiatingPurpose,
         flowId = "flow-id",
         expirationDate = LocalDateTime.now().plusHours(1),
         sessionDate = LocalDateTime.now(),
@@ -308,6 +312,7 @@ class InteractiveFlowEngineTest {
     private fun completedSession() = CompletedInteractiveFlowSession(
         id = UUID.randomUUID(),
         purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+        initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
         flowId = "flow-id",
         expirationDate = LocalDateTime.now().plusHours(1),
         sessionDate = LocalDateTime.now(),
@@ -320,6 +325,7 @@ class InteractiveFlowEngineTest {
     private fun cancelledSession() = CancelledInteractiveFlowSession(
         id = UUID.randomUUID(),
         purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+        initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
         flowId = "flow-id",
         expirationDate = LocalDateTime.now().plusHours(1),
         userId = UUID.randomUUID(),
@@ -332,6 +338,7 @@ class InteractiveFlowEngineTest {
     private fun failedSession() = FailedInteractiveFlowSession(
         id = UUID.randomUUID(),
         purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+        initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
         flowId = "flow-id",
         expirationDate = LocalDateTime.now().plusHours(1),
         errorDetailsId = "error",

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
@@ -139,6 +139,7 @@ class InteractiveFlowSessionManagerTest {
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
@@ -166,6 +167,7 @@ class InteractiveFlowSessionManagerTest {
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
             purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
@@ -191,6 +193,7 @@ class InteractiveFlowSessionManagerTest {
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
             purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
             completedPurposes = listOf(InteractiveFlowPurpose.CONFIRM),
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
@@ -216,6 +219,7 @@ class InteractiveFlowSessionManagerTest {
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             completedPurposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE),
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
@@ -246,6 +250,7 @@ class InteractiveFlowSessionManagerTest {
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
@@ -269,6 +274,7 @@ class InteractiveFlowSessionManagerTest {
         val session = OnGoingInteractiveFlowSession(
             id = UUID.randomUUID(),
             purposes = listOf(InteractiveFlowPurpose.MFA_ENROLLMENT),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionManagerTest.kt
@@ -134,29 +134,48 @@ class InteractiveFlowSessionManagerTest {
     }
 
     @Test
-    fun `appendPurpose - Persists the extended purpose list and returns the updated session`() = runTest {
+    fun `insertPurposeAfter - Inserts the purpose right after the given one and persists the list`() = runTest {
         val sessionId = UUID.randomUUID()
         val session = OnGoingInteractiveFlowSession(
             id = sessionId,
-            purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
-            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
+            purposes = listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            ),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),
-            userId = null,
+            userId = UUID.randomUUID(),
         )
-        // Stub with the exact expected persisted names so reaching the assertion proves the right list was saved.
+        // Stub with the exact expected persisted names so reaching the assertion proves the right ordering was
+        // saved: the inserted MFA_CHALLENGE lands right after REAUTHENTICATION, ahead of the trailing purpose.
         coEvery {
             sessionRepository.updatePurposes(
                 sessionId,
-                listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE.name, InteractiveFlowPurpose.OAUTH2_AUTHORIZE.name)
+                listOf(
+                    InteractiveFlowPurpose.CONFIRM.name,
+                    InteractiveFlowPurpose.REAUTHENTICATION.name,
+                    InteractiveFlowPurpose.MFA_CHALLENGE.name,
+                    InteractiveFlowPurpose.MFA_ENROLLMENT.name,
+                )
             )
         } returns Unit
 
-        val result = interactiveFlowSessionManager.appendPurpose(session, InteractiveFlowPurpose.OAUTH2_AUTHORIZE)
+        val result = interactiveFlowSessionManager.insertPurposeAfter(
+            session,
+            purpose = InteractiveFlowPurpose.MFA_CHALLENGE,
+            afterPurpose = InteractiveFlowPurpose.REAUTHENTICATION,
+        )
 
         assertEquals(
-            listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            listOf(
+                InteractiveFlowPurpose.CONFIRM,
+                InteractiveFlowPurpose.REAUTHENTICATION,
+                InteractiveFlowPurpose.MFA_CHALLENGE,
+                InteractiveFlowPurpose.MFA_ENROLLMENT,
+            ),
             result.purposes
         )
     }

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManagerTest.kt
@@ -1,0 +1,200 @@
+package com.sympauthy.business.manager.flow
+
+import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.manager.flow.reauth.InteractiveFlowSessionReauthenticationManager
+import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.manager.provider.ProviderClaimsResolver
+import com.sympauthy.business.manager.provider.ProviderManager
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
+import com.sympauthy.business.model.flow.InteractiveFlowSession
+import com.sympauthy.business.model.flow.InteractiveFlowSessionProvider
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.provider.EnabledProvider
+import com.sympauthy.business.model.provider.ProviderUserInfo
+import com.sympauthy.business.model.provider.config.ProviderOAuth2Config
+import com.sympauthy.business.model.provider.config.ProviderUserInfoConfig
+import com.sympauthy.business.model.provider.oauth2.ProviderOAuth2Tokens
+import com.sympauthy.business.model.user.RawProviderClaims
+import com.sympauthy.client.oauth2.TokenEndpointClient
+import com.sympauthy.config.model.UrlsConfig
+import io.mockk.*
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.SpyK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class InteractiveFlowSessionOAuth2ProviderManagerTest {
+
+    @MockK
+    lateinit var sessionManager: InteractiveFlowSessionManager
+
+    @MockK
+    lateinit var providerManager: InteractiveFlowSessionProviderManager
+
+    @MockK
+    lateinit var reauthenticationManager: InteractiveFlowSessionReauthenticationManager
+
+    @MockK
+    lateinit var providerConfigManager: ProviderManager
+
+    @MockK
+    lateinit var providerClaimsManager: ProviderClaimsManager
+
+    @MockK
+    lateinit var providerClaimsResolver: ProviderClaimsResolver
+
+    @MockK
+    lateinit var engine: InteractiveFlowEngine
+
+    @MockK
+    lateinit var tokenEndpointClient: TokenEndpointClient
+
+    @MockK
+    lateinit var establisher: ProviderUserEstablisher
+
+    @MockK
+    lateinit var uncheckedUrlsConfig: UrlsConfig
+
+    @SpyK
+    @InjectMockKs
+    lateinit var manager: InteractiveFlowSessionOAuth2ProviderManager
+
+    private fun createProvider(): EnabledProvider {
+        return EnabledProvider(
+            id = "test-provider",
+            name = "Test Provider",
+            userInfo = mockk<ProviderUserInfoConfig>(),
+            auth = mockk<ProviderOAuth2Config>()
+        )
+    }
+
+    // --- getOAuth2 ---
+
+    @Test
+    fun `getOAuth2 - Return config when provider uses OAuth2`() {
+        val oauth2Config = mockk<ProviderOAuth2Config>()
+        val provider = EnabledProvider(
+            id = "test-provider",
+            name = "Test Provider",
+            userInfo = mockk<ProviderUserInfoConfig>(),
+            auth = oauth2Config
+        )
+
+        val result = manager.getOAuth2(provider)
+
+        assertSame(oauth2Config, result)
+    }
+
+    // --- authorizeWithProvider (re-authentication guard) ---
+
+    @Test
+    fun `authorizeWithProvider - Re-authentication rejects a provider not linked to the session user`() = runTest {
+        val userId = UUID.randomUUID()
+        val provider = createProvider()
+        val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+        coEvery { providerConfigManager.findByIdAndCheckEnabled(provider.id) } returns provider
+        coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, provider.id) } returns null
+
+        val exception = assertThrows<BusinessException> {
+            manager.authorizeWithProvider(session, provider.id)
+        }
+
+        assertEquals("flow.reauthentication.provider_not_linked", exception.detailsId)
+        assertTrue(exception.recoverable)
+        coVerify(exactly = 0) { providerManager.setProvider(any(), any(), any()) }
+    }
+
+    // --- signInOrSignUpUsingProvider (re-authentication branch) ---
+
+    /**
+     * Stub the provider callback chain (token exchange, claim resolution, stored-subject lookup) up to the
+     * point where the re-authentication branch is evaluated. fetchTokens is final, stubbed on the spy manager.
+     */
+    private fun stubProviderCallbackChain(
+        session: OnGoingInteractiveFlowSession,
+        provider: EnabledProvider,
+        subject: String,
+        existingUserInfo: ProviderUserInfo?
+    ): RawProviderClaims {
+        val sessionProvider = mockk<InteractiveFlowSessionProvider> { every { providerId } returns provider.id }
+        val tokens = mockk<ProviderOAuth2Tokens>()
+        val rawUserInfo = RawProviderClaims(subject = subject, email = "user@example.com")
+        coEvery { providerManager.fetchProviderOrNull(session) } returns sessionProvider
+        coEvery { providerConfigManager.findByIdAndCheckEnabled(provider.id) } returns provider
+        coEvery { manager.fetchTokens(provider, provider.auth, "code") } returns tokens
+        coEvery { providerManager.buildProviderNonceOrNull(sessionProvider) } returns null
+        coEvery { providerClaimsResolver.resolveClaims(provider, tokens, null) } returns rawUserInfo
+        coEvery { providerClaimsManager.findByProviderAndSubject(provider, subject) } returns existingUserInfo
+        return rawUserInfo
+    }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Re-authentication confirms the linked provider account without establishing identity`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val provider = createProvider()
+            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns userId }
+            val rawUserInfo = stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
+            val advanced = mockk<InteractiveFlowSession>()
+            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.REAUTHENTICATION
+            coJustRun { providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo) }
+            coEvery { reauthenticationManager.markPrimaryCredentialProven(session) } returns mockk()
+            coEvery { engine.completeIfNecessary(session) } returns advanced
+
+            val result = manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+
+            assertSame(advanced, result)
+            coVerify { reauthenticationManager.markPrimaryCredentialProven(session) }
+            coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
+        }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Re-authentication rejects a provider account linked to a different user`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val provider = createProvider()
+            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns UUID.randomUUID() }
+            stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
+            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.REAUTHENTICATION
+
+            val exception = assertThrows<BusinessException> {
+                manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+            }
+
+            assertEquals("flow.reauthentication.provider_not_linked", exception.detailsId)
+            assertTrue(exception.recoverable)
+            coVerify(exactly = 0) { reauthenticationManager.markPrimaryCredentialProven(any()) }
+            coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
+            coVerify(exactly = 0) { providerClaimsManager.refreshUserInfo(any(), any()) }
+        }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Does not establish or switch identity when a later purpose is active after re-auth`() =
+        runTest {
+            // Regression for the confirm-never-establish gap: once REAUTHENTICATION has resolved and a later
+            // purpose (e.g. MFA_CHALLENGE) is active, a provider round-trip must NOT fall through to the
+            // establish path and switch the already-fixed session user.
+            val userId = UUID.randomUUID()
+            val provider = createProvider()
+            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns userId }
+            stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
+            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.MFA_CHALLENGE
+
+            val result = manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+
+            assertSame(session, result)
+            coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
+            coVerify(exactly = 0) { reauthenticationManager.markPrimaryCredentialProven(any()) }
+            coVerify(exactly = 0) { providerClaimsManager.refreshUserInfo(any(), any()) }
+        }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/InteractiveFlowSessionOAuth2ProviderManagerTest.kt
@@ -1,12 +1,18 @@
 package com.sympauthy.business.manager.flow
 
 import com.sympauthy.business.exception.BusinessException
+import com.sympauthy.business.manager.flow.link.InteractiveFlowSessionLinkProviderManager
 import com.sympauthy.business.manager.flow.reauth.InteractiveFlowSessionReauthenticationManager
 import com.sympauthy.business.manager.provider.ProviderClaimsManager
 import com.sympauthy.business.manager.provider.ProviderClaimsResolver
 import com.sympauthy.business.manager.provider.ProviderManager
+import com.sympauthy.business.manager.user.UserManager
+import com.sympauthy.business.model.user.User
+import com.sympauthy.business.model.user.claim.OpenIdConnectClaimId
+import com.sympauthy.config.model.EnabledAuthConfig
 import com.sympauthy.business.model.flow.InteractiveFlowPurpose
 import com.sympauthy.business.model.flow.InteractiveFlowSession
+import com.sympauthy.business.model.flow.InteractiveFlowSessionLinkProvider
 import com.sympauthy.business.model.flow.InteractiveFlowSessionProvider
 import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.provider.EnabledProvider
@@ -60,6 +66,15 @@ class InteractiveFlowSessionOAuth2ProviderManagerTest {
     lateinit var establisher: ProviderUserEstablisher
 
     @MockK
+    lateinit var linkProviderManager: InteractiveFlowSessionLinkProviderManager
+
+    @MockK
+    lateinit var userManager: UserManager
+
+    @MockK
+    lateinit var uncheckedAuthConfig: EnabledAuthConfig
+
+    @MockK
     lateinit var uncheckedUrlsConfig: UrlsConfig
 
     @SpyK
@@ -100,6 +115,7 @@ class InteractiveFlowSessionOAuth2ProviderManagerTest {
         val provider = createProvider()
         val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
         coEvery { providerConfigManager.findByIdAndCheckEnabled(provider.id) } returns provider
+        coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.REAUTHENTICATION
         coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, provider.id) } returns null
 
         val exception = assertThrows<BusinessException> {
@@ -196,5 +212,103 @@ class InteractiveFlowSessionOAuth2ProviderManagerTest {
             coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
             coVerify(exactly = 0) { reauthenticationManager.markPrimaryCredentialProven(any()) }
             coVerify(exactly = 0) { providerClaimsManager.refreshUserInfo(any(), any()) }
+        }
+
+    // --- authorizeWithProvider / signInOrSignUpUsingProvider (LINK_PROVIDER branch) ---
+
+    @Test
+    fun `authorizeWithProvider - Rejects a provider that is not the link target under LINK_PROVIDER`() = runTest {
+        val userId = UUID.randomUUID()
+        val provider = createProvider()
+        val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+        coEvery { providerConfigManager.findByIdAndCheckEnabled(provider.id) } returns provider
+        coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.LINK_PROVIDER
+        coEvery { linkProviderManager.fetchLinkProviderOrNull(session) } returns
+            InteractiveFlowSessionLinkProvider(sessionId = UUID.randomUUID(), providerId = "other-provider")
+
+        val exception = assertThrows<BusinessException> {
+            manager.authorizeWithProvider(session, provider.id)
+        }
+
+        assertEquals("flow.link_provider.wrong_provider", exception.detailsId)
+        assertTrue(exception.recoverable)
+        coVerify(exactly = 0) { providerManager.setProvider(any(), any(), any()) }
+    }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Links the resolved provider to the fixed user`() = runTest {
+        val userId = UUID.randomUUID()
+        val provider = createProvider()
+        val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+        val rawUserInfo = stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo = null)
+        val advanced = mockk<InteractiveFlowSession>()
+        coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.LINK_PROVIDER
+        every { uncheckedAuthConfig.identifierClaims } returns emptyList()
+        coEvery { providerClaimsManager.saveUserInfo(provider, userId, rawUserInfo) } returns mockk()
+        coEvery { engine.completeIfNecessary(session) } returns advanced
+
+        val result = manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+
+        assertSame(advanced, result)
+        coVerify { providerClaimsManager.saveUserInfo(provider, userId, rawUserInfo) }
+    }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Link is idempotent when the subject is already linked to this user`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val provider = createProvider()
+            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns userId }
+            val rawUserInfo = stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
+            val advanced = mockk<InteractiveFlowSession>()
+            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.LINK_PROVIDER
+            coJustRun { providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo) }
+            coEvery { engine.completeIfNecessary(session) } returns advanced
+
+            val result = manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+
+            assertSame(advanced, result)
+            coVerify { providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo) }
+            coVerify(exactly = 0) { providerClaimsManager.saveUserInfo(any(), any(), any()) }
+        }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Link hard-fails when the subject is linked to another account`() = runTest {
+        val userId = UUID.randomUUID()
+        val provider = createProvider()
+        val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+        val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns UUID.randomUUID() }
+        stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
+        coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.LINK_PROVIDER
+
+        val exception = assertThrows<BusinessException> {
+            manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+        }
+
+        assertEquals("flow.link_provider.subject_conflict", exception.detailsId)
+        assertFalse(exception.recoverable)
+        coVerify(exactly = 0) { providerClaimsManager.saveUserInfo(any(), any(), any()) }
+    }
+
+    @Test
+    fun `signInOrSignUpUsingProvider - Link hard-fails when an identifier claim is owned by another account`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val provider = createProvider()
+            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
+            stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo = null)
+            val otherUser = mockk<User> { every { id } returns UUID.randomUUID() }
+            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.LINK_PROVIDER
+            every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdConnectClaimId.EMAIL)
+            coEvery { userManager.findByIdentifierClaims(mapOf("email" to "user@example.com")) } returns otherUser
+
+            val exception = assertThrows<BusinessException> {
+                manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
+            }
+
+            assertEquals("flow.link_provider.identifier_conflict", exception.detailsId)
+            assertFalse(exception.recoverable)
+            coVerify(exactly = 0) { providerClaimsManager.saveUserInfo(any(), any(), any()) }
         }
 }

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/auth/InteractiveAuthFlowSessionProviderEstablisherTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/auth/InteractiveAuthFlowSessionProviderEstablisherTest.kt
@@ -1,40 +1,24 @@
 package com.sympauthy.business.manager.flow.auth
 
-import com.sympauthy.business.manager.flow.InteractiveFlowEngine
-import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
-import com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2Manager
-import com.sympauthy.business.manager.flow.InteractiveFlowSessionProviderManager
-import com.sympauthy.business.manager.flow.reauth.InteractiveFlowSessionReauthenticationManager
-
 import com.sympauthy.business.exception.BusinessException
 import com.sympauthy.business.manager.ClaimManager
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionOAuth2Manager
 import com.sympauthy.business.manager.invitation.InvitationManager
 import com.sympauthy.business.manager.provider.ProviderClaimsManager
-import com.sympauthy.business.manager.provider.ProviderClaimsResolver
-import com.sympauthy.business.manager.provider.ProviderManager
 import com.sympauthy.business.manager.user.CollectedClaimManager
 import com.sympauthy.business.manager.user.UserManager
-import com.sympauthy.business.model.flow.InteractiveFlowPurpose
-import com.sympauthy.business.model.flow.InteractiveFlowSession
-import com.sympauthy.business.model.flow.InteractiveFlowSessionProvider
-import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
 import com.sympauthy.business.model.provider.EnabledProvider
-import com.sympauthy.business.model.provider.ProviderUserInfo
 import com.sympauthy.business.model.provider.config.ProviderOAuth2Config
 import com.sympauthy.business.model.provider.config.ProviderUserInfoConfig
-import com.sympauthy.business.model.provider.oauth2.ProviderOAuth2Tokens
 import com.sympauthy.business.model.user.RawProviderClaims
 import com.sympauthy.business.model.user.User
 import com.sympauthy.business.model.user.UserStatus
 import com.sympauthy.business.model.user.claim.Claim
 import com.sympauthy.business.model.user.claim.OpenIdConnectClaimId
-import com.sympauthy.client.oauth2.TokenEndpointClient
 import com.sympauthy.config.model.EnabledAuthConfig
-import com.sympauthy.config.model.UrlsConfig
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
-import io.mockk.impl.annotations.SpyK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -45,59 +29,34 @@ import java.time.LocalDateTime
 import java.util.*
 
 @ExtendWith(MockKExtension::class)
-class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
-
-    @MockK
-    lateinit var sessionManager: InteractiveFlowSessionManager
+class InteractiveAuthFlowSessionProviderEstablisherTest {
 
     @MockK
     lateinit var oauth2Manager: InteractiveFlowSessionOAuth2Manager
 
     @MockK
-    lateinit var providerManager: InteractiveFlowSessionProviderManager
-
-    @MockK
-    lateinit var reauthenticationManager: InteractiveFlowSessionReauthenticationManager
-
-    @MockK
-    lateinit var claimManager: ClaimManager
-
-    @MockK
-    lateinit var collectedClaimManager: CollectedClaimManager
+    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
 
     @MockK
     lateinit var invitationManager: InvitationManager
 
     @MockK
-    lateinit var providerConfigManager: ProviderManager
+    lateinit var userManager: UserManager
 
     @MockK
     lateinit var providerClaimsManager: ProviderClaimsManager
 
     @MockK
-    lateinit var providerClaimsResolver: ProviderClaimsResolver
+    lateinit var collectedClaimManager: CollectedClaimManager
 
     @MockK
-    lateinit var interactiveAuthFlowSessionManager: InteractiveAuthFlowSessionManager
-
-    @MockK
-    lateinit var engine: InteractiveFlowEngine
-
-    @MockK
-    lateinit var tokenEndpointClient: TokenEndpointClient
-
-    @MockK
-    lateinit var userManager: UserManager
+    lateinit var claimManager: ClaimManager
 
     @MockK
     lateinit var uncheckedAuthConfig: EnabledAuthConfig
 
-    @MockK
-    lateinit var uncheckedUrlsConfig: UrlsConfig
-
-    @SpyK
     @InjectMockKs
-    lateinit var manager: InteractiveAuthFlowSessionOAuth2ProviderManager
+    lateinit var establisher: InteractiveAuthFlowSessionProviderEstablisher
 
     private fun createProvider(): EnabledProvider {
         return EnabledProvider(
@@ -114,23 +73,6 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             status = UserStatus.ENABLED,
             creationDate = LocalDateTime.now()
         )
-    }
-
-    // --- getOAuth2 ---
-
-    @Test
-    fun `getOAuth2 - Return config when provider uses OAuth2`() {
-        val oauth2Config = mockk<ProviderOAuth2Config>()
-        val provider = EnabledProvider(
-            id = "test-provider",
-            name = "Test Provider",
-            userInfo = mockk<ProviderUserInfoConfig>(),
-            auth = oauth2Config
-        )
-
-        val result = manager.getOAuth2(provider)
-
-        assertSame(oauth2Config, result)
     }
 
     // --- createOrAssociateUserWithProviderUserInfo ---
@@ -152,7 +94,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             coEvery { userManager.findByIdentifierClaims(mapOf("email" to "user@example.com")) } returns existingUser
             coJustRun { providerClaimsManager.saveUserInfo(provider, existingUser.id, providerUserInfo) }
 
-            val result = manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+            val result = establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
 
             assertFalse(result.created)
             assertSame(existingUser, result.user)
@@ -178,7 +120,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             coJustRun { collectedClaimManager.update(newUser, any()) }
             coJustRun { providerClaimsManager.saveUserInfo(provider, newUser.id, providerUserInfo) }
 
-            val result = manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+            val result = establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
 
             assertTrue(result.created)
             assertSame(newUser, result.user)
@@ -215,7 +157,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
         } returns existingUser
         coJustRun { providerClaimsManager.saveUserInfo(provider, existingUser.id, providerUserInfo) }
 
-        val result = manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+        val result = establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
 
         assertFalse(result.created)
         assertSame(existingUser, result.user)
@@ -253,7 +195,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             coJustRun { collectedClaimManager.update(newUser, any()) }
             coJustRun { providerClaimsManager.saveUserInfo(provider, newUser.id, providerUserInfo) }
 
-            val result = manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+            val result = establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
 
             assertTrue(result.created)
             coVerify {
@@ -278,7 +220,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             every { uncheckedAuthConfig.identifierClaims } returns listOf(OpenIdConnectClaimId.EMAIL)
 
             val exception = assertThrows<BusinessException> {
-                manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+                establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
             }
 
             assertEquals("user.create_with_provider.missing_identifier_claim", exception.detailsId)
@@ -299,7 +241,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             every { claimManager.findByIdOrNull(OpenIdConnectClaimId.EMAIL) } returns null
 
             val exception = assertThrows<BusinessException> {
-                manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+                establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
             }
 
             assertEquals("user.create_with_provider.missing_identifier_claim_config", exception.detailsId)
@@ -325,7 +267,7 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
             coJustRun { collectedClaimManager.update(newUser, any()) }
             coJustRun { providerClaimsManager.saveUserInfo(provider, newUser.id, providerUserInfo) }
 
-            val result = manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+            val result = establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
 
             assertTrue(result.created)
             assertSame(newUser, result.user)
@@ -355,116 +297,10 @@ class InteractiveAuthFlowSessionOAuth2ProviderManagerTest {
         coEvery { userManager.findByIdentifierClaims(mapOf("email" to "existing@example.com")) } returns existingUser
 
         val exception = assertThrows<BusinessException> {
-            manager.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
+            establisher.createOrAssociateUserWithProviderUserInfo(provider, providerUserInfo)
         }
 
         assertEquals("user.create_with_provider.existing_user", exception.detailsId)
         coVerify(exactly = 0) { userManager.createUser() }
     }
-
-    // --- authorizeWithProvider (re-authentication guard) ---
-
-    @Test
-    fun `authorizeWithProvider - Re-authentication rejects a provider not linked to the session user`() = runTest {
-        val userId = UUID.randomUUID()
-        val provider = createProvider()
-        val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
-        coEvery { providerConfigManager.findByIdAndCheckEnabled(provider.id) } returns provider
-        coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, provider.id) } returns null
-
-        val exception = assertThrows<BusinessException> {
-            manager.authorizeWithProvider(session, provider.id)
-        }
-
-        assertEquals("flow.reauthentication.provider_not_linked", exception.detailsId)
-        assertTrue(exception.recoverable)
-        coVerify(exactly = 0) { providerManager.setProvider(any(), any(), any()) }
-    }
-
-    // --- signInOrSignUpUsingProvider (re-authentication branch) ---
-
-    /**
-     * Stub the provider callback chain (token exchange, claim resolution, stored-subject lookup) up to the
-     * point where the re-authentication branch is evaluated. fetchTokens is final, stubbed on the spy manager.
-     */
-    private fun stubProviderCallbackChain(
-        session: OnGoingInteractiveFlowSession,
-        provider: EnabledProvider,
-        subject: String,
-        existingUserInfo: ProviderUserInfo?
-    ): RawProviderClaims {
-        val sessionProvider = mockk<InteractiveFlowSessionProvider> { every { providerId } returns provider.id }
-        val tokens = mockk<ProviderOAuth2Tokens>()
-        val rawUserInfo = RawProviderClaims(subject = subject, email = "user@example.com")
-        coEvery { providerManager.fetchProviderOrNull(session) } returns sessionProvider
-        coEvery { providerConfigManager.findByIdAndCheckEnabled(provider.id) } returns provider
-        coEvery { manager.fetchTokens(provider, provider.auth, "code") } returns tokens
-        coEvery { providerManager.buildProviderNonceOrNull(sessionProvider) } returns null
-        coEvery { providerClaimsResolver.resolveClaims(provider, tokens, null) } returns rawUserInfo
-        coEvery { providerClaimsManager.findByProviderAndSubject(provider, subject) } returns existingUserInfo
-        return rawUserInfo
-    }
-
-    @Test
-    fun `signInOrSignUpUsingProvider - Re-authentication confirms the linked provider account without establishing identity`() =
-        runTest {
-            val userId = UUID.randomUUID()
-            val provider = createProvider()
-            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
-            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns userId }
-            val rawUserInfo = stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
-            val advanced = mockk<InteractiveFlowSession>()
-            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.REAUTHENTICATION
-            coJustRun { providerClaimsManager.refreshUserInfo(existingUserInfo, rawUserInfo) }
-            coEvery { reauthenticationManager.markPrimaryCredentialProven(session) } returns mockk()
-            coEvery { engine.completeIfNecessary(session) } returns advanced
-
-            val result = manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
-
-            assertSame(advanced, result)
-            coVerify { reauthenticationManager.markPrimaryCredentialProven(session) }
-            coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
-        }
-
-    @Test
-    fun `signInOrSignUpUsingProvider - Re-authentication rejects a provider account linked to a different user`() =
-        runTest {
-            val userId = UUID.randomUUID()
-            val provider = createProvider()
-            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
-            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns UUID.randomUUID() }
-            stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
-            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.REAUTHENTICATION
-
-            val exception = assertThrows<BusinessException> {
-                manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
-            }
-
-            assertEquals("flow.reauthentication.provider_not_linked", exception.detailsId)
-            assertTrue(exception.recoverable)
-            coVerify(exactly = 0) { reauthenticationManager.markPrimaryCredentialProven(any()) }
-            coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
-            coVerify(exactly = 0) { providerClaimsManager.refreshUserInfo(any(), any()) }
-        }
-
-    @Test
-    fun `signInOrSignUpUsingProvider - Does not establish or switch identity when a later purpose is active after re-auth`() =
-        runTest {
-            // Regression for the confirm-never-establish gap: once REAUTHENTICATION has resolved and a later
-            // purpose (e.g. MFA_CHALLENGE) is active, a provider round-trip must NOT fall through to the
-            // establish path and switch the already-fixed session user.
-            val userId = UUID.randomUUID()
-            val provider = createProvider()
-            val session = mockk<OnGoingInteractiveFlowSession> { every { this@mockk.userId } returns userId }
-            val existingUserInfo = mockk<ProviderUserInfo> { every { this@mockk.userId } returns userId }
-            stubProviderCallbackChain(session, provider, "sub-123", existingUserInfo)
-            coEvery { engine.currentPurposeOrNull(session) } returns InteractiveFlowPurpose.MFA_CHALLENGE
-
-            val result = manager.signInOrSignUpUsingProvider(session, provider.id, authorizeCode = "code")
-
-            assertSame(session, result)
-            coVerify(exactly = 0) { sessionManager.setAuthenticatedUserId(any(), any(), any()) }
-            coVerify(exactly = 0) { reauthenticationManager.markPrimaryCredentialProven(any()) }
-            coVerify(exactly = 0) { providerClaimsManager.refreshUserInfo(any(), any()) }
-        }
 }

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/auth/OAuth2AuthorizeInteractiveFlowPurposeHandlerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/auth/OAuth2AuthorizeInteractiveFlowPurposeHandlerTest.kt
@@ -387,6 +387,7 @@ class OAuth2AuthorizeInteractiveFlowPurposeHandlerTest {
         return OnGoingInteractiveFlowSession(
             id = UUID.randomUUID(),
             purposes = listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE),
+            initiatingPurpose = InteractiveFlowPurpose.OAUTH2_AUTHORIZE,
             flowId = "flow-id",
             expirationDate = LocalDateTime.now().plusHours(1),
             sessionDate = LocalDateTime.now(),

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/link/InteractiveFlowSessionLinkProviderManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/link/InteractiveFlowSessionLinkProviderManagerTest.kt
@@ -1,0 +1,125 @@
+package com.sympauthy.business.manager.flow.link
+
+import com.sympauthy.business.manager.flow.InteractiveFlowSessionManager
+import com.sympauthy.business.manager.flow.confirm.InteractiveFlowSessionConfirmManager
+import com.sympauthy.business.mapper.InteractiveFlowSessionLinkProviderMapper
+import com.sympauthy.business.model.flow.AuthorizationFlow
+import com.sympauthy.business.model.flow.ConfirmActionType
+import com.sympauthy.business.model.flow.InteractiveFlowPurpose
+import com.sympauthy.business.model.flow.InteractiveFlowRedirectType
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.data.repository.InteractiveFlowSessionLinkProviderRepository
+import io.mockk.*
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class InteractiveFlowSessionLinkProviderManagerTest {
+
+    @MockK
+    lateinit var sessionManager: InteractiveFlowSessionManager
+
+    @MockK
+    lateinit var confirmManager: InteractiveFlowSessionConfirmManager
+
+    @MockK
+    lateinit var linkProviderRepository: InteractiveFlowSessionLinkProviderRepository
+
+    @MockK
+    lateinit var linkProviderMapper: InteractiveFlowSessionLinkProviderMapper
+
+    @InjectMockKs
+    lateinit var manager: InteractiveFlowSessionLinkProviderManager
+
+    private fun stubStart(
+        sessionId: UUID,
+        userId: UUID,
+        returnUri: URI,
+        cancelUri: URI?,
+        initiatingClientId: String?,
+        flow: AuthorizationFlow,
+    ): OnGoingInteractiveFlowSession {
+        val newSession = mockk<OnGoingInteractiveFlowSession> { every { id } returns sessionId }
+        val withUser = mockk<OnGoingInteractiveFlowSession> { every { id } returns sessionId }
+        coEvery {
+            sessionManager.newSession(
+                purposes = listOf(
+                    InteractiveFlowPurpose.CONFIRM,
+                    InteractiveFlowPurpose.REAUTHENTICATION,
+                    InteractiveFlowPurpose.LINK_PROVIDER,
+                ),
+                initiatingPurpose = InteractiveFlowPurpose.LINK_PROVIDER,
+                flow = flow,
+                successRedirectUri = returnUri,
+                redirectType = InteractiveFlowRedirectType.PLAIN,
+                cancelRedirectUri = cancelUri,
+            )
+        } returns newSession
+        coEvery { sessionManager.setAuthenticatedUserId(newSession, userId) } returns withUser
+        coEvery {
+            confirmManager.setConfirm(withUser, ConfirmActionType.LINK_PROVIDER, initiatingClientId)
+        } returns mockk()
+        coEvery { linkProviderRepository.findBySessionId(sessionId) } returns null
+        coEvery { linkProviderRepository.save(any()) } returns mockk()
+        every { linkProviderMapper.toInteractiveFlowSessionLinkProvider(any()) } returns mockk()
+        return withUser
+    }
+
+    @Test
+    fun `startLinkProviderSession - Builds a CONFIRM REAUTHENTICATION LINK_PROVIDER session and stores the intent`() =
+        runTest {
+            val userId = UUID.randomUUID()
+            val sessionId = UUID.randomUUID()
+            val returnUri = URI.create("https://client.example.com/linked")
+            val cancelUri = URI.create("https://client.example.com/cancelled")
+            val flow = mockk<AuthorizationFlow>()
+            val withUser = stubStart(sessionId, userId, returnUri, cancelUri, "client-id", flow)
+
+            val result = manager.startLinkProviderSession(
+                userId = userId,
+                providerId = "target-provider",
+                returnUri = returnUri,
+                flow = flow,
+                initiatingClientId = "client-id",
+                cancelUri = cancelUri,
+            )
+
+            assertSame(withUser, result)
+            coVerify { confirmManager.setConfirm(withUser, ConfirmActionType.LINK_PROVIDER, "client-id") }
+            coVerify {
+                linkProviderRepository.save(withArg {
+                    assertEquals(sessionId, it.sessionId)
+                    assertEquals("target-provider", it.providerId)
+                })
+            }
+        }
+
+    @Test
+    fun `startLinkProviderSession - Stores a null client id for an admin-initiated link`() = runTest {
+        val userId = UUID.randomUUID()
+        val sessionId = UUID.randomUUID()
+        val returnUri = URI.create("https://client.example.com/linked")
+        val flow = mockk<AuthorizationFlow>()
+        // Admin-initiated: the confirm record must carry a null client id (rendered as "an administrator").
+        stubStart(sessionId, userId, returnUri, null, null, flow)
+
+        manager.startLinkProviderSession(
+            userId = userId,
+            providerId = "target-provider",
+            returnUri = returnUri,
+            flow = flow,
+            initiatingClientId = null,
+            cancelUri = null,
+        )
+
+        coVerify { confirmManager.setConfirm(any(), ConfirmActionType.LINK_PROVIDER, null) }
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/link/LinkProviderInteractiveFlowPurposeHandlerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/link/LinkProviderInteractiveFlowPurposeHandlerTest.kt
@@ -1,0 +1,65 @@
+package com.sympauthy.business.manager.flow.link
+
+import com.sympauthy.business.manager.provider.ProviderClaimsManager
+import com.sympauthy.business.model.flow.InteractiveFlowSessionLinkProvider
+import com.sympauthy.business.model.flow.InteractiveFlowStep
+import com.sympauthy.business.model.flow.OnGoingInteractiveFlowSession
+import com.sympauthy.business.model.provider.ProviderUserInfo
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class LinkProviderInteractiveFlowPurposeHandlerTest {
+
+    @MockK
+    lateinit var linkProviderManager: InteractiveFlowSessionLinkProviderManager
+
+    @MockK
+    lateinit var providerClaimsManager: ProviderClaimsManager
+
+    @InjectMockKs
+    lateinit var handler: LinkProviderInteractiveFlowPurposeHandler
+
+    private fun session(userId: UUID): OnGoingInteractiveFlowSession {
+        val sessionId = UUID.randomUUID()
+        return mockk {
+            every { id } returns sessionId
+            every { this@mockk.userId } returns userId
+        }
+    }
+
+    @Test
+    fun `nextStepOrNull - Drives to the target provider authorization when not yet linked`() = runTest {
+        val userId = UUID.randomUUID()
+        val session = session(userId)
+        coEvery { linkProviderManager.fetchLinkProviderOrNull(session) } returns
+            InteractiveFlowSessionLinkProvider(sessionId = session.id, providerId = "target-provider")
+        coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, "target-provider") } returns null
+
+        val step = handler.nextStepOrNull(session)
+
+        assertEquals(InteractiveFlowStep.AuthorizeProvider("target-provider"), step)
+    }
+
+    @Test
+    fun `nextStepOrNull - Resolves once the target provider is linked to the session user`() = runTest {
+        val userId = UUID.randomUUID()
+        val session = session(userId)
+        coEvery { linkProviderManager.fetchLinkProviderOrNull(session) } returns
+            InteractiveFlowSessionLinkProvider(sessionId = session.id, providerId = "target-provider")
+        coEvery { providerClaimsManager.findByUserIdAndProviderIdOrNull(userId, "target-provider") } returns
+            mockk<ProviderUserInfo>()
+
+        assertNull(handler.nextStepOrNull(session))
+    }
+}

--- a/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManagerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/manager/flow/mfa/InteractiveFlowSessionMfaEnrollmentManagerTest.kt
@@ -68,6 +68,7 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
         coEvery {
             sessionManager.newSession(
                 purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+                initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
                 flow = flow,
                 successRedirectUri = returnUri,
                 redirectType = InteractiveFlowRedirectType.PLAIN,
@@ -95,6 +96,7 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
         coEvery {
             sessionManager.newSession(
                 purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+                initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
                 flow = flow,
                 successRedirectUri = returnUri,
                 redirectType = InteractiveFlowRedirectType.PLAIN,
@@ -122,6 +124,7 @@ class InteractiveFlowSessionMfaEnrollmentManagerTest {
             coEvery {
                 sessionManager.newSession(
                     purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+                    initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
                     flow = flow,
                     successRedirectUri = returnUri,
                     redirectType = InteractiveFlowRedirectType.PLAIN,

--- a/server/src/test/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapperTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/mapper/InteractiveFlowSessionMapperTest.kt
@@ -190,6 +190,7 @@ class InteractiveFlowSessionMapperTest {
     ): InteractiveFlowSessionEntity {
         return InteractiveFlowSessionEntity(
             purposes = arrayOf(purpose.name),
+            initiatingPurpose = purpose.name,
             sessionDate = sessionDate,
             flowId = flowId,
             expirationDate = expirationDate,

--- a/server/src/test/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/business/model/flow/InteractiveFlowSessionTest.kt
@@ -7,9 +7,13 @@ import java.util.*
 
 class InteractiveFlowSessionTest {
 
-    private fun ongoing(purposes: List<InteractiveFlowPurpose>) = OnGoingInteractiveFlowSession(
+    private fun ongoing(
+        purposes: List<InteractiveFlowPurpose>,
+        initiatingPurpose: InteractiveFlowPurpose,
+    ) = OnGoingInteractiveFlowSession(
         id = UUID.randomUUID(),
         purposes = purposes,
+        initiatingPurpose = initiatingPurpose,
         flowId = null,
         expirationDate = LocalDateTime.now().plusMinutes(5),
         sessionDate = LocalDateTime.now(),
@@ -17,16 +21,14 @@ class InteractiveFlowSessionTest {
     )
 
     @Test
-    fun `initiatingPurpose - Skips the CONFIRM gate to the first real purpose`() {
-        val session = ongoing(listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT))
+    fun `copy - Preserves the stored initiatingPurpose`() {
+        val session = ongoing(
+            purposes = listOf(InteractiveFlowPurpose.CONFIRM, InteractiveFlowPurpose.MFA_ENROLLMENT),
+            initiatingPurpose = InteractiveFlowPurpose.MFA_ENROLLMENT,
+        )
 
-        assertEquals(InteractiveFlowPurpose.MFA_ENROLLMENT, session.initiatingPurpose)
-    }
+        val copied = session.copy(userId = UUID.randomUUID())
 
-    @Test
-    fun `initiatingPurpose - Is the first purpose when there is no CONFIRM gate`() {
-        val session = ongoing(listOf(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, InteractiveFlowPurpose.MFA_CHALLENGE))
-
-        assertEquals(InteractiveFlowPurpose.OAUTH2_AUTHORIZE, session.initiatingPurpose)
+        assertEquals(InteractiveFlowPurpose.MFA_ENROLLMENT, copied.initiatingPurpose)
     }
 }


### PR DESCRIPTION
Implements the client/admin-initiated **provider-link** flow from #294 — the structural twin of the standalone MFA-enrollment endpoints, gated by `CONFIRM` (#286) and `REAUTHENTICATION` (#295).

Two new endpoints start an interactive `[CONFIRM, REAUTHENTICATION, LINK_PROVIDER]` flow:
- `POST /api/v1/client/providers/{providerId}/link` — scope `users:providers:write`; the end-user is identified by their access token in the body.
- `POST /api/v1/admin/users/{userId}/providers/{providerId}/link` — scope `admin:users:write`; user from the path, client from the body.

Both return `{ redirect_url }` (the client also returns `state`). The end-user confirms, re-authenticates, and authorizes the target provider; the resolved provider `subject` is then linked to their **fixed** account.

## Notable design decisions (deltas from the issue, posted there before coding)

- **The link commits in the provider callback**, next to claim resolution — mirroring how `REAUTHENTICATION` confirms in the callback (the resolved claims only exist there). The `LINK_PROVIDER` handler has no terminal effect.
- **A security fix the original design missed:** `REAUTHENTICATION` appends an `MFA_CHALLENGE`, and the old `appendPurpose` added it to the *end* of the purpose list — which would let the link commit **before** the second factor for MFA-enrolled accounts. The engine now **inserts a gate's follow-up immediately after the gate**, so the MFA challenge always runs before the link.
- **`initiatingPurpose` is now a stored session field**, not a derived getter that had to skip an ever-growing set of gate purposes.
- **Provider-manager split:** the shared provider machinery moved to a generic `InteractiveFlowSessionOAuth2ProviderManager`; the OAuth2-authorize sign-up/merge/invitation logic sits behind a `ProviderUserEstablisher` seam.
- **Hardening:** the relaxed authorize guard enforces the *link intent* (the provider must be the one the session was created to link, so a leaked `state` can't authorize an arbitrary provider); collisions **hard-fail** (the subject, or an identifier claim, already owned by another account); the confirm page exposes a server-computed `requires_reauthentication`.

Re-authentication is **security-load-bearing** — linking a provider mints a durable login credential, so the browser must prove it owns the account before the link commits. That rationale is cemented in `InteractiveFlowSessionLinkProviderManager.startLinkProviderSession`'s KDoc so a future "simplification" can't silently reopen an account-takeover vector.

## Tests

- **Unit:** the handler, the start manager, every link-execution branch (idempotent + both hard-fails + intent mismatch), the engine ordering fix, the split provider manager, both controllers, and the confirm field. Full `./gradlew test` green.
- **Integration:** `ClientProviderLinkFeatureIT` + `AdminUserProviderLinkFeatureIT` cover the start contract + rejections — **18 tests green on H2 + PostgreSQL** (run against a working-tree JVM image).

## Deferred / out of scope

- The end-to-end round-trip IT (confirm → re-auth → provider authorize → link) needs a `testcontainers-sympauthy` sign-in handler + mock provider — tracked in #303.
- Functional/technical docs (`docs/technical/api/*`, `docs/functional/*`) live in the separate `sympauthy.github.io` repo.

Implements the backend + tests for #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
