### PR TITLE
Publish the OpenAPI specification as a release asset

### DIFF
--- a/.github/actions/setup_java/action.yml
+++ b/.github/actions/setup_java/action.yml
@@ -6,8 +6,9 @@ inputs:
     default: temurin
   github-token:
     description: >-
-      Token forwarded to graalvm/setup-graalvm. Composite actions cannot read secrets, so callers
-      installing GraalVM must pass ${{ secrets.GITHUB_TOKEN }} explicitly.
+      Token forwarded to graalvm/setup-graalvm. Composite actions cannot read the secrets context, so
+      callers installing GraalVM must pass the GITHUB_TOKEN secret explicitly. Note that expression
+      syntax is evaluated even inside these descriptions, so it cannot be spelled out here.
     default: ''
   cache:
     description: "Build tool whose dependencies are cached ('gradle', 'maven', …). Empty disables caching."

--- a/.github/actions/setup_java/action.yml
+++ b/.github/actions/setup_java/action.yml
@@ -1,0 +1,50 @@
+name: setup_java
+description: Extract the Java version from the build script and install the matching JDK.
+inputs:
+  distribution:
+    description: "Distribution to install: 'temurin' for a plain JDK, 'graalvm' when native-image is needed."
+    default: temurin
+  github-token:
+    description: >-
+      Token forwarded to graalvm/setup-graalvm. Composite actions cannot read secrets, so callers
+      installing GraalVM must pass ${{ secrets.GITHUB_TOKEN }} explicitly.
+    default: ''
+  cache:
+    description: "Build tool whose dependencies are cached ('gradle', 'maven', …). Empty disables caching."
+    default: ''
+outputs:
+  version:
+    description: Java version extracted from server/build.gradle.kts.
+    value: ${{ steps.extract.outputs.version }}
+runs:
+  using: composite
+  steps:
+    # The build script is the single source of truth for the Java version. Requires the repository to
+    # be checked out before this action runs.
+    - name: Extract Java version from build script
+      id: extract
+      shell: bash
+      run: |
+        VERSION=$(grep -E 'JavaVersion\.VERSION_[0-9]+' server/build.gradle.kts | grep -oE '[0-9]+$')
+        if [[ -z "$VERSION" ]]; then
+          echo "::error::Could not extract the Java version from server/build.gradle.kts"
+          exit 1
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Setup ${{ inputs.distribution }} JDK ${{ steps.extract.outputs.version }}
+      if: inputs.distribution != 'graalvm'
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ steps.extract.outputs.version }}
+        distribution: ${{ inputs.distribution }}
+        cache: ${{ inputs.cache }}
+
+    - name: Setup GraalVM for JDK ${{ steps.extract.outputs.version }}
+      if: inputs.distribution == 'graalvm'
+      uses: graalvm/setup-graalvm@v1
+      with:
+        java-version: ${{ steps.extract.outputs.version }}
+        distribution: graalvm
+        github-token: ${{ inputs.github-token }}
+        cache: ${{ inputs.cache }}

--- a/.github/workflows/build-native-binary.yml
+++ b/.github/workflows/build-native-binary.yml
@@ -39,17 +39,9 @@ jobs:
           name: sympauthy-admin-dist
           path: server/src/main/resources/sympauthy-admin
 
-      - name: Extract Java version from build script
-        id: java-version
-        shell: bash
-        run: |
-          VERSION=$(grep -E 'JavaVersion\.VERSION_[0-9]+' server/build.gradle.kts | grep -oE '[0-9]+$')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Setup GraalVM for JDK ${{ steps.java-version.outputs.version }}
-        uses: graalvm/setup-graalvm@v1
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
         with:
-          java-version: ${{ steps.java-version.outputs.version }}
           distribution: graalvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-openapi.yml
+++ b/.github/workflows/build-openapi.yml
@@ -1,8 +1,10 @@
 # Generates the server's OpenAPI contract and uploads it as the `sympauthy-openapi` artifact so the
 # release / nightly workflows can attach it to the GitHub release next to the native binaries.
 #
-# The published document is the one extracted from the jar by :server:syncPackagedOpenApiSpec, i.e.
-# the exact copy a running instance serves at GET /openapi.yml (with {rootUrl} left unresolved).
+# The published document comes from :server:syncOpenApiSpec — the KSP rendering, which is also what
+# the integration-tests client is generated from, so every green integration run is evidence that it
+# describes the running server. It is NOT the copy packaged in the jar: micronaut-openapi runs under
+# both kapt and KSP, and the packaged (kapt) rendering carries spurious schema properties. See #316.
 
 name: Build SympAuthy OpenAPI specification
 
@@ -37,11 +39,11 @@ jobs:
         uses: ./.github/actions/setup_java
 
       - name: Generate OpenAPI specification
-        run: ./gradlew :server:syncPackagedOpenApiSpec --no-daemon
+        run: ./gradlew :server:syncOpenApiSpec --no-daemon
 
       - name: Prepare specification for upload
         run: |
-          SPEC=server/build/openapi-packaged/openapi.yml
+          SPEC=server/build/openapi/openapi.yml
           # Fail here rather than attaching an empty or truncated asset to a release.
           test -s "$SPEC"
           head -1 "$SPEC" | grep -qE '^openapi: 3\.'

--- a/.github/workflows/build-openapi.yml
+++ b/.github/workflows/build-openapi.yml
@@ -1,0 +1,57 @@
+# Generates the server's OpenAPI contract and uploads it as the `sympauthy-openapi` artifact so the
+# release / nightly workflows can attach it to the GitHub release next to the native binaries.
+#
+# The published document is the one extracted from the jar by :server:syncPackagedOpenApiSpec, i.e.
+# the exact copy a running instance serves at GET /openapi.yml (with {rootUrl} left unresolved).
+
+name: Build SympAuthy OpenAPI specification
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git reference of the commit to build
+        type: string
+        required: true
+  # Dispatchable on its own so the spec generation can be rehearsed without cutting a release.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git reference to build
+        type: string
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build OpenAPI specification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
+
+      - name: Generate OpenAPI specification
+        run: ./gradlew :server:syncPackagedOpenApiSpec --no-daemon
+
+      - name: Prepare specification for upload
+        run: |
+          SPEC=server/build/openapi-packaged/openapi.yml
+          # Fail here rather than attaching an empty or truncated asset to a release.
+          test -s "$SPEC"
+          head -1 "$SPEC" | grep -qE '^openapi: 3\.'
+          grep -q '^paths:' "$SPEC"
+          # Name it sympauthy-* so publish_release's existing `sympauthy-*` glob collects it.
+          cp "$SPEC" sympauthy-openapi.yml
+
+      - name: Upload OpenAPI specification artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sympauthy-openapi
+          path: sympauthy-openapi.yml
+          if-no-files-found: error

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,19 +45,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Extract Java version from build script
-        id: java-version
-        shell: bash
-        run: |
-          VERSION=$(grep -E 'JavaVersion\.VERSION_[0-9]+' server/build.gradle.kts | grep -oE '[0-9]+$')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       # Single toolchain for both paths: GraalVM runs Gradle for the integration tests, and provides
       # native-image for the build-from-source path below.
-      - name: Setup GraalVM for JDK ${{ steps.java-version.outputs.version }}
-        uses: graalvm/setup-graalvm@v1
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
         with:
-          java-version: ${{ steps.java-version.outputs.version }}
           distribution: graalvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-binaries.yml
+++ b/.github/workflows/nightly-binaries.yml
@@ -100,6 +100,13 @@ jobs:
     with:
       ref: ${{ inputs.ref || 'main' }}
 
+  build_openapi:
+    needs: [ should_build ]
+    if: needs.should_build.outputs.result == '1'
+    uses: ./.github/workflows/build-openapi.yml
+    with:
+      ref: ${{ inputs.ref || 'main' }}
+
   build_linux_binary:
     needs: [ should_build, build_flow, build_admin ]
     if: needs.should_build.outputs.result == '1'
@@ -204,7 +211,7 @@ jobs:
 
   publish_release:
     name: Publish to nightly release
-    needs: [ should_build, build_linux_binary, build_macos_binary, integration_test ]
+    needs: [ should_build, build_linux_binary, build_macos_binary, integration_test, build_openapi ]
     if: needs.should_build.outputs.result == '1'
     runs-on: ubuntu-latest
     steps:
@@ -224,6 +231,8 @@ jobs:
         run: |
           mkdir -p release-assets
           find binaries -maxdepth 1 -type f -name 'sympauthy-*' -exec cp {} release-assets/ \;
+          # The OpenAPI spec rides in on the `sympauthy-*` glob above (artifact: sympauthy-openapi).
+          test -f release-assets/sympauthy-openapi.yml
           ls -la release-assets/
 
       - name: Create or update nightly release
@@ -243,6 +252,11 @@ jobs:
           | sympauthy-linux-arm64 | Linux ARM64 |
           | sympauthy-macos-x64 | macOS Intel |
           | sympauthy-macos-arm64 | macOS Apple Silicon |
+
+          ## API
+          | File | Description |
+          |------|-------------|
+          | sympauthy-openapi.yml | OpenAPI 3.0 contract of the SympAuthy HTTP API (`{rootUrl}` placeholder unresolved) |
           EOF
           )" \
             --prerelease \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,8 +245,8 @@ jobs:
           |------|-------------|
           | sympauthy-openapi.yml | OpenAPI 3.0 contract of the SympAuthy HTTP API |
 
-          This is the same document a running instance serves at \`/openapi.yml\`. Server URLs keep
-          the \`{rootUrl}\` placeholder, which an instance substitutes with its configured root URL.
+          Server URLs keep the \`{rootUrl}\` placeholder; substitute the root URL of your deployment.
+          A running instance also serves its contract at \`/openapi.yml\`.
 
           ## Docker
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,17 +99,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Extract Java version from build script
-        id: java-version
-        run: |
-          VERSION=$(grep -E 'JavaVersion\.VERSION_[0-9]+' server/build.gradle.kts | grep -oE '[0-9]+$')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Setup JDK ${{ steps.java-version.outputs.version }}
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ steps.java-version.outputs.version }}
-          distribution: temurin
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
 
       - name: Run tests
         run: ./gradlew test --no-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,14 @@ jobs:
       - name: Run tests
         run: ./gradlew test --no-daemon
 
+  # Sibling of `test` rather than downstream of it: the spec is cheap to build and must not sit on the
+  # critical path of the native builds.
+  build_openapi:
+    needs: [ validate_branch, read_version ]
+    uses: ./.github/workflows/build-openapi.yml
+    with:
+      ref: ${{ github.ref_name }}
+
   build_flow:
     needs: [ read_version, test ]
     uses: ./.github/workflows/build-flow.yml
@@ -192,7 +200,7 @@ jobs:
 
   publish_release:
     name: Publish GitHub release
-    needs: [ read_version, build_binary, integration_test ]
+    needs: [ read_version, build_binary, integration_test, build_openapi ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -208,6 +216,8 @@ jobs:
         run: |
           mkdir -p release-assets
           find binaries -maxdepth 1 -type f -name 'sympauthy-*' -exec cp {} release-assets/ \;
+          # The OpenAPI spec rides in on the `sympauthy-*` glob above (artifact: sympauthy-openapi).
+          test -f release-assets/sympauthy-openapi.yml
           ls -la release-assets/
 
       - name: Create GitHub release
@@ -228,6 +238,15 @@ jobs:
           | sympauthy-linux-arm64 | Linux ARM64 |
           | sympauthy-macos-x64 | macOS Intel |
           | sympauthy-macos-arm64 | macOS Apple Silicon |
+
+          ## API
+
+          | File | Description |
+          |------|-------------|
+          | sympauthy-openapi.yml | OpenAPI 3.0 contract of the SympAuthy HTTP API |
+
+          This is the same document a running instance serves at \`/openapi.yml\`. Server URLs keep
+          the \`{rootUrl}\` placeholder, which an instance substitutes with its configured root URL.
 
           ## Docker
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,5 @@
 name: Test
 
-env:
-  JAVA_VERSION: 25
-
 on:
   push:
     branches-ignore:
@@ -19,9 +16,7 @@ jobs:
         with:
           gradle-version: wrapper
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: ./.github/actions/setup_java
         with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'temurin'
-          cache: 'gradle'
+          cache: gradle
       - run: ./gradlew test --no-daemon

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -232,23 +232,3 @@ artifacts {
         builtBy(syncOpenApiSpec)
     }
 }
-
-// --- OpenAPI release asset ----------------------------------------------------------------------
-// Both kapt (injected by the Micronaut plugin, present here for MapStruct) and KSP run
-// micronaut-openapi, and the two renderings differ. The `duplicatesStrategy = EXCLUDE` above decides
-// which one is packaged, and that packaged copy is the one OpenApiController serves at
-// GET /openapi.yml. Extract it straight out of the jar — rather than from either processor's output
-// directory — so the published release asset is byte-identical to what the released binary serves,
-// whichever processor happens to win.
-// Distinct from syncOpenApiSpec above, which deliberately exports the KSP copy because the
-// integration-tests client generator needs its accurate parameter types.
-val syncPackagedOpenApiSpec by tasks.registering(Sync::class) {
-    description = "Extracts the OpenAPI spec packaged in the server jar to build/openapi-packaged/openapi.yml."
-    group = "openapi"
-    from(tasks.jar.flatMap { it.archiveFile }.map { zipTree(it) }) {
-        include("META-INF/swagger/*.yml")
-        eachFile { path = "openapi.yml" }
-        includeEmptyDirs = false
-    }
-    into(layout.buildDirectory.dir("openapi-packaged"))
-}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -232,3 +232,23 @@ artifacts {
         builtBy(syncOpenApiSpec)
     }
 }
+
+// --- OpenAPI release asset ----------------------------------------------------------------------
+// Both kapt (injected by the Micronaut plugin, present here for MapStruct) and KSP run
+// micronaut-openapi, and the two renderings differ. The `duplicatesStrategy = EXCLUDE` above decides
+// which one is packaged, and that packaged copy is the one OpenApiController serves at
+// GET /openapi.yml. Extract it straight out of the jar — rather than from either processor's output
+// directory — so the published release asset is byte-identical to what the released binary serves,
+// whichever processor happens to win.
+// Distinct from syncOpenApiSpec above, which deliberately exports the KSP copy because the
+// integration-tests client generator needs its accurate parameter types.
+val syncPackagedOpenApiSpec by tasks.registering(Sync::class) {
+    description = "Extracts the OpenAPI spec packaged in the server jar to build/openapi-packaged/openapi.yml."
+    group = "openapi"
+    from(tasks.jar.flatMap { it.archiveFile }.map { zipTree(it) }) {
+        include("META-INF/swagger/*.yml")
+        eachFile { path = "openapi.yml" }
+        includeEmptyDirs = false
+    }
+    into(layout.buildDirectory.dir("openapi-packaged"))
+}


### PR DESCRIPTION
Releases shipped only the four native executables, so anyone wanting a version-pinned HTTP contract had to boot an instance and `curl /openapi.yml`. This attaches the spec to the release next to the binaries, at a stable URL:

```
https://github.com/sympauthy/sympauthy/releases/download/v0.5.0/sympauthy-openapi.yml
```

Both the versioned release and the rolling `nightly` pre-release get it.

## Which spec gets published

`micronaut-openapi` runs **twice**: KSP declares it explicitly, and the Micronaut Gradle plugin also injects it onto the kapt annotation-processor path (kapt is here for MapStruct). The two renderings are not identical:

| Producer | Size | Consumed by |
|---|---|---|
| KSP | 147 783 B | `syncOpenApiSpec` → the `:integration-tests` client generator |
| kapt | 155 793 B | the jar → the native binary → `GET /openapi.yml` |

The asset is the **KSP** rendering, via the existing `:server:syncOpenApiSpec`. Two reasons:

1. It is correct. The packaged kapt rendering adds a spurious property named after the enclosing schema to both `TokenResource` and `IntrospectionResource`, and marks the `TokenResource` one **required** — a client generated from it expects a mandatory `TokenResource` string on every token response that the server never sends. Filed as #316.
2. It is continuously validated. `:integration-tests` generates its entire typed client from this exact document and runs it against the real native binary in a container, so every green integration run is evidence that it describes the running server.

Consequence worth knowing: the published asset is **not** byte-identical to what a released binary returns from `GET /openapi.yml`, because that endpoint serves the packaged kapt copy. #316 is the fix; once it lands the two converge and this note goes away. The release notes therefore point at `/openapi.yml` as a separate route to the contract rather than claiming the two match.

## Wiring

`build-openapi.yml` is a new reusable workflow (also `workflow_dispatch`-able, so spec generation can be rehearsed without cutting a release) that uploads the file as the `sympauthy-openapi` artifact. Naming it `sympauthy-openapi.yml` lets it ride the `sympauthy-*` pattern the two `publish_release` jobs already download and collect, so those steps only gain a `test -f` assertion guarding against a silent miss.

## Drive-by: shared `setup_java` action

Four workflows repeated the same "grep the Java version out of `server/build.gradle.kts`, then install a JDK" pair, and `test.yml` had drifted into a second source of truth (a hardcoded `JAVA_VERSION: 25`). All four now use `.github/actions/setup_java`, whose `distribution` input selects temurin or GraalVM.

## Verification

| Check | Result |
|---|---|
| `Test` workflow on a real runner | green |
| Clean build (`:server:clean :server:syncOpenApiSpec`) | 147 783 B, 57 paths, zero spurious properties |
| Both release-notes heredocs | rendered from the real files — backticks, `{rootUrl}` and `${VERSION}` all correct |
| Collection glob | simulated: exactly 5 assets, frontend dist debris excluded |
| `actionlint` | clean on all 8 workflows |

Still unrehearsed, because `workflow_dispatch` needs the file on the default branch: a standalone `build-openapi.yml` dispatch, and a full nightly run. Worth doing both before the next release, since the nightly `publish_release` job is near-identical to the release one.

Refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)