### PR TITLE
Return expires_in in seconds from the token endpoint

### DIFF
--- a/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AuthorizationCodeFeatureIT.kt
+++ b/integration-tests/src/integrationTest/kotlin/com/sympauthy/it/feature/AuthorizationCodeFeatureIT.kt
@@ -40,6 +40,10 @@ class AuthorizationCodeFeatureIT : AbstractSympauthyIT() {
             assertNotNull(tokens.accessToken(), "token response should carry an access token")
             assertNotNull(tokens.idToken(), "the openid scope should yield an id_token")
 
+            // RFC 6749 names this expires_in and defines it as the lifetime in seconds. The default
+            // access token expiration is 1h, so the response must advertise 3600 under that exact name.
+            assertEquals(3600L, tokens.expiresIn(), "expires_in should be the token lifetime in seconds")
+
             // Verify the id_token is genuinely signed by the key the server publishes at its jwks_uri.
             val claims = verifyIdTokenSignature(sympauthy, tokens.idToken())
             assertEquals(sympauthy.issuerUrl, claims.issuer, "id_token should be issued by this container")

--- a/server/src/main/kotlin/com/sympauthy/api/controller/oauth2/TokenController.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/controller/oauth2/TokenController.kt
@@ -40,8 +40,6 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.inject.Inject
 import java.time.Duration
-import java.time.Instant
-import java.time.ZoneOffset
 
 @Controller(OAUTH2_TOKEN_ENDPOINT)
 class TokenController(
@@ -275,7 +273,7 @@ Client authentication is supported via:
         return TokenResource(
             accessToken = tokens.accessToken.token,
             tokenType = tokenType,
-            expiredIn = getExpiredIn(tokens.accessToken),
+            expiresIn = getExpiresIn(tokens.accessToken),
             scope = getScope(tokens.accessToken),
             refreshToken = tokens.refreshToken?.token,
             idToken = tokens.idToken?.token
@@ -297,7 +295,7 @@ Client authentication is supported via:
         return TokenResource(
             accessToken = accessToken.token,
             tokenType = tokenType,
-            expiredIn = getExpiredIn(accessToken),
+            expiresIn = getExpiresIn(accessToken),
             scope = getScope(accessToken),
             refreshToken = refreshedRefreshToken?.token ?: encodedRefreshToken
         )
@@ -323,7 +321,7 @@ Client authentication is supported via:
         return TokenResource(
             accessToken = accessToken.token,
             tokenType = tokenType,
-            expiredIn = getExpiredIn(accessToken),
+            expiresIn = getExpiresIn(accessToken),
             scope = getScope(accessToken),
             refreshToken = null,
             idToken = null
@@ -370,7 +368,7 @@ Client authentication is supported via:
         return TokenResource(
             accessToken = accessToken.token,
             tokenType = tokenType,
-            expiredIn = getExpiredIn(accessToken),
+            expiresIn = getExpiresIn(accessToken),
             scope = getScope(accessToken),
             refreshToken = null,
             idToken = null,
@@ -395,12 +393,16 @@ Client authentication is supported via:
             .nullIfBlank()
     }
 
-    private fun getExpiredIn(accessToken: EncodedAuthenticationToken): Int? {
+    /**
+     * Returns the lifetime in seconds of the [accessToken], or null if it never expires.
+     *
+     * The lifetime is measured from the issue date of the token rather than from now, so that the
+     * returned value is exactly the configured lifetime instead of being shortened by the time spent
+     * handling the request.
+     */
+    private fun getExpiresIn(accessToken: EncodedAuthenticationToken): Int? {
         return accessToken.expirationDate?.let {
-            Duration.between(
-                Instant.now(),
-                it.toInstant(ZoneOffset.UTC)
-            ).toMillisPart()
+            Duration.between(accessToken.issueDate, it).toSeconds().toInt()
         }
     }
 

--- a/server/src/main/kotlin/com/sympauthy/api/resource/oauth2/TokenResource.kt
+++ b/server/src/main/kotlin/com/sympauthy/api/resource/oauth2/TokenResource.kt
@@ -18,8 +18,12 @@ data class TokenResource(
     val accessToken: String,
     @get:JsonProperty("token_type")
     val tokenType: String,
-    @get:JsonProperty("expired_in")
-    val expiredIn: Int?,
+    /**
+     * The lifetime in seconds of the access token, as defined by OAuth 2.0 (RFC 6749, section 5.1).
+     * Null if the access token never expires.
+     */
+    @get:JsonProperty("expires_in")
+    val expiresIn: Int?,
     @get:JsonProperty("scope")
     val scope: String? = null,
     @get:JsonProperty("refresh_token")

--- a/server/src/test/kotlin/com/sympauthy/api/controller/oauth2/TokenControllerTest.kt
+++ b/server/src/test/kotlin/com/sympauthy/api/controller/oauth2/TokenControllerTest.kt
@@ -117,12 +117,14 @@ class TokenControllerTest {
     private fun mockEncodedToken(
         token: String = "encoded-token",
         scopes: List<String> = emptyList(),
+        issueDate: LocalDateTime = LocalDateTime.of(2024, 1, 1, 0, 0),
         expirationDate: LocalDateTime? = null,
         type: AuthenticationTokenType = ACCESS
     ): EncodedAuthenticationToken {
         return mockk {
             every { this@mockk.token } returns token
             every { this@mockk.scopes } returns scopes
+            every { this@mockk.issueDate } returns issueDate
             every { this@mockk.expirationDate } returns expirationDate
             every { this@mockk.type } returns type
         }
@@ -585,5 +587,48 @@ class TokenControllerTest {
         assertEquals("bearer", result.tokenType)
         assertNull(result.refreshToken)
         assertNull(result.idToken)
+        assertNull(result.expiresIn, "a token without an expiration date has no lifetime to report")
+    }
+
+    // --- expires_in tests ---
+
+    @Test
+    fun `getTokens - Returns the lifetime of the access token in seconds`() = runTest {
+        val request = mockRequestWithoutAuth()
+        val client = mockClient("my-client")
+        val accessToken = mockEncodedToken(
+            token = "cc-access",
+            issueDate = LocalDateTime.of(2024, 1, 1, 12, 0, 0),
+            expirationDate = LocalDateTime.of(2024, 1, 1, 13, 0, 0)
+        )
+
+        coEvery { clientAuthenticationUtil.resolveClient(request, any(), any()) } returns client
+        coEvery { scopeManager.parseRequestedClientScopes(client, null) } returns emptyList()
+        coEvery { clientScopeGrantingManager.grantClientScopes(client, emptyList()) } returns ClientGrantScopesResult(
+            requestedScopes = emptyList(),
+            results = emptyList()
+        )
+        coEvery {
+            accessTokenGenerator.generateAccessTokenForClient(
+                clientId = "my-client",
+                tokenAudience = any(),
+                clientScopes = emptyList(),
+                dpopJkt = null
+            )
+        } returns accessToken
+
+        val result = controller.getTokens(
+            request = request,
+            grantType = "client_credentials",
+            code = null,
+            redirectUri = null,
+            refreshToken = null,
+            scope = null,
+            clientId = "my-client",
+            clientSecret = "secret",
+            codeVerifier = null
+        )
+
+        assertEquals(3600, result.expiresIn)
     }
 }


### PR DESCRIPTION
Fixes #317.

The token endpoint advertised the access token lifetime under the name `expired_in`, filled with
`Duration.toMillisPart()` — the millisecond remainder *within the second*, so a value in `0..999`
that changed on every request. [RFC 6749
§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) names the parameter `expires_in`
and defines it as the lifetime in seconds.

```diff
 {
   "access_token": "…",
   "token_type": "bearer",
-  "expired_in": 961
+  "expires_in": 3600
 }
```

Either half alone breaks a client. A client following the RFC finds no `expires_in` at all and
cannot tell when the token expires — with `oidc-client-ts` (which `sympauthy-admin` uses)
`User.expires_at` stays undefined and `automaticSilentRenew` never fires, so the expiry only
surfaces as a 401 from the resource server. A client that *did* read `expired_in` as seconds would
be worse off, considering every token expired within a second of issuing it and refreshing in a
loop.

## Changes

- **`TokenResource`** — JSON name `expired_in` → `expires_in`; the Kotlin property is renamed to
  `expiresIn` to match, with a KDoc stating the unit.
- **`TokenController`** — `getExpiredIn` → `getExpiresIn`, returning `Duration.toSeconds()`.

The lifetime is measured from the token's own `issueDate` rather than `Instant.now()`.
`AccessTokenGenerator` sets `expirationDate = issueDate.plus(accessExpiration)`, so the difference is
exactly the configured lifetime; `now()` would truncate `3600` to `3599` on any request that takes a
millisecond.

## Tests

- `TokenControllerTest` — a new case asserting `3600` for a token issued at 12:00 expiring at 13:00,
  plus `assertNull(expiresIn)` on the no-expiration path.
- `AuthorizationCodeFeatureIT` — asserts `expiresIn() == 3600L` on the real HTTP response. This is
  the guard for the *wire name*: `testcontainers-sympauthy`'s `TokenResponse` already parses
  `expires_in`, so the field it exposes was simply never sent. No library bump is needed, and the
  assertion fails against the old name.

Verified with `:server:test` (800 tests, green) and
`:integration-tests:integrationTest --tests '*AuthorizationCodeFeatureIT'` against a JVM image built
from this branch, green on both H2 and PostgreSQL. The native run in CI remains the source of truth.

## Compatibility

Both halves are breaking for anything reading `expired_in`, which within this repository is nothing.
The published [client](https://sympauthy.github.io/technical/api/client) and
[admin](https://sympauthy.github.io/technical/api/admin) documentation already describes the response
as `"expires_in": 3600`, so it becomes accurate rather than needing an update. The generated OpenAPI
spec now carries `expires_in` as a nullable `int32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
